### PR TITLE
Add support for private keys

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -42,6 +42,7 @@ class BaseSSHConnection(object):
         self.port = int(port)
         self.username = username
         self.password = password
+        self.key_file = key_file
         self.secret = secret
         self.device_type = device_type
         self.ansi_escape_codes = False

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -31,6 +31,7 @@ class SCPConn(object):
                               port=self.ssh_ctl_chan.port,
                               username=self.ssh_ctl_chan.username,
                               password=self.ssh_ctl_chan.password,
+                              key_filename=self.ssh_ctl_chan.key_file,
                               look_for_keys=False,
                               allow_agent=False,
                               timeout=8)


### PR DESCRIPTION
Added support to be able to pass in a private key file.  Modified base_connection.py and scp_handler.py to support this feature.  I successfully tested this feature connecting to a Cisco router using a private key as well as I made sure a username and password would still continue to work.  I will also be opening a pull request for scp_sidecar to support private keys.

Let me know if there are any issues with my changes.