### PR TITLE
remove read_data from telnet_login

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -219,10 +219,10 @@ class BaseConnection(object):
         i = 1
         while i <= max_loops:
             try:
-                read_data = self.read_channel()
+                output = self.read_channel()
                 if debug:
-                    print(read_data)
-                if re.search(r"sername", read_data):
+                    print(output)
+                if re.search(r"sername", output):
                     self.write_channel(self.username + '\n')
                     time.sleep(1 * delay_factor)
                     output += self.read_channel()


### PR DESCRIPTION
In case the switch does not ask for a username the login would not be possible. With the changed code it works with and without username.

example Cisco config:

> line vty 0 4
>  exec-timeout 0 0
>  password GUESSME
>  login
> 

example output:

> Connected to 255.255.255.255.
> Escape character is '^]'.
> 
> User Access Verification
> 
> Password:
