### PR TITLE
Added in support for session logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ examples/SECRET_DEVICE_CREDS.py
 build
 dist
 netmiko.egg-info
+.idea
 .cache
 bin/.netmiko.cfg


### PR DESCRIPTION
Created new optional parameter for `BaseConnection` called `session_log`. This can be either a `logger` object that has been created by the user or optionally the file path for the log file as a `str`. Logging is done via Python's `logging` module. Ref #279