### PR TITLE
fixed double newline in ICX output

### DIFF
--- a/netmiko/brocade/brocade_fastiron_ssh.py
+++ b/netmiko/brocade/brocade_fastiron_ssh.py
@@ -12,6 +12,6 @@ class BrocadeFastironSSH(SSHConnection):
 
     @staticmethod
     def normalize_linefeeds(a_string):
-        """Convert '\r\r\n','\r\n', '\n\r' to '\n."""
-        newline = re.compile(r'(\r\r\r\n|\r\r\n|\r\n|\n\r)')
-        return newline.sub('\n', a_string).replace('\n\n', '\n')
+        """Convert '\r\n\r\n', '\r\r\n','\r\n', '\n\r' to '\n."""
+        newline = re.compile(r'(\r\n\r\n|\r\r\n|\r\n|\n\r|\r)')
+        return newline.sub('\n', a_string)

--- a/netmiko/brocade/brocade_fastiron_ssh.py
+++ b/netmiko/brocade/brocade_fastiron_ssh.py
@@ -1,3 +1,4 @@
+import re
 from netmiko.ssh_connection import SSHConnection
 
 
@@ -8,3 +9,9 @@ class BrocadeFastironSSH(SSHConnection):
         self.set_base_prompt()
         self.enable()
         self.disable_paging(command="skip-page-display")
+
+    @staticmethod
+    def normalize_linefeeds(a_string):
+        """Convert '\r\r\n','\r\n', '\n\r' to '\n."""
+        newline = re.compile(r'(\r\r\r\n|\r\r\n|\r\n|\n\r)')
+        return newline.sub('\n', a_string).replace('\n\n', '\n')


### PR DESCRIPTION
Not sure if this is the 'right' way to do this or not. But it addresses this problem:
```
>>> config_commands = ['logging console',
...                    'no logging console']
>>> output = net_connect.send_config_set(config_commands)
>>> print(output)
config term

SSH@ICX7250-24P Router(config)#logging console

SSH@ICX7250-24P Router(config)#no logging console

SSH@ICX7250-24P Router(config)#end

SSH@ICX7250-24P Router#
>>> print (repr(output))
u'config term\n\nSSH@ICX7250-24P Router(config)#logging console\n\nSSH@ICX7250-24P Router(config)#no logging console\n\nSSH@ICX7250-24P Router(config)#end\n\nSSH@ICX7250-24P Router#'
>>>
```
After making this change, the output looks like this:
```
>>> config_commands = ['logging console',
...                    'no logging console']
>>> output = net_connect.send_config_set(config_commands)
>>> print(output)
config term
SSH@ICX7250-24P Router(config)#logging console
SSH@ICX7250-24P Router(config)#no logging console
SSH@ICX7250-24P Router(config)#end
SSH@ICX7250-24P Router#
>>>
```