### PR TITLE
HP Procurve switches new firmware new escape codes on prompt

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -859,9 +859,11 @@ class BaseConnection(object):
         code_erase_line = chr(27) + r'\[2K'
         code_erase_start_line = chr(27) + r'\[K'
         code_enable_scroll = chr(27) + r'\[\d+;\d+r'
+        code_form_feed = chr(27) + r'\[1L'
+        code_carriage_return = chr(27) + r'\[1M'
 
         code_set = [code_position_cursor, code_show_cursor, code_erase_line, code_enable_scroll,
-                    code_erase_start_line]
+                    code_erase_start_line, code_form_feed, code_carriage_return]
 
         output = string_buffer
         for ansi_esc_code in code_set:


### PR DESCRIPTION
HP Procurve switches starting adding "tty=ansi " to the beginning of their prompt plus two escade codes: form feed and carriage return.  I added those to the strip_ansi_escape_codes method to remove them, this way find prompt does work.

This started on models 2530, on firmware versions YA.16.01.0011 and YA.16.01.0011. Probably more switches will follow this path.