### PR TITLE
modify scp_handler.py to support file transfers from remote

### DIFF
--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -41,9 +41,26 @@ class SCPConn(object):
         """
         Transfer file using SCP
 
-        Must close the SCP connection to get the file to write to the remote filesystem
+        Must close the SCP connection to get the file to write to the remote
+        filesystem.
         """
-        self.scp_client.put(source_file, dest_file)
+        self.scp_transfer_file_to_remote(source_file, dest_file)
+
+    def scp_transfer_file_to_remote(self, local_file, remote_file):
+        """
+        Transfer file to the remote using SCP
+
+        Must close the SCP connection to get the file to write to the remote
+        filesystem.
+        """
+        self.scp_client.put(local_file, remote_file)
+
+    def scp_transfer_file_from_remote(self, remote_file, local_file):
+        """
+        Transfer file from the remote using SCP
+
+        """
+        self.scp_client.get(remote_file, local_file)
 
     def close(self):
         """Close the SCP connection."""
@@ -51,14 +68,35 @@ class SCPConn(object):
 
 
 class FileTransfer(object):
-    """Class to manage SCP file transfer and associated SSH control channel."""
-    def __init__(self, ssh_conn, source_file, dest_file, file_system=None):
+    """Class to manage SCP file transfer and associated SSH control channel.
+
+    Allows for transfer to and from the local host.
+    """
+    def __init__(self, ssh_conn, local_file, remote_file, file_system=None,
+                 local_dir=None):
+        if local_file is None and local_dir is None:
+            raise ValueError('local_dir cannot be None if local_file is None.')
+
         self.ssh_ctl_chan = ssh_conn
-        self.source_file = source_file
-        self.source_md5 = self.file_md5(source_file)
-        self.dest_file = dest_file
-        src_file_stats = os.stat(source_file)
-        self.file_size = src_file_stats.st_size
+
+        #local_file can be None if transfering from remote
+        if local_file is not None:
+            if os.path.sep in local_file:
+                if local_dir is not None:
+                    self.local_dir = os.path.dirname(local_file)
+                self.local_file = os.path.basename(local_file)
+        else:
+            # Use remote filename for local filename.
+            self.local_file = remote_file
+
+        if not hasattr(self,local_file):
+            self.local_file = local_file
+        if local_dir is None or not hasattr(self, local_dir):
+            self.local_dir = '.' + os.path.sep
+        self.remote_file = remote_file
+        # local_file may not exist yet if the source is the remote file system.
+        if os.path.isfile(self.local_file):
+            self.get_local_file_info()
         if not file_system:
             self.file_system = self.ssh_ctl_chan._autodetect_fs()
         else:
@@ -75,6 +113,12 @@ class FileTransfer(object):
         if exc_type is not None:
             raise exc_type(exc_value)
 
+    def get_local_file_info(self):
+        self.local_md5 = self.file_md5(os.path.join(
+            self.local_dir, self.local_file))
+        src_file_stats = os.stat(self.local_file)
+        self.local_file_size = src_file_stats.st_size
+
     def establish_scp_conn(self):
         """Establish SCP connection."""
         self.scp_conn = SCPConn(self.ssh_ctl_chan)
@@ -90,16 +134,16 @@ class FileTransfer(object):
         remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
         match = re.search(search_pattern, remote_output)
         space_avail = int(match.group(1))
-        if space_avail > self.file_size:
+        if space_avail > self.local_file_size:
             return True
         return False
 
     def check_file_exists(self, remote_cmd=""):
-        """Check if the dest_file exists on the remote file system (return boolean)."""
+        """Check if the remote_file exists on the remote file system (return boolean)."""
         if not remote_cmd:
-            remote_cmd = "dir {0}/{1}".format(self.file_system, self.dest_file)
+            remote_cmd = "dir {0}/{1}".format(self.file_system, self.remote_file)
         remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
-        search_string = r"Directory of .*{0}".format(self.dest_file)
+        search_string = r"Directory of .*{0}".format(self.remote_file)
         if 'Error opening' in remote_out:
             return False
         elif re.search(search_string, remote_out):
@@ -133,7 +177,7 @@ class FileTransfer(object):
     def compare_md5(self, base_cmd='verify /md5', delay_factor=8):
         """Compare md5 of file on network device to md5 of local file"""
         dest_md5 = self.remote_md5(base_cmd=base_cmd)
-        return self.source_md5 == dest_md5
+        return self.local_md5 == dest_md5
 
     def remote_md5(self, base_cmd='verify /md5', delay_factor=8):
         """
@@ -141,17 +185,38 @@ class FileTransfer(object):
 
         This command can be CPU intensive on the remote device.
         """
-        remote_md5_cmd = "{0} {1}{2}".format(base_cmd, self.file_system, self.dest_file)
+        remote_md5_cmd = "{0} {1}{2}".format(base_cmd, self.file_system,
+                                             self.remote_file)
         dest_md5 = self.ssh_ctl_chan.send_command_expect(remote_md5_cmd)
         dest_md5 = self.process_md5(dest_md5)
         return dest_md5
 
+    @property
+    def _get_remote(self):
+        remote = "{}{}".format(self.file_system, self.remote_file)
+        if ':' not in remote:
+            raise ValueError("Invalid remote file system specified %s",
+                             remote)
+        return remote
+
     def transfer_file(self):
-        """SCP transfer source_file to remote device."""
-        destination = "{}{}".format(self.file_system, self.dest_file)
-        if ':' not in destination:
-            raise ValueError("Invalid destination file system specified")
-        self.scp_conn.scp_transfer_file(self.source_file, destination)
+        return self.transfer_file_to_remote()
+
+    def transfer_file_to_remote(self):
+        """SCP transfer local_file to remote device."""
+        remote = self._get_remote
+        local = os.path.join(self.local_dir, self.local_file)
+        self.scp_conn.scp_transfer_file_to_remote(local, remote)
+        # Must close the SCP connection to get the file written (flush)
+        self.scp_conn.close()
+
+    def transfer_file_from_remote(self, local_file=None):
+        """SCP transfer local_file to remote device."""
+        remote = self._get_remote
+        if local_file is not None:
+            self.local_file = local_file
+        local = os.path.join(self.local_dir, self.local_file)
+        self.scp_conn.scp_transfer_file_from_remote(remote, local)
         # Must close the SCP connection to get the file written (flush)
         self.scp_conn.close()
 


### PR DESCRIPTION
scp_handler implemented file transfers to a remote device via
the scp.put() method.  This change adds the ability to copy
files from a remote device via the scp.get() method.