### PR TITLE
adding addtl name for juniper junos devices

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -41,6 +41,7 @@ CLASS_MAPPER_BASE = {
     'huawei': HuaweiSSH,
     'f5_ltm': F5LtmSSH,
     'juniper': JuniperSSH,
+    'juniper_junos': JuniperSSH,
     'brocade_vdx': BrocadeNosSSH,
     'brocade_nos': BrocadeNosSSH,
     'brocade_fastiron': BrocadeFastironSSH,


### PR DESCRIPTION
This is along the same lines as my last PR.  Trying to standardize device types / plaforms as vendor_os_api on some ntc modules.  With your latest modification to my last PR along with this change, we can now use juniper_junos or juniper_junos_ssh (or the existing Juniper one).