### PR TITLE
Fixed bug in 'exit_config_mode' in ssh_connection.py

### DIFF
--- a/.idea/netmiko.iml
+++ b/.idea/netmiko.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+

--- a/.idea/netmiko.iml
+++ b/.idea/netmiko.iml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>
-

--- a/netmiko/ssh_connection.py
+++ b/netmiko/ssh_connection.py
@@ -49,9 +49,9 @@ class SSHConnection(BaseSSHConnection):
 
         # only new_output is returned if 'end' is executed
         output = self.send_command('\n', strip_prompt=False, strip_command=False)
-        if '(config)' in output:
+        if '(config' in output:
             new_output = self.send_command('end', strip_prompt=False, strip_command=False)
-            if '(config)' in new_output:
+            if '(config' in new_output:
                 raise ValueError("Failed to exit configuration mode")
             return new_output
 


### PR DESCRIPTION
If the device was in config mode other than (config), then exit_config_mode would fail. For example, R1(config-pmap)# would fail. Changed it to check for '(config' instead. 