### PR TITLE
Adding support for VyOS

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -25,6 +25,7 @@ from netmiko.alcatel import AlcatelSrosSSH
 from netmiko.dell import DellForce10SSH
 from netmiko.paloalto import PaloAltoPanosSSH
 from netmiko.quanta import QuantaMeshSSH
+from netmiko.vyos import VyOSSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -57,6 +58,7 @@ CLASS_MAPPER_BASE = {
     'dell_force10': DellForce10SSH,
     'paloalto_panos': PaloAltoPanosSSH,
     'quanta_mesh': QuantaMeshSSH,
+    'vyos': VyOSSSH,
 }
 
 # Also support keys that end in _ssh

--- a/netmiko/vyos/__init__.py
+++ b/netmiko/vyos/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.vyos.vyos_ssh import VyOSSSH
+
+__all__ = ['VyOSSSH']

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -1,0 +1,117 @@
+from netmiko.netmiko_globals import MAX_BUFFER
+from netmiko.ssh_connection import BaseSSHConnection
+
+
+class VyOSSSH(BaseSSHConnection):
+    '''
+    Implement methods for interacting with VyOS network devices.
+
+    Disables `enable()` and `check_enable_mode()` methods.
+    '''
+
+    def session_preparation(self):
+       """
+       Prepare the session after the connection has been established.
+       """
+
+       self.set_base_prompt()
+       self.disable_paging(command="set terminal length 0\n")
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on VyOS."""
+        pass
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on VyOS."""
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        """No enable mode on VyOS."""
+        pass
+
+    def check_config_mode(self, check_string='#'):
+        """Checks if the device is in configuration mode"""
+        return super(VyOSSSH, self).check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command='configure', pattern='[edit]'):
+        """Enter configuration mode."""
+        return super(VyOSSSH, self).config_mode(config_command=config_command, pattern=pattern)
+
+    def exit_config_mode(self, exit_config='exit', pattern='exit'):
+        """Exit configuration mode"""
+
+        output = ""
+        if self.check_config_mode():
+            output = self.send_command(exit_config, strip_prompt=False, strip_command=False)
+
+            if 'Cannot exit: configuration modified' in output:
+                #insert delay?
+                output += self.send_command('exit discard', strip_prompt=False, strip_command=False)
+            if self.check_config_mode():
+                raise ValueError("Failed to exit configuration mode")
+        return output
+
+    def commit(self, comment='', delay_factor=.1):
+       """
+       Commit the candidate configuration.
+
+       Commit the entered configuration. Raise an error and return the failure
+       if the commit fails.
+
+       default:
+           command_string = commit
+       comment:
+           command_string = commit comment <comment>
+
+       """
+       delay_factor = self.select_delay_factor(delay_factor)
+       error_marker = 'Failed to generate committed config'
+       command_string = 'commit'
+
+       if comment:
+           command_string += ' comment "{}"'.format(comment)
+
+       output = self.config_mode()
+       output += self.send_command_expect(command_string, strip_prompt=False,
+                                          strip_command=False, delay_factor=delay_factor)
+
+       if error_marker in output:
+           raise ValueError('Commit failed with following errors:\n\n{}'.format(output))
+
+       return output
+
+    def set_base_prompt(self, pri_prompt_terminator='$', alt_prompt_terminator='#',
+                        delay_factor=.5):
+        """
+        Sets self.base_prompt
+
+        Used as delimiter for stripping of trailing prompt in output.
+
+        """
+        debug = False
+        if debug:
+            print("In set_base_prompt")
+
+        delay_factor = self.select_delay_factor(delay_factor)
+        self.clear_buffer()
+        self.remote_conn.sendall("\n")
+
+        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
+        prompt = self.normalize_linefeeds(prompt)
+
+        # If multiple lines in the output take the last line
+        prompt = prompt.split('\n')[-1].strip()
+
+        # Check that ends with a valid terminator character
+        if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
+            raise ValueError("Router prompt not found: {0}".format(prompt))
+
+        # Set prompt to user@hostname 
+
+        self.base_prompt = prompt[:-3].strip()
+
+        if debug:
+            print("prompt: {}".format(self.base_prompt))
+
+        return self.base_prompt
+


### PR DESCRIPTION
Initial commit for limited support of VyOS. Ran tests against on VM running VyOS. 

```
# rollerr @ ubuntu-server in ~/workplace/src/netmiko/tests on git:vyos_support x [7:51:19] C:1
$ py.test -v test_netmiko_show.py --test_device vyos --debug
writing pytestdebug information to /home/rollerr/workplace/src/netmiko/tests/pytestdebug.log
================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/rollerr/workplace/src/bin/python
using: pytest-2.9.2 pylib-1.4.31
cachedir: ../.cache
rootdir: /home/rollerr/workplace/src/netmiko, inifile:
collected 11 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_send_command PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

=============================================================== 11 passed in 16.69 seconds ===============================================================
wrote pytestdebug information to /home/rollerr/workplace/src/netmiko/tests/pytestdebug.log


# rollerr @ ubuntu-server in ~/workplace/src/netmiko/tests on git:vyos_support x [7:50:50]
$ py.test -v test_netmiko_config.py --test_device vyos --debug
writing pytestdebug information to /home/rollerr/workplace/src/netmiko/tests/pytestdebug.log
================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/rollerr/workplace/src/bin/python
using: pytest-2.9.2 pylib-1.4.31
cachedir: ../.cache
rootdir: /home/rollerr/workplace/src/netmiko, inifile:
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

=============================================================== 7 passed in 12.33 seconds ================================================================
wrote pytestdebug information to /home/rollerr/workplace/src/netmiko/tests/pytestdebug.log
```