### PR TITLE
Proposal to add context manager functionality

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -88,6 +88,14 @@ class BaseConnection(object):
             self.establish_connection()
             self.session_preparation()
 
+    def __enter__(self):
+        """Enter runtime context"""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Gracefully close connection on context manager exit"""
+        self.disconnect()
+
     def write_channel(self, out_data):
         """Generic handler that will write to both SSH and telnet channel."""
         if self.protocol == 'ssh':


### PR DESCRIPTION
Reference: https://github.com/ktbyers/netmiko/issues/295

I also can see value in being able to use a context manager with the `ConnectHandler` method, and here's a proposed approach to adding that functionality by adding the `__enter__` and `__exit__` methods to `BaseConnection`.

```
>>> from netmiko import ConnectHandler
>>> with ConnectHandler(**linux_device) as conn:
...     print("Testing netmiko context manager functionality")
...     print(conn.send_command('uname -a'))
...
Testing netmiko context manager functionality
Linux raspberrypi 4.4.13-v7+ #894 SMP Mon Jun 13 13:13:27 BST 2016 armv7l GNU/Linux
```