### PR TITLE
Fix for configure mode on Arista 7500 models

### DIFF
--- a/netmiko/arista/arista_ssh.py
+++ b/netmiko/arista/arista_ssh.py
@@ -2,4 +2,6 @@ from netmiko.ssh_connection import SSHConnection
 
 
 class AristaSSH(SSHConnection):
-    pass
+    def check_config_mode(self, check_string='config)'):
+    	"""Checks if the device is in configuration mode or not."""
+        return super(SSHConnection, self).check_config_mode(check_string=check_string)

--- a/netmiko/arista/arista_ssh.py
+++ b/netmiko/arista/arista_ssh.py
@@ -2,6 +2,6 @@ from netmiko.ssh_connection import SSHConnection
 
 
 class AristaSSH(SSHConnection):
-    def check_config_mode(self, check_string='config)'):
+    def check_config_mode(self, check_string='(config'):
     	"""Checks if the device is in configuration mode or not."""
         return super(SSHConnection, self).check_config_mode(check_string=check_string)


### PR DESCRIPTION
Need to look for config), as Arista 7500 has supervisor # (s1) / (s2) in prompt.
This confuses the default check_string, which only looks for ')#'.
Arista 7500 output:
loc1-core01(s1)#configure terminal 
loc1-core01(s1)(config)#