### PR TITLE
Remove last hard-coded reference to flash: filesystem

### DIFF
--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -134,7 +134,7 @@ class FileTransfer(object):
         '''
 
         if not remote_cmd:
-            remote_cmd = "dir flash:/{0}".format(self.dest_file)
+            remote_cmd = "dir {0}/{1}".format(self.file_system, self.dest_file)
 
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
 


### PR DESCRIPTION
This commit removes the last hardcoded reference to the flash: filesystem and uses the self.file_system attribute (which defaults to flash:).

With this change (and basic support for another filesystem in the cisco_file_transfer ansible module which I will push shortly) I was able to manage files on a 7200 VXR with disk2: as file system