### PR TITLE
Fix proxycommand support

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -394,8 +394,7 @@ class BaseConnection(object):
             ssh_config_instance = paramiko.SSHConfig()
             with open(full_path) as f:
                 ssh_config_instance.parse(f)
-                host_specifier = "{0}:{1}".format(self.host, self.port)
-                source = ssh_config_instance.lookup(host_specifier)
+                source = ssh_config_instance.lookup(self.host)
         else:
             source = {}
 


### PR DESCRIPTION
Prior to this, the port was appended to the hostname parameter when given to paramiko.SSHConfig, this causes a config such as:

```
  ProxyCommand ssh jumphost nc %h %p
```

to be expanded to something like:

```
  ssh jumphost nc 10.0.0.1:22 22
```

Which isn't correct according to ssh_configs doc's on the usage of the replacements:

> In the command string, any occurrence of ‘%h’ will be substituted by the host name to connect, ‘%p’ by the port, and ‘%r’ by the remote user name.


This bug was introduced in 649dbcd4e1


------


The commit that introduces this isn't super clear on why this was done, I may be missing something but I'm not sure how this can be working in it's current state.

Thanks!