### PR TITLE
Changed setup.py to use setuptools rather than distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import os
 import re
 


### PR DESCRIPTION
This change is to add support for the install_requires parameter passed to the setup()
function. Distutils does not support install_requires and therefore will
not automatically resolve dependencies for setup.py. In addition the lack
of support for install_requires creates problems for packages that specify
netmiko as a dependency. The dependency tree will not be created correctly
and will attempt to install netmiko before paramiko or scp if they are
specified in as a dependency as well.

A concern for this might be that setuptools is not a built-in Python
library while distutils is. I feel that this does not greatly affect
compatibility with existing deployment scenarios because setuptools is
included by default with Python3+ as of PEP0453 and Python2.7 as of
PEP0477. These PEPs specify that pip be included in Python as a default
and setuptools is a requirement of pip.

See here:
https://www.python.org/dev/peps/pep-0453/#automatic-installation-of-setuptools