### PR TITLE
Fixed vyos timing issues when exiting configuration mode

### DIFF
--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -79,3 +79,11 @@ class VyOSSSH(CiscoSSHConnection):
         # Set prompt to user@hostname (remove two additional characters)
         self.base_prompt = prompt[:-2].strip()
         return self.base_prompt
+
+    def send_config_set(self, config_commands=None, exit_config_mode=False, delay_factor=1,
+                        max_loops=150, strip_prompt=False, strip_command=False):
+        """Remain in configuration mode."""
+        return super(VyOSSSH, self).send_config_set(config_commands=config_commands, exit_config_mode=exit_config_mode, 
+                                                    delay_factor=delay_factor, max_loops=max_loops,
+                                                    strip_prompt=strip_prompt, strip_command=strip_command)
+        

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -35,10 +35,9 @@ class VyOSSSH(CiscoSSHConnection):
         """Exit configuration mode"""
         output = ""
         if self.check_config_mode():
-            output = self.send_command(exit_config, strip_prompt=False, strip_command=False)
+            output = self.send_command_timing(exit_config, strip_prompt=False, strip_command=False)
             if 'Cannot exit: configuration modified' in output:
-                # insert delay?
-                output += self.send_command('exit discard', strip_prompt=False, strip_command=False)
+                output += self.send_command_timing('exit discard', strip_prompt=False, strip_command=False)
             if self.check_config_mode():
                 raise ValueError("Failed to exit configuration mode")
         return output


### PR DESCRIPTION
Existing from vyos config needs a minor delay to obtain output. Currently the send_command method is timing out. 

Prior to changes:

```

In [8]: b.device_type
Out[8]: 'vyos'

In [9]: results = b.send_config_from_file('branch2-edg-r1.conf', exit_config_mode=False)

In [10]: b.host
Out[10]: 'branch2-edg-r1'

In [11]: b.exit_config_mode()
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-11-bdf81436692a> in <module>()
----> 1 b.exit_config_mode()

/usr/local/lib/python2.7/dist-packages/netmiko/vyos/vyos_ssh.pyc in exit_config_mode(self, exit_config, pattern)
     39             if 'Cannot exit: configuration modified' in output:
     40                 # insert delay?
---> 41                 output += self.send_command('exit discard', strip_prompt=False, strip_command=False)
     42             if self.check_config_mode():
     43                 raise ValueError("Failed to exit configuration mode")

/usr/local/lib/python2.7/dist-packages/netmiko/base_connection.pyc in send_command(self, command_string, expect_string, delay_factor, max_loops, auto_find_prompt, strip_prompt, strip_command)
    656         else:   # nobreak
    657             raise IOError("Search pattern never detected in send_command_expect: {0}".format(
--> 658                 search_pattern))
    659
    660         output = self._sanitize_output(output, strip_command=strip_command,

IOError: Search pattern never detected in send_command_expect: admin\@branch2\-edg\-r1\#
```

After adjusting:
```
In [4]: b.send_config_from_file('/home/ubuntu/workplace/ansible_vyos/vyos/output/branch2-edg-r1.conf', exit_config_mode=False)
Out[4]: u'set interfaces ethernet eth5 address 18.0.0.42/30\n\n  Configuration path: [interfaces ethernet eth5 address 18.0.0.42/30] already exists\n\n[edit]\nadmin@branch2-edg-r1# set interfaces ethernet eth5 description "--> super-pe-r1  \r| eth11"\n\n  Configuration path: [interfaces ethernet eth5 description --> super-pe-r1 | eth11] already exists\n\n[edit]\nadmin@branch2-edg-r1# set interfaces ethernet eth6 address 18.0.0.46/30\n\n  Configuration path: [interfaces ethernet eth6 address 18.0.0.46/30] already exists\n\n[edit]\nadmin@branch2-edg-r1# set interfaces ethernet eth6 description "--> super-pe-r1  \r| eth12"\n\n  Configuration path: [interfaces ethernet eth6 description --> super-pe-r1 | eth12] already exists\n\n[edit]\nadmin@branch2-edg-r1# '

In [5]: b.commit()
Out[5]: u'commit\nNo configuration changes to commit\n[edit]\nadmin@branch2-edg-r1# '

In [6]: b.exit_config_mode()
Out[6]: u'exit\nexit\nadmin@branch2-edg-r1:~$ '

In [7]:
```