### PR TITLE
Define $ as alt prompt terminator vs primary terminator for Fortinet

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -11,7 +11,7 @@ class FortinetSSH(SSHConnection):
 
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
-        self.set_base_prompt(pri_prompt_terminator='$')
+        self.set_base_prompt(alt_prompt_terminator='$')
         self.disable_paging()
 
     def disable_paging(self, delay_factor=.1):


### PR DESCRIPTION
Current version of Fortinet CLI uses '#' as a prompt instead of '$'. Redefined '$' terminator as `alt_prompt_terminator` in `FortinetSSH` class and rely on using `pri_prompt_terminator='#'` from the `set_base_prompt` method of `BaseSSHConnection` class. This will support current Fortinet devices with '#' prompt but retain backward compatibility for '$'.