### PR TITLE
Set retry time to 60 seconds for auth timeouts.

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -381,7 +381,7 @@ class BaseConnection(object):
         delay_factor = self.select_delay_factor(delay_factor=0)
         main_delay = delay_factor * .1
         time.sleep(main_delay)
-        while i <= 60:
+        while i <= 40:
             new_data = self._read_channel()
             if new_data:
                 break
@@ -391,7 +391,7 @@ class BaseConnection(object):
                 if main_delay >= 8:
                     main_delay = 8
                 time.sleep(main_delay)
-                i += main_delay
+                i += 1
         # check if data was ever present
         if new_data:
             return ""

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -381,7 +381,7 @@ class BaseConnection(object):
         delay_factor = self.select_delay_factor(delay_factor=0)
         main_delay = delay_factor * .1
         time.sleep(main_delay)
-        while i <= 20:
+        while i <= 60:
             new_data = self._read_channel()
             if new_data:
                 break
@@ -391,7 +391,7 @@ class BaseConnection(object):
                 if main_delay >= 8:
                     main_delay = 8
                 time.sleep(main_delay)
-                i += 1
+                i += main_delay
         # check if data was ever present
         if new_data:
             return ""


### PR DESCRIPTION
This allows for up to 60 seconds of trying to read data from the device during the initial connection.  This is in relation to issue #257  where TACACS, RADIUS, etc are not available and the device may not respond in a timely fashion.  I tested this in my environment and I was able to connect to my devices that have RADIUS as primary and the servers were unavailable.

Couple things: changed the max loop to 60 to resemble 60 seconds.  Changed i += 1 to using main_delay, reason for this; we should probably wait a consistent amount of time and not rely on someone setting global_delay_factor. Using main_delay mimics actual wait time. With this change only affecting the establishment of the connection, I feel 60 seconds is ample amount of time to wait for authentication.  I don't know if I feel allowing a user to specify a high amount for global_delay_factor is the best idea for fixing the timeout issue especially since a global delay factor affects other items.  I know it's best to try and keep things dynamic but I have no problem with this setting being static.

Thoughts?