### PR TITLE
Moved "connection established" message

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -74,9 +74,6 @@ class BaseSSHConnection(object):
         self.remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         # initiate SSH connection
-        if verbose:
-            print "SSH connection established to {0}:{1}".format(self.ip, self.port)
-
         try:
             self.remote_conn_pre.connect(hostname=self.ip, port=self.port,
                                          username=self.username, password=self.password,
@@ -91,6 +88,9 @@ class BaseSSHConnection(object):
                 device_type=self.device_type, ip=self.ip, port=self.port)
             msg += '\n' + str(e)
             raise NetMikoAuthenticationException(msg)
+
+        if verbose:
+            print "SSH connection established to {0}:{1}".format(self.ip, self.port)
 
         # Use invoke_shell to establish an 'interactive session'
         self.remote_conn = self.remote_conn_pre.invoke_shell()


### PR DESCRIPTION
Moved "connection established" message such that it only displays after the connection is successfully made.