### PR TITLE
Add support for Quanta switches

### DIFF
--- a/netmiko/quanta/__init__.py
+++ b/netmiko/quanta/__init__.py
@@ -1,3 +1,3 @@
-from netmiko.quanta.quanta_ssh import QuantaSSH
+from netmiko.quanta.quanta_mesh_ssh import QuantaMeshSSH
 
-__all__ = ['QuantaSSH']
+__all__ = ['QuantaMeshSSH']

--- a/netmiko/quanta/__init__.py
+++ b/netmiko/quanta/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.quanta.quanta_ssh import QuantaSSH
+
+__all__ = ['QuantaSSH']

--- a/netmiko/quanta/quanta_mesh_ssh.py
+++ b/netmiko/quanta/quanta_mesh_ssh.py
@@ -1,11 +1,11 @@
 from netmiko.ssh_connection import SSHConnection
 
 
-class QuantaSSH(SSHConnection):
+class QuantaMeshSSH(SSHConnection):
     def disable_paging(self, command="no pager", delay_factor=.1):
         """Disable paging"""
-        return super(QuantaSSH, self).disable_paging(command=command)
+        return super(QuantaMeshSSH, self).disable_paging(command=command)
 
     def config_mode(self, config_command='configure'):
         """Enter configuration mode."""
-        return super(QuantaSSH, self).config_mode(config_command=config_command)
+        return super(QuantaMeshSSH, self).config_mode(config_command=config_command)

--- a/netmiko/quanta/quanta_ssh.py
+++ b/netmiko/quanta/quanta_ssh.py
@@ -1,0 +1,11 @@
+from netmiko.ssh_connection import SSHConnection
+
+
+class QuantaSSH(SSHConnection):
+    def disable_paging(self, command="no pager", delay_factor=.1):
+        """Disable paging"""
+        return super(QuantaSSH, self).disable_paging(command=command)
+
+    def config_mode(self, config_command='configure'):
+        """Enter configuration mode."""
+        return super(QuantaSSH, self).config_mode(config_command=config_command)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -26,7 +26,7 @@ from netmiko.enterasys import EnterasysSSH
 from netmiko.extreme import ExtremeSSH
 from netmiko.alcatel import AlcatelSrosSSH
 from netmiko.dell import DellForce10SSH
-from netmiko.quanta import QuantaSSH
+from netmiko.quanta import QuantaMeshSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -57,7 +57,7 @@ CLASS_MAPPER_BASE = {
     'alcatel_sros': AlcatelSrosSSH,
     'fortinet': FortinetSSH,
     'dell_force10': DellForce10SSH,
-    'quanta': QuantaSSH,
+    'quanta': QuantaMeshSSH,
 }
 
 # Also support keys that end in _ssh

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -26,6 +26,7 @@ from netmiko.enterasys import EnterasysSSH
 from netmiko.extreme import ExtremeSSH
 from netmiko.alcatel import AlcatelSrosSSH
 from netmiko.dell import DellForce10SSH
+from netmiko.quanta import QuantaSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -56,6 +57,7 @@ CLASS_MAPPER_BASE = {
     'alcatel_sros': AlcatelSrosSSH,
     'fortinet': FortinetSSH,
     'dell_force10': DellForce10SSH,
+    'quanta': QuantaSSH,
 }
 
 # Also support keys that end in _ssh

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
               'netmiko/extreme',
               'netmiko/alcatel',
               'netmiko/dell',
-              'netmiko/avaya'],
+              'netmiko/avaya',
+              'netmiko/quanta'],
     install_requires=['paramiko>=1.13.0', 'scp>=0.10.0'],
     extras_require={
         'test': ['pytest>=2.6.0', 'pyyaml']


### PR DESCRIPTION
This adds support for the default OS that comes with Quanta whitebox switches. Tested on:

```
(Quanta) #sh ver

Switch: 1

System Description............................. LY2R, Runtime Code 1.4.21.00, Linux 2.6.35
Machine Type................................... LY2R
Machine Model.................................. QUANTA LY2R
FRU Number..................................... 1
Part Number.................................... 1LY2BZZ000N
Maintenance Level.............................. 1
Manufacturer................................... 0x0100
Software Version............................... 1.4.21.00
Operating System............................... Linux 2.6.35
Network Processing Device...................... BCM56846_A1

```

