### PR TITLE
Set base_prompt for linux to '@'

### DIFF
--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -7,10 +7,7 @@ class LinuxSSH(SSHConnection):
     def set_base_prompt(self, pri_prompt_terminator='$',
                         alt_prompt_terminator='#', delay_factor=.1):
         """Determine base prompt."""
-        return super(SSHConnection, self).set_base_prompt(
-            pri_prompt_terminator=pri_prompt_terminator,
-            alt_prompt_terminator=alt_prompt_terminator,
-            delay_factor=delay_factor)
+        self.base_prompt = '@'
 
     def send_config_set(self, config_commands=None, exit_config_mode=True, **kwargs):
         """Can't exit from root (if root)"""


### PR DESCRIPTION
On linux host base prompt depends on username and may be customized.
By default it is set to the following:
for user: user@hostname:~$
for root: root@hostname:#

This patch sets base prompt for linux to '@'.
It fixes issue when it is not possible to get to configuration mode from general user.
Since after 'sudo su' command, output prompt from host is changed to root@hostname...
While base_prompt left user@hostname...