### PR TITLE
added device_type check

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -61,6 +61,9 @@ def ConnectHandler(*args, **kwargs):
 
     Returns the object
     '''
+
+    if kwargs['device_type'] not in platforms:
+        raise ValueError('Invalid Device Type. Available options are:', platforms)
     ConnectionClass = ssh_dispatcher(kwargs['device_type'])
     return ConnectionClass(*args, **kwargs)
 


### PR DESCRIPTION
When I  mis-type the `device_type`, I get a KeyError.  Trying to add something in to be more user friendly...you can also create a custom error rather than a ValueError, but this seems to do the trick.

Let me know what you think.