### PR TITLE
Brocade ICX/FastIron support

### DIFF
--- a/netmiko/brocade/brocade_fastiron_ssh.py
+++ b/netmiko/brocade/brocade_fastiron_ssh.py
@@ -2,6 +2,9 @@ from netmiko.ssh_connection import SSHConnection
 
 
 class BrocadeFastironSSH(SSHConnection):
-    '''Placeholder for Brocade FastIron'''
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError
+    """Brocade FastIron aka ICX support."""
+    def session_preparation(self):
+        """FastIron requires to be enable mode to disable paging."""
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging(command="skip-page-display")

--- a/tests/brocade_fastiron_commands.txt
+++ b/tests/brocade_fastiron_commands.txt
@@ -1,0 +1,3 @@
+logging buffered 4000
+logging buffered 3000
+no logging console

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -76,3 +76,13 @@ paloalto_panos:
   support_commit: True
   config_verification: 'run show vlan all'
 
+brocade_fastiron:
+  version: "show version"
+  basic: "show ip interface"
+  extended_output: "show running-config"   # requires paging to be disabled
+  config: 
+    - "logging buffered 4000"      # base command
+    - "no logging console"
+    - "logging buffered 3000"      # something you can verify has changed
+  config_verification: "show run | inc logging buffer"
+  config_file: "brocade_fastiron_commands.txt"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -28,4 +28,13 @@ paloalto_panos:
   multiple_line_output: 'logdb-version: 7.0.9'
   version_banner: 'sw-version: 7.0.1'
   cmd_response_init: 'new_test'
-  cmd_response_final: 'another_test'
+  cmd_response_final: 'another_test'---
+
+brocade_fastiron:
+  base_prompt: SSH@ICX7250-24P Router
+  router_prompt : SSH@ICX7250-24P Router>
+  enable_prompt: SSH@ICX7250-24P Router#
+  interface_ip: 10.18.253.130
+  version_banner: "SW: Version"
+  multiple_line_output: "interface management 1"
+  file_check_cmd: "logging buffered 3000"

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -44,3 +44,9 @@ paloalto_panos:
   username: admin
   password: paloalto123
 
+brocade_fastiron:
+  device_type: brocade_fastiron
+  ip: 10.18.253.130
+  username: admin
+  password: password
+  secret: password


### PR DESCRIPTION
First commit for ICX support. Key point is that the disable_paging command is `skip-page-display`, and it must be entered from enable mode.

I've also provided examples for the test definitions. All tests passing so far.