### PR TITLE
OpenSSH Configuration Support (#131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/SECRET_DEVICE_CREDS.py
 build
 dist
 netmiko.egg-info
+.cache

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -15,6 +15,7 @@ import time
 import socket
 import re
 import io
+import os
 
 from netmiko.netmiko_globals import MAX_BUFFER
 from netmiko.ssh_exception import NetMikoTimeoutException, NetMikoAuthenticationException
@@ -27,8 +28,9 @@ class BaseSSHConnection(object):
     Otherwise method left as a stub method.
     '''
 
-    def __init__(self, ip, username, password, secret='', port=22, device_type='', verbose=True,
-                 use_keys=False, key_file=None, global_delay_factor=.5):
+    def __init__(self, ip, username, password, secret='', port=22, device_type='',
+                 verbose=True, use_keys=False, key_file=None, global_delay_factor=.5,
+                 ssh_config_path='~/.ssh/config'):
 
         self.ip = ip
         self.port = port
@@ -39,6 +41,7 @@ class BaseSSHConnection(object):
         self.ansi_escape_codes = False
         # Use the greater of global_delay_factor or delay_factor local to method
         self.global_delay_factor = global_delay_factor
+        self.ssh_config_path = ssh_config_path
 
         # set in set_base_prompt method
         self.base_prompt = ''
@@ -63,6 +66,43 @@ class BaseSSHConnection(object):
         self.set_base_prompt()
 
 
+    def _return_config(self, use_keys=False, key_file=None, timeout=8):
+        '''Return dict of kwargs that Paramiko will accept for connect'''
+
+        # Fully expand ssh_config_path and test its existence
+        # If it exists, use Paramiko SSHConfig to generate source content.
+        # Otherwise use empty dict
+        full_path = os.path.abspath(os.path.expanduser(self.ssh_config_path))
+        if os.path.exists(full_path):
+            ssh_config_instance = paramiko.SSHConfig()
+            with open(full_path) as f:
+                ssh_config_instance.parse(f)
+                source = ssh_config_instance.lookup(self.ip)
+        else:
+            source = {}
+
+        if source.get('proxycommand'):
+            proxy = paramiko.ProxyCommand(source['proxycommand'])
+        else:
+            None
+
+        # Contents of source aren't reliable, except for hostname and even
+        # then we're setting source to empty dict sometimes. When these fields
+        # are present though, favoring them should result in smoother user
+        # experience.
+        return {
+            'hostname': source.get('hostname', self.ip),
+            'port': source.get('port', self.port),
+            'username': source.get('username', self.username),
+            'password': self.password,
+            'sock': proxy,
+            'look_for_keys': use_keys,
+            'allow_agent': False,
+            'key_filename': key_file,
+            'timeout': timeout,
+        }
+
+
     def establish_connection(self, sleep_time=3, verbose=True, timeout=8,
                              use_keys=False, key_file=None):
         '''
@@ -74,6 +114,13 @@ class BaseSSHConnection(object):
         use_keys is a boolean that allows ssh-keys to be used for authentication
         '''
 
+        # Fetch configuration for Paramiko client
+        ssh_config = self._return_config(
+            use_keys=use_keys,
+            key_file=key_file,
+            timeout=timeout,
+        )
+        print(ssh_config['sock'])
         # Create instance of SSHClient object
         self.remote_conn_pre = paramiko.SSHClient()
 
@@ -82,10 +129,18 @@ class BaseSSHConnection(object):
 
         # initiate SSH connection
         try:
-            self.remote_conn_pre.connect(hostname=self.ip, port=self.port,
-                                         username=self.username, password=self.password,
-                                         look_for_keys=use_keys, allow_agent=False,
-                                         key_filename=key_file, timeout=timeout)
+            self.remote_conn_pre.connect(**ssh_config)
+
+        # TODO: If the user provides 'my_router' or other custom SSH Host Alias
+        # that gets stuffed into self.ip, but properly converted via SSHConfig
+        # these logs and further documentation'd use of self.ip in subclasses
+        # might be unintuitive. Maybe not though considering it is what the
+        # user provides
+        #
+        # Guess this depends on whether we want to ignore from the user that
+        # they are using a proxy or whether it should be shown to be more
+        # forward about technical details (eg, why isn't this working oh it's
+        # because my route to proxy server is gone!)
         except socket.error:
             msg = "Connection to device timed-out: {device_type} {ip}:{port}".format(
                 device_type=self.device_type, ip=self.ip, port=self.port)

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -120,7 +120,6 @@ class BaseSSHConnection(object):
             key_file=key_file,
             timeout=timeout,
         )
-        print(ssh_config['sock'])
         # Create instance of SSHClient object
         self.remote_conn_pre = paramiko.SSHClient()
 


### PR DESCRIPTION
This has been implemented by outsourcing paramiko.SSHClient.connect(**kwargs)
to a private method ._return_config()

Not only will this give a more central place to tweak client configuration in
the future, but it serves a nice place to do some conditions and openssh cfg
file reading thanks to paramiko.SSHConfig

As of this commit, ssh_config_path is an __init__ arg defaulting to ~/.ssh/config.
If an unparsable ssh config is passed, Exception will be thrown. We can easily
capture this and error something better if needed, but it's a straightfwd error.

On top of proxycommand support, there is now support for Host Aliasing within
a user SSH config. The only drawback/discussion might need of this is whether
to log the provided hostname or the resolved one (and port).

Username will also be favored from the config if provided under the Host block.