### PR TITLE
Disable enable_mode for linux

### DIFF
--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -33,11 +33,10 @@ class LinuxSSH(SSHConnection):
         return super(SSHConnection, self).exit_config_mode(exit_config=exit_config)
 
     def exit_enable_mode(self, exit_command='exit'):
-        return self.exit_config_mode()
+        pass
 
     def check_enable_mode(self, check_string='#'):
-        return self.check_config_mode()
+        pass
 
     def enable(self):
-        '''Attempt to become root'''
-        return self.config_mode()
+        pass


### PR DESCRIPTION
We can't mirror enable and config mode.
It is impossible to exit from config_mode in this case
since both enable and config modes are using the same
check_string='#'