### PR TITLE
update telnet code for cisco console over telnet

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -323,7 +323,7 @@ class BaseConnection(object):
                     if debug:
                         print("checkpoint5")
                     return return_msg
-                self.write_channel("\n")
+                self.write_channel("\r\n")
                 time.sleep(.5 * delay_factor)
                 i += 1
             except EOFError:

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -313,15 +313,31 @@ class BaseConnection(object):
                         if debug:
                             print("checkpoint3")
                         return return_msg
-                if re.search(r"assword required, but none set", output):
+                if re.search(r"initial configuration dialog\? \[yes/no\]: ", output):
                     if debug:
                         print("checkpoint4")
+                    self.write_channel("no\n")
+                    # we want to drop into a mini loop after this until the router is
+                    # ready for login, occasionally output before the 'press RETURN'
+                    # will contain the prompt character
+                    while i <= max_loops:
+                        output = self.read_channel()
+                        return_msg += output
+                        if re.search(r"ress RETURN to get started!", output):
+                            output = ""
+                            break
+                        output = ""
+                        time.sleep(2 * delay_factor)
+                        i += 1
+                if re.search(r"assword required, but none set", output):
+                    if debug:
+                        print("checkpoint5")
                     msg = "Telnet login failed - Password required, but none set: {0}".format(
                         self.host)
                     raise NetMikoAuthenticationException(msg)
                 if pri_prompt_terminator in output or alt_prompt_terminator in output:
                     if debug:
-                        print("checkpoint5")
+                        print("checkpoint6")
                     return return_msg
                 self.write_channel("\r\n")
                 time.sleep(.5 * delay_factor)


### PR DESCRIPTION
fixes problems with console-over-telnet when not at login prompt yet

using netmiko to connect to devices connected over console port on opengear console servers, when at the initial 'Press RETURN to get started.' the \n sent by netmiko doesn't cause the device to wake, we need to send \r\n or \r&lt;nul&gt; (see Mark's comment at: http://stackoverflow.com/questions/4159342/how-to-send-carriage-return-over-telnet) 