### PR TITLE
Adding delay factor for VyOS base prompt

### DIFF
--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -78,11 +78,7 @@ class VyOSSSH(BaseSSHConnection):
             print("In set_base_prompt")
 
         delay_factor = self.select_delay_factor(delay_factor)
-        self.clear_buffer()
-        self.remote_conn.sendall("\n")
-
-        prompt = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
-        prompt = self.normalize_linefeeds(prompt)
+        prompt = self.find_prompt(delay_factor=delay_factor)
 
         # If multiple lines in the output take the last line
         prompt = prompt.split('\n')[-1].strip()


### PR DESCRIPTION
Running into some delay issues while waiting for base_prompt. I've been testing by loading configs with the netmiko ansible module[0]. Appears to work well so far. 

[0] https://github.com/ktbyers/netmiko-ansible/blob/master/library/netmiko_install_config
```
# rollerr @ ubuntu-server in ~/workplace/src/netmiko/tests on git:vyos_delay o [17:17:58]
$ py.test -v test_netmiko_show.py --test_device vyos
================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/rollerr/workplace/src/bin/python
cachedir: ../.cache
rootdir: /home/rollerr/workplace/src/netmiko, inifile:
collected 11 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_send_command PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

=============================================================== 11 passed in 17.59 seconds ===============================================================
(src)
# rollerr @ ubuntu-server in ~/workplace/src/netmiko/tests on git:vyos_delay x [17:20:56]
$ py.test -v test_netmiko_config.py --test_device vyos
================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-2.9.2, py-1.4.31, pluggy-0.3.1 -- /home/rollerr/workplace/src/bin/python
cachedir: ../.cache
rootdir: /home/rollerr/workplace/src/netmiko, inifile:
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

=============================================================== 7 passed in 11.42 seconds ================================================================
(src)
```