### PR TITLE
ignore non-UTF-8 input

### DIFF
--- a/netmiko/avaya/avaya_ers_ssh.py
+++ b/netmiko/avaya/avaya_ers_ssh.py
@@ -27,7 +27,7 @@ class AvayaErsSSH(SSHConnection):
         i = 0
         while i <= 12:
             if self.remote_conn.recv_ready():
-                output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+                output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if 'Ctrl-Y' in output:
                     self.remote_conn.sendall(CTRL_Y)
                 if 'sername' in output:

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -177,7 +177,7 @@ class BaseSSHConnection(object):
         time.sleep(sleep_time)
         # Strip any initial data
         if self.remote_conn.recv_ready():
-            return self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+            return self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         else:
             i = 0
             while i <= 10:
@@ -185,7 +185,7 @@ class BaseSSHConnection(object):
                 self.remote_conn.sendall('\n')
                 time.sleep(.5)
                 if self.remote_conn.recv_ready():
-                    return self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+                    return self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 else:
                     i += 1
             return ""
@@ -216,7 +216,7 @@ class BaseSSHConnection(object):
         time.sleep(1 * delay_factor)
 
         # Clear the buffer on the screen
-        output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         if self.ansi_escape_codes:
             output = self.strip_ansi_escape_codes(output)
 
@@ -259,7 +259,7 @@ class BaseSSHConnection(object):
         self.clear_buffer()
         self.remote_conn.sendall("\n")
         self.wait_for_recv_ready(delay_factor)
-        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
 
         # Some platforms have ANSI escape codes
         if self.ansi_escape_codes:
@@ -302,7 +302,7 @@ class BaseSSHConnection(object):
         self.remote_conn.sendall("\n")
         time.sleep(1 * delay_factor)
 
-        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
 
         # Some platforms have ANSI escape codes
         if self.ansi_escape_codes:
@@ -326,7 +326,7 @@ class BaseSSHConnection(object):
         '''
 
         if self.remote_conn.recv_ready():
-            return self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+            return self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         else:
             return None
 
@@ -370,7 +370,7 @@ class BaseSSHConnection(object):
             i += 1
             # Keep reading data as long as available (up to max_loops)
             if self.remote_conn.recv_ready():
-                output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+                output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
             else:
                 not_done = False
 
@@ -454,7 +454,7 @@ class BaseSSHConnection(object):
             if self.remote_conn.recv_ready():
                 if debug:
                     print("recv_ready = True")
-                output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+                output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if search_pattern in output:
                     break
             else:

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -63,12 +63,12 @@ class CiscoAsaSSH(SSHConnection):
         self.remote_conn.sendall("\nenable\n")
         time.sleep(1 * delay_factor)
 
-        output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         if 'password' in output.lower():
             self.remote_conn.sendall(self.secret + '\n')
             self.remote_conn.sendall('\n')
             time.sleep(1 * delay_factor)
-            output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+            output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
 
         if not self.check_enable_mode():
             raise ValueError("Failed to enter enable mode")

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -29,7 +29,7 @@ class CiscoWlcSSH(BaseSSHConnection):
         i = 0
         while i <= 12:
             if self.remote_conn.recv_ready():
-                output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+                output = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if 'login as' in output or 'User' in output:
                     self.remote_conn.sendall(self.username + '\n')
                 elif 'Password' in output:
@@ -84,8 +84,7 @@ class CiscoWlcSSH(BaseSSHConnection):
                     i += 1
                     if self.remote_conn.recv_ready():
                         # Unicode error occurred in output (errors=ignore strips this out).
-                        output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8',
-                                                                           errors='ignore')
+                        output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                     else:
                         not_done = False
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -105,7 +105,7 @@ class FortinetSSH(SSHConnection):
 
         # Strip the initial router prompt
         time.sleep(sleep_time)
-        return self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        return self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
 
     def config_mode(self, config_command=''):
         '''

--- a/netmiko/hp/hp_comware_ssh.py
+++ b/netmiko/hp/hp_comware_ssh.py
@@ -70,7 +70,7 @@ class HPComwareSSH(SSHConnection):
         self.remote_conn.sendall("\n")
         time.sleep(1 * delay_factor)
 
-        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         prompt = self.normalize_linefeeds(prompt)
 
         # If multiple lines in the output take the last line

--- a/netmiko/huawei/huawei_ssh.py
+++ b/netmiko/huawei/huawei_ssh.py
@@ -70,7 +70,7 @@ class HuaweiSSH(SSHConnection):
         self.remote_conn.sendall("\n")
         time.sleep(1 * delay_factor)
 
-        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
         prompt = self.normalize_linefeeds(prompt)
 
         # If multiple lines in the output take the last line

--- a/netmiko/juniper/juniper_ssh.py
+++ b/netmiko/juniper/juniper_ssh.py
@@ -31,7 +31,7 @@ class JuniperSSH(BaseSSHConnection):
         while True:
             self.remote_conn.sendall("\n")
             time.sleep(1)
-            cur_prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8')
+            cur_prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
             if re.search(r'root@.*%', cur_prompt):
                 self.remote_conn.sendall("cli\n")
                 time.sleep(1)


### PR DESCRIPTION
I received some non-UTF-8 input from some types of devices. This makes python ignore the garbage that cannot be decoded and work with the rest.