### PR TITLE
send_command_expect loop stops when connection is closed

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -382,7 +382,7 @@ class BaseSSHConnection(object):
         pattern = re.escape(pattern)
         if debug:
             print("Pattern is: {}".format(pattern))
-        while True:
+        while self.remote_conn.closed:
             try:
                 output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if re.search(pattern, output, flags=re_flags):
@@ -399,7 +399,7 @@ class BaseSSHConnection(object):
             pattern = self.base_prompt
         pattern = re.escape(pattern)
         base_prompt_pattern = re.escape(self.base_prompt)
-        while True:
+        while self.remote_conn.closed:
             try:
                 output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if re.search(pattern, output, flags=re_flags) or re.search(base_prompt_pattern,

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -391,6 +391,7 @@ class BaseSSHConnection(object):
                     return output
             except socket.timeout:
                 raise NetMikoTimeoutException("Timed-out reading channel, data not available.")
+        return output
 
     def read_until_prompt_or_pattern(self, pattern='', re_flags=0):
         """Read until either self.base_prompt or pattern is detected. Return ALL data available."""
@@ -407,6 +408,7 @@ class BaseSSHConnection(object):
                     return output
             except socket.timeout:
                 raise NetMikoTimeoutException("Timed-out reading channel, data not available.")
+        return output
 
     def send_command_expect(self, command_string, expect_string=None,
                             delay_factor=.2, max_loops=500, auto_find_prompt=True,

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -456,7 +456,7 @@ class BaseSSHConnection(object):
         i = 1
         # Keep reading data until search_pattern is found (or max_loops)
         output = ''
-        while i <= max_loops:
+        while i <= max_loops or not self.remote_conn.closed:
             if self.remote_conn.recv_ready():
                 output += self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                 if debug:


### PR DESCRIPTION
The `send_command_expect` function does not stop on connection loss. This pull request addresses this issue by checking the state of `remote_conn.closed` at each iteration.