### PR TITLE
Added support for enterasys and extreme switches.

### DIFF
--- a/netmiko/enterasys/__init__.py
+++ b/netmiko/enterasys/__init__.py
@@ -1,0 +1,1 @@
+from netmiko.enterasys.ent_ssh import ENTSSH

--- a/netmiko/enterasys/ent_ssh.py
+++ b/netmiko/enterasys/ent_ssh.py
@@ -1,0 +1,17 @@
+'''
+ENT support
+'''
+from netmiko.ssh_connection import SSHConnection
+
+
+class ENTSSH(SSHConnection):
+    '''
+    ENT support
+    '''
+    def session_preparation(self):
+        '''
+        ENT requires to be enable mode to disable paging
+        '''
+        self.enable()
+        self.disable_paging(command="set length 0\n")
+        self.set_base_prompt()

--- a/netmiko/extreme/__init__.py
+++ b/netmiko/extreme/__init__.py
@@ -1,0 +1,1 @@
+from netmiko.extreme.ext_ssh import EXTSSH

--- a/netmiko/extreme/ext_ssh.py
+++ b/netmiko/extreme/ext_ssh.py
@@ -1,0 +1,17 @@
+'''
+EXT support
+'''
+from netmiko.ssh_connection import SSHConnection
+
+
+class EXTSSH(SSHConnection):
+    '''
+    EXT support
+    '''
+    def session_preparation(self):
+        '''
+        EXT requires to be enable mode to disable paging
+        '''
+        self.enable()
+        self.disable_paging(command="disable clipaging\n")
+        self.set_base_prompt()

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -18,6 +18,8 @@ from netmiko.a10 import A10SSH
 from netmiko.avaya import AvayaVspSSH
 from netmiko.avaya import AvayaErsSSH
 from netmiko.ovs import OvsLinuxSSH
+from netmiko.enterasys import ENTSSH
+from netmiko.extreme import EXTSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER = {
@@ -39,6 +41,8 @@ CLASS_MAPPER = {
     'avaya_vsp': AvayaVspSSH,
     'avaya_ers': AvayaErsSSH,
     'ovs_linux': OvsLinuxSSH,
+    'enterasys': ENTSSH,
+    'extreme': EXTSSH,
 }
 
 platforms = list(CLASS_MAPPER.keys())

--- a/tests/test_enterasys_switch.py
+++ b/tests/test_enterasys_switch.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# This will run an ssh command successfully on an enterasys SSA and so SSH must be enabled on the device(s).
+
+import sys
+sys.path.append('../')
+from netmiko import ConnectHandler
+
+enterasyshandle = {'device_type':'enterasys', 'ip' : '10.54.116.175', 'username':'admin', 'password':''}
+net_connect = ConnectHandler(**enterasyshandle)
+output = net_connect.send_command('show config policy')
+print(output)

--- a/tests/test_extreme_switch.py
+++ b/tests/test_extreme_switch.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# This will run an ssh command successfully on an extreme switch and so SSH must be enabled on the device(s).
+
+import sys
+sys.path.append('../')
+from netmiko import ConnectHandler
+
+extremehandle = {'device_type':'extreme', 'ip' : '10.54.149.80', 'username':'admin', 'password':'',
+		 'global_delay_factor': 1}
+net_connect = ConnectHandler(**extremehandle)
+output = net_connect.send_command('show config vlan')
+print(output)


### PR DESCRIPTION
I read through the VENDORS.md file but I noticed when testing the extreme switches that sometimes my output would be 

    '\n\r'

or something similar to that but when I ran the script again or ran the test again, I would get the output I desired. I also checked the prompt and netmiko was discovering that correctly too.

Increasing the global delay factor in the config json from 0.5 to 1 seemed to do the trick. 

    extremehandle = {'device_type':'extreme', 'ip' : '10.54.149.80', 'username':'admin', 'password':'',
		 'global_delay_factor': 1}

Is there a way to better debug than by increasing the global delay factor?

My TODO is to write a few tests for these switches too. I'll try to add that in the next commit.