### PR TITLE
set_base_prompt() - Further check on prompt

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -153,6 +153,11 @@ class BaseSSHConnection(object):
         prompt = prompt.split('\n')[-1]
         prompt = prompt.strip()
 
+        # If prompt returned is empty, throw an exception with more information
+        if len(prompt) < 1:
+            if DEBUG: print "Length of base prompt is {0}".format(len(prompt))
+            raise ValueError("Base prompt return was empty")
+
         # Check that ends with a valid terminator character
         if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
             raise ValueError("Router prompt not found: {0}".format(prompt))


### PR DESCRIPTION
I've occasionally found the following traceback:
  File "/usr/lib/python2.6/site-packages/netmiko/base_connection.py", line 154, in set_base_prompt
    if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
IndexError: string index out of range

I've added another check that if the length of the prompt is 0 - then it will throw a more meaningful response. I am still unsure of the original reason for the prompt being empty.