### PR TITLE
flush buffer on console

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -103,6 +103,7 @@ class BaseSSHConnection(object):
 
         # Strip the initial router prompt
         time.sleep(sleep_time)
+        self.remote_conn.send('\n')
         return self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
 
 


### PR DESCRIPTION
When logging in through a console server, paramiko's recv() hangs for a long time. I guess that is because there is nothing in the console server's buffer and that it's similar to the behavior observed when manually logging into a console server and having to hit ENTER twice after you enter your password in order to see the shell prompt.

This fix hits ENTER for you solved my problems using netmiko.