### PR TITLE
VDX login delay and test command/responses

### DIFF
--- a/netmiko/brocade/brocade_nos_ssh.py
+++ b/netmiko/brocade/brocade_nos_ssh.py
@@ -1,4 +1,5 @@
 """Support for Brocade NOS/VDX."""
+import time
 from netmiko.ssh_connection import SSHConnection
 
 
@@ -11,3 +12,11 @@ class BrocadeNosSSH(SSHConnection):
     def exit_enable_mode(self, *args, **kwargs):
         """No enable mode on Brocade VDX."""
         pass
+
+    def special_login_handler(self, delay_factor=.5):
+        '''
+            Adding a delay after login
+        '''
+        delay_factor = self.select_delay_factor(delay_factor)
+        self.remote_conn.sendall('\n')
+        time.sleep(2 * delay_factor)

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -97,3 +97,12 @@ brocade_netiron:
     - "logging buffered 3000"      # something you can verify has changed
   config_verification: "show run | inc logging buffer"
   config_file: "brocade_netiron_commands.txt"
+
+brocade_nos:
+  version: "show version"
+  basic: "show interface Management"
+  extended_output: "show ip interface brief"   # requires paging to be disabled
+  config: 
+    - "logging raslog console WARNING"      # base command
+    - "logging raslog console INFO"
+  config_verification: "show run | inc raslog"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -47,3 +47,13 @@ brocade_netiron:
   version_banner: "IronWare : Version"
   multiple_line_output: "All show version done"
   file_check_cmd: "logging buffered 3000"
+
+brocade_nos:
+  base_prompt: Leaf1
+  router_prompt : Leaf1#
+  enable_prompt: Leaf1#
+  interface_ip: 10.254.4.117
+  version_banner: "Network Operating System Version:"
+  multiple_line_output: "TenGigabitEthernet 34/0/48"
+  cmd_response_init: 'logging raslog console WARNING'
+  cmd_response_final: 'logging raslog console INFO'

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -57,3 +57,9 @@ brocade_netiron:
   username: admin
   password: password
   secret: password
+
+brocade_nos:
+  device_type: brocade_nos
+  ip: 10.254.4.117
+  username: admin
+  password: password


### PR DESCRIPTION
This addresses the issue in #239. Fix written by @samirsss. I've added the test commands/responses for Brocade VDX. Tests so far look good with this update