### PR TITLE
Initial delay factor

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -164,7 +164,11 @@ class BaseSSHConnection(object):
 
         self.clear_buffer()
         self.remote_conn.sendall("\n")
-        time.sleep(1 * delay_factor)
+        
+        i = 0
+        while not self.remote_conn.recv_ready() and i < 10:
+            time.sleep(1 * delay_factor)
+            i += 1
 
         prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -143,6 +143,20 @@ class BaseSSHConnection(object):
         return output
 
 
+    def wait_for_recv_ready(self, delay_factor, max_loops):
+        '''
+        Wait for data to be in the buffer so it can be received.
+
+        delay_factor can be used to increase the delays.
+
+        max_loops can be used to increase the number of times it reads the data buffer
+        '''
+        i = 0
+        while not self.remote_conn.recv_ready() and i < max_loops:
+            time.sleep(1 * delay_factor)
+            i += 1
+
+    
     def set_base_prompt(self, pri_prompt_terminator='#',
                         alt_prompt_terminator='>', delay_factor=.5):
         '''
@@ -165,10 +179,7 @@ class BaseSSHConnection(object):
         self.clear_buffer()
         self.remote_conn.sendall("\n")
         
-        i = 0
-        while not self.remote_conn.recv_ready() and i < 10:
-            time.sleep(1 * delay_factor)
-            i += 1
+        self.wait_for_recv_ready(delay_factor, 10)
 
         prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
 
@@ -242,7 +253,6 @@ class BaseSSHConnection(object):
         else:
             return None
 
-
     def send_command(self, command_string, delay_factor=.5, max_loops=30,
                      strip_prompt=True, strip_command=True):
         '''
@@ -274,18 +284,14 @@ class BaseSSHConnection(object):
 
         self.remote_conn.sendall(command_string)
 
-        time.sleep(1 * delay_factor)
-        not_done = True
-        i = 1
-
-        while (not_done) and (i <= max_loops):
-            time.sleep(1 * delay_factor)
-            i += 1
-            # Keep reading data as long as available (up to max_loops)
-            if self.remote_conn.recv_ready():
-                output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
-            else:
-                not_done = False
+        # Wait for recv_ready()
+        self.wait_for_recv_ready(delay_factor, max_loops)
+        
+        # Keep reading data as long as available (up to max_loops)
+        i = 0
+        while self.remote_conn.recv_ready() and i < max_loops:
+            output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+            self.wait_for_recv_ready(delay_factor, max_loops)
 
         # Some platforms have ansi_escape codes
         if self.ansi_escape_codes:


### PR DESCRIPTION
Hey Kirk,

This PR resolves #126 and also similar problems I found in ``send_command()`` on higher-delay links with Cisco switches. Namely, ``send_command()`` would return the empty string because there was no data in the buffer yet. The PR includes:

* the addition of a ``wait_for_recv_ready()`` function that loops and sleeps using ``delay_factor`` and ``max_loops`` until data is in the buffer
* the application of ``wait_for_recv_ready()`` in ``set_base_prompt``
* the application of ``wait_for_recv_ready()`` in ``send_command()``

Feel free to use it if it's helpful.

Thanks,
Michael