### PR TITLE
add support for Cisco TelePresence endpoints (TC and CE software)

### DIFF
--- a/examples/ciscoTP_example.py
+++ b/examples/ciscoTP_example.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+'''
+Test Netmiko on Cisco TelePresence Video device (C, SX, DX, EX, MX)
+'''
+
+from netmiko import ConnectHandler, cisco
+    
+mydevice = {
+'device_type': 'cisco_tp',
+'ip': '192.168.105.1',
+'username': 'admin',
+'password': 'Tandberg',
+'verbose':True
+}     
+
+ssh_conn = ConnectHandler(**mydevice)
+print( "\n\n")
+
+
+command_list = ['help', 'whoami', 'whoaami', 'echo test', 'xconfig']
+#command_list = ['help', 'whoami', 'whoaami', 'echo test']
+
+ssh_conn = ConnectHandler(**mydevice)
+print( "\n\n")
+
+for command in command_list:
+    print('>>> running command : ' + command)
+    output = ssh_conn.send_command(command)
+    print('Result = ' + output + '\n')

--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -4,6 +4,7 @@ from netmiko.cisco.cisco_nxos_ssh import CiscoNxosSSH
 from netmiko.cisco.cisco_xr_ssh import CiscoXrSSH
 from netmiko.cisco.cisco_wlc_ssh import CiscoWlcSSH
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
+from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
 
 __all__ = ['CiscoIosSSH', 'CiscoIosTelnet', 'CiscoAsaSSH', 'CiscoNxosSSH', 'CiscoXrSSH',
-           'CiscoWlcSSH', 'CiscoS300SSH']
+           'CiscoWlcSSH', 'CiscoS300SSH', 'CiscoTpTcCeSSH']

--- a/netmiko/cisco/cisco_tp_tcce.py
+++ b/netmiko/cisco/cisco_tp_tcce.py
@@ -1,0 +1,158 @@
+import re
+import socket
+import time
+
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko.ssh_exception import NetMikoTimeoutException
+from netmiko.netmiko_globals import BACKSPACE_CHAR
+
+
+class CiscoTpTcCeSSH(CiscoSSHConnection):
+
+    def __init__(self, ip='', host='', username='', password='', secret='', port=None,
+                 device_type='', verbose=False, global_delay_factor=1, use_keys=False,
+                 key_file=None, allow_agent=False, ssh_strict=False, system_host_keys=False,
+                 alt_host_keys=False, alt_key_file='', ssh_config_file=None, timeout=8):
+        self.prompt_search_last_depth = -2
+        CiscoSSHConnection.__init__(self, ip=ip, host=host, username=username, password=password, secret=secret, port=port,
+                 device_type=device_type, verbose=verbose, global_delay_factor=global_delay_factor, use_keys=use_keys,
+                 key_file=key_file, allow_agent=allow_agent, ssh_strict=ssh_strict, system_host_keys=system_host_keys,
+                 alt_host_keys=alt_host_keys, alt_key_file=alt_key_file, ssh_config_file=ssh_config_file, timeout=timeout)
+                 
+    def disable_paging(self, *args, **kwargs):
+        """Linux doesn't have paging by default."""
+        return ""
+        
+    def session_preparation(self):
+        """
+        Prepare the session after the connection has been established
+
+        This method handles some of vagaries that occur between various devices
+        early on in the session.
+
+        In general, it should include:
+        self.set_base_prompt()
+        self.disable_paging()
+        self.set_terminal_width()
+        """
+        
+        """self.set_base_prompt()"""
+        self.disable_paging()
+        self.set_terminal_width()        
+
+
+
+    def set_base_prompt(self, pri_prompt_terminator='OK',
+                        alt_prompt_terminator='ERROR', delay_factor=1):
+        """Determine base prompt."""
+        return super(CiscoSSHConnection, self).set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            delay_factor=delay_factor)
+
+
+        
+    def send_command2(self, command_string, expect_string=None,
+                     delay_factor=1, max_loops=500, auto_find_prompt=True,
+                     strip_prompt=True, strip_command=True):
+        '''
+        Send command to network device retrieve output until router_prompt or expect_string
+
+        By default this method will keep waiting to receive data until the network device prompt is
+        detected. The current network device prompt will be determined automatically.
+
+        command_string = command to execute
+        expect_string = pattern to search for uses re.search (use raw strings)
+        delay_factor = decrease the initial delay before we start looking for data
+        max_loops = number of iterations before we give up and raise an exception
+        strip_prompt = strip the trailing prompt from the output
+        strip_command = strip the leading command from the output
+        '''
+        debug = False
+        delay_factor = self.select_delay_factor(delay_factor)
+        if (hasattr(self, 'prompt_search_last_depth')):
+            prompt_search_last_depth = self.prompt_search_last_depth
+        else:
+            prompt_search_last_depth = 0        
+        
+        # Find the current router prompt
+        if expect_string is None:
+            if auto_find_prompt:
+                try:
+                    prompt = self.find_prompt(delay_factor=delay_factor)
+                except ValueError:
+                    prompt = self.base_prompt
+                if debug:
+                    print("Found prompt: {}".format(prompt))
+            else:
+                prompt = self.base_prompt
+            search_pattern = re.escape(prompt.strip())
+        else:
+            search_pattern = expect_string
+
+        command_string = self.normalize_cmd(command_string)
+        if debug:
+            print("Command is: {0}".format(command_string))
+            print("Search to stop receiving data is: '{0}'".format(search_pattern))
+
+        time.sleep(delay_factor * .2)
+        self.clear_buffer()
+        self.write_channel(command_string)
+
+        # Initial delay after sending command
+        i = 1
+        # Keep reading data until search_pattern is found (or max_loops)
+        output = ''
+        while i <= max_loops:
+            new_data = self.read_channel()
+            if new_data:
+                output += new_data
+                if debug:
+                    print("{}:{}".format(i, output))
+                try:
+                    lines = output.split("\n")
+                    first_line = lines[0]
+                    # First line is the echo line containing the command. In certain situations
+                    # it gets repainted and needs filtered
+                    if BACKSPACE_CHAR in first_line:
+                        pattern = search_pattern + r'.*$'
+                        first_line = re.sub(pattern, repl='', string=first_line)
+                        lines[0] = first_line
+                        output = "\n".join(lines)
+                except IndexError:
+                    pass
+                    
+                is_prompt_found = False
+                j = -1
+                if (prompt_search_last_depth != 0):
+                    while (len(lines)>j*(-1)):
+                        if debug:
+                            print("searching on last line {0} of {1} : text= {2}".format(-1*j, -1*prompt_search_last_depth, lines[j]))
+                        if re.search(search_pattern, lines[j].strip()):
+                            is_prompt_found = True
+                            break
+                        if (j <= prompt_search_last_depth):
+                            break
+                        j = j - 1
+
+                if (prompt_search_last_depth!=0 and is_prompt_found):
+                   break
+                elif re.search(search_pattern, output):
+                        break
+            else:
+                time.sleep(delay_factor * .2)
+            i += 1
+        else:   # nobreak
+            raise IOError("Search pattern never detected in send_command_expect: {0}".format(
+                search_pattern))
+
+        output = self._sanitize_output(output, strip_command=strip_command,
+                                       command_string=command_string, strip_prompt=strip_prompt)
+        return output
+
+    def send_command(self, command_string, expect_string='^(OK|ERROR|Command not recognized\.)$',
+                     delay_factor=1, max_loops=500, auto_find_prompt=True,
+                     strip_prompt=True, strip_command=True):
+        return self.send_command2(command_string=command_string, expect_string=expect_string,
+                     delay_factor=delay_factor, max_loops=max_loops, auto_find_prompt=auto_find_prompt,
+                     strip_prompt=strip_prompt, strip_command=strip_command)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -31,6 +31,7 @@ from netmiko.quanta import QuantaMeshSSH
 from netmiko.aruba import ArubaSSH
 from netmiko.vyos import VyOSSSH
 from netmiko.ubiquiti import UbiquitiEdgeSSH
+from netmiko.cisco import CiscoTpTcCeSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -70,6 +71,7 @@ CLASS_MAPPER_BASE = {
     'quanta_mesh': QuantaMeshSSH,
     'aruba_os': ArubaSSH,
     'ubiquiti_edge': UbiquitiEdgeSSH,
+    'cisco_tp':CiscoTpTcCeSSH,
 }
 
 # Also support keys that end in _ssh


### PR DESCRIPTION
Hello,

Sorry for the late update. This PR follow the old PR#345.

For this class I redefine send_command method to add "prompt_search_last_depth" variable. Prompt  on Cisco Telepresence ("OK" most of the case) is not in the current line (cursor) but the line just before do I set "prompt_search_last_depth=-2" to search prompt on the line just before.

@Kirk, I look on your link for Netmiko Unit test but I didn't know how to configure it for Cisco Telepresence. Especially on command.yml and response.yml, I don't understand what to put in each tag "basic", "extended_output", "version_banner", "multiple_line_output"... most of them doesn't exist for Cisco Telepresence has shell is really basic, completely different than Cisco IOS. Can you contact me for some help on unit tests ?

Thanks,
Ahmad BARRIN