### PR TITLE
Check for username and password, always lowercase 

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -28,7 +28,7 @@ class CiscoAsaSSH(SSHConnection):
         time.sleep(1*delay_factor)
 
         output = self.remote_conn.recv(MAX_BUFFER)
-        if 'assword' in output:
+        if 'password' in output.lower():
             self.remote_conn.send(self.secret+'\n')
             self.remote_conn.send('\n')
             time.sleep(1*delay_factor)

--- a/netmiko/hp/hp_procurve_ssh.py
+++ b/netmiko/hp/hp_procurve_ssh.py
@@ -30,9 +30,9 @@ class HPProcurveSSH(SSHConnection):
         DEBUG = False
 
         output = self.send_command('enable')
-        if 'sername' in output:
+        if 'username' in output.lower():
             output += self.send_command(default_username)
-        if 'assword' in output:
+        if 'password' in output.lower():
             output += self.send_command(self.secret)
 
         if DEBUG: 

--- a/netmiko/ssh_connection.py
+++ b/netmiko/ssh_connection.py
@@ -18,7 +18,7 @@ class SSHConnection(BaseSSHConnection):
         '''
 
         output = self.send_command('enable')
-        if 'assword' in output:
+        if 'password' in output.lower():
             output += self.send_command(self.secret)
 
         self.set_base_prompt()


### PR DESCRIPTION
Though checking for 'assword' will capture both 'Passsword' and 'password' it won't capture other forms of interesting capitalisation (like full caps) of the word. This guarantees that we always check for the 'password' string in the lowercased output. The same goes for 'username'.

It does make the code a bit less funny to read.