### PR TITLE
base_prompt improvement for multi context ASA's

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from netmiko.ssh_connection import SSHConnection
 from netmiko.netmiko_globals import MAX_BUFFER
 import time
@@ -15,20 +16,35 @@ class CiscoAsaSSH(SSHConnection):
         self.disable_paging(command="terminal pager 0\n")
         self.set_base_prompt()
 
+    def send_command(self, command_string, delay_factor=.5, max_loops=30,
+                 strip_prompt=True, strip_command=True):
+        '''
+        If ASA is in multi context mode, then the base_prompt needs to be
+        updated after each change of context to make strip_prompt behave
+        properly.
+        '''
 
-    def enable(self, delay_factor=.5):
+        output=super(CiscoAsaSSH,self).send_command(command_string,delay_factor,
+                max_loops,strip_prompt,strip_command)
+        if "changeto" in command_string:
+            self.set_base_prompt()
+        return output
+
+    def enable(self):
         '''
         Enter enable mode
 
         Must manually control the channel at this point for ASA
         '''
 
+        delay_factor = .5
+
         self.clear_buffer()
         self.remote_conn.send("\nenable\n")
         time.sleep(1*delay_factor)
 
         output = self.remote_conn.recv(MAX_BUFFER)
-        if 'assword' in output:
+        if 'password' in output.lower():
             self.remote_conn.send(self.secret+'\n')
             self.remote_conn.send('\n')
             time.sleep(1*delay_factor)

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -30,6 +30,12 @@ class CiscoAsaSSH(SSHConnection):
             self.set_base_prompt()
         return output
 
+    def set_base_prompt(self):
+        output=super(CiscoAsaSSH,self).set_base_prompt()
+        if "(config)" in output:
+            self.base_prompt=output[0:-9]
+            return self.base_prompt
+
     def enable(self):
         '''
         Enter enable mode


### PR DESCRIPTION
Hi,

If you have an ASA in multi context mode and you change to another context, then the prompt changes.
This brakes strip_prompt when you execute a command in a context other then the context to which you initially connect.
This pull request overrides the send_command function in the CiscoAsaSSH class. The overridden function first calls it's parents class send_command function. Then checks if the executed command was a command to change context and if so calls set_base_prompt to update the base_prompt attribute.