### PR TITLE
Fixed condition to check if vdoms are enabled

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -16,7 +16,7 @@ class FortinetSSH(CiscoSSHConnection):
         self.vdoms = False
 
         # According with http://www.gossamer-threads.com/lists/rancid/users/6729
-        if output.find("Virtual domain configuration: enable"):
+        if output.find("Virtual domain configuration: enable") != -1:
             self.vdoms = True
             vdom_additional_command = "config global"
             output = self.send_command_timing(vdom_additional_command)


### PR DESCRIPTION
When connecting to a Fortinet device with vdoms disabled I found that device.vdoms == True. The condition to check was using output.find("Virtual domain configuration: enabled") which evaluated to True even though the result was -1. This could be unique to my setup as I'm using Windows with python 3.4.2, however I thought it would be best to explicitly test for -1.