### PR TITLE
Use a command after connection instead of invoking a shell

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -30,7 +30,7 @@ class BaseSSHConnection(object):
     def __init__(self, ip=u'', host=u'', username=u'', password=u'', secret=u'', port=22,
                  device_type=u'', verbose=False, global_delay_factor=.1, use_keys=False,
                  key_file=None, ssh_strict=False, system_host_keys=False, alt_host_keys=False,
-                 alt_key_file='', ssh_config_file=None):
+                 alt_key_file='', ssh_config_file=None, cmd=u'', cmd_sleep=.1):
 
         if ip:
             self.host = ip
@@ -45,6 +45,8 @@ class BaseSSHConnection(object):
         self.secret = secret
         self.device_type = device_type
         self.ansi_escape_codes = False
+        self.cmd=u''
+        self.cmd_sleep = int(cmd_sleep)
 
         # Use the greater of global_delay_factor or delay_factor local to method
         self.global_delay_factor = global_delay_factor
@@ -176,8 +178,14 @@ class BaseSSHConnection(object):
         if verbose:
             print("SSH connection established to {0}:{1}".format(self.host, self.port))
 
-        # Use invoke_shell to establish an 'interactive session'
-        self.remote_conn = self.remote_conn_pre.invoke_shell()
+        if self.cmd:
+            self.remote_conn = self.remote_conn_pre.get_transport().open_channel("session")
+            self.remote_conn.exec_command(self.cmd)
+            time.sleep(self.cmd_sleep)
+        else
+            # Use invoke_shell to establish an 'interactive session'
+            self.remote_conn = self.remote_conn_pre.invoke_shell()
+
         self.special_login_handler()
         if verbose:
             print("Interactive SSH session established")


### PR DESCRIPTION
Hi,

I have a special use case. For security reason, I have to jump on a first host before connecting to the real destination. The connections looks like this:

Me --SSH--> Secure_Host --SSH--> final destination

I connect with SSH to Secure_Host, executing a special command (not a shell) that starts a new SSH connection between Secure_Host and my final destination. This looks like  "ssh me@Secure_Host -- other_user@final_destination".

This means that I can't use any solution based on ProxyCommand (like [this one](http://www.cyberciti.biz/faq/linux-unix-ssh-proxycommand-passing-through-one-host-gateway-server/)). ProxyCommand is useful when you want to make a tunnel through a jump host, but with a SSH connection between you and the destination.

In my case I need to run a command on the jump host to establish a second SSH session between it and the final destination. With paramiko, I need to use _exec_command()_ instead of _invoke_shell()_.

This patch basically allows to run any command right after the connection, by adding two new parameters to _BaseSSHConnection_'s constructor: _cmd_ and _cmd_sleep_:

- The _cmd_ while be launch after the connection, on his own channel, and this channel will be used after instead of a shell channel.

- The _cmd_sleep_ is the duration in second to sleep after running the command. If the command returns some text too slowly before returning the actual destination's prompt _find_prompt()_ fails because it gets a fragment of the command output without the prompt it is looking for.

With my modification I can use netmiko with these parameters:

```python
args = {
    'cmd': 'other_user@final_destination,
    'cmd_sleep': 1,
    'ip': 'Secure_Host',
    'device_type': 'cisco_ios',
    'username': 'me',
    'use_keys': True,
    'verbose': True,
}
```