### PR TITLE
Fix setup errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/etc/responses.yml
 examples/SECRET_DEVICE_CREDS.py
 build
 dist
+*\.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from distutils.core import setup
+from setuptools import setup
 
 
 def find_version(*file_paths):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,30 @@
+import os
+import re
+
 from distutils.core import setup
 
-import netmiko
+
+def find_version(*file_paths):
+    """
+    This pattern was modeled on a method from the Python Packaging User Guide:
+        https://packaging.python.org/en/latest/single_source_version.html
+
+    We read instead of importing so we don't get import errors if our code
+    imports from dependencies listed in install_requires.
+    """
+    base_module_file = os.path.join(*file_paths)
+    with open(base_module_file) as f:
+        base_module_data = f.read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              base_module_data, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='netmiko',
-    version=netmiko.__version__,
+    version=find_version('netmiko', '__init__.py'),
     url='https://github.com/ktbyers/netmiko',
     license='MIT',
     author='Kirk Byers',
@@ -19,4 +39,3 @@ setup(
               'netmiko/brocade',
               'netmiko/huawei',],
     )
-


### PR DESCRIPTION
Fixes #91 and #103.

Uses a PyPa recommended way to fix race conditions in dependency install and uses setuptools instead of distutils (distutils is deprecated). There are a couple ways to do these, just let me know if you think there's a better one and I'll update the PR.

I tested that the install succeeds in empty Python 2 virtualenvs and Python 3 pyvenvs.