### PR TITLE
Update cisco_asa enable method

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -74,5 +74,11 @@ class CiscoAsaSSH(SSHConnection):
             time.sleep(1 * delay_factor)
             output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
 
+        if not self.check_enable_mode() and self.secret == '':
+            raise ValueError("Failed to enter enable mode - Warning: secret is not set")
+        elif not self.check_enable_mode():
+            raise ValueError("Failed to enter enable mode")
+
+
         self.set_base_prompt()
         self.clear_buffer()


### PR DESCRIPTION
Raise exception if enable password is not accepted. 
Throw an longer warning if enable secret is not set (personally I normally expect the login password to be tried, but instead I thought it would be best to give a longer warning).

I had issues where if the secret was not set, it would throw an issue about not setting base prompt, which wasn't very intuitive.