### PR TITLE
fix enable() for slow tacacs+ servers

### DIFF
--- a/netmiko/ssh_connection.py
+++ b/netmiko/ssh_connection.py
@@ -17,7 +17,7 @@ class SSHConnection(BaseSSHConnection):
         Enter enable mode
         '''
 
-        output = self.send_command('enable')
+        output = self.send_command_expect('enable', expect_string="password:")
         if 'password' in output.lower():
             output += self.send_command(self.secret)
 


### PR DESCRIPTION
Added expect for the password prompt to enable() to allow it to work with slow tacacs+ setups (eg, remote LDAP-integrated). This *should* always work- I can't find any documented examples of enable where it doesn't have a password prompt (you're either in enable immediately at login, or you get a password prompt).

