### PR TITLE
Pass through all ssh_config to scp

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -394,8 +394,7 @@ class BaseConnection(object):
             ssh_config_instance = paramiko.SSHConfig()
             with open(full_path) as f:
                 ssh_config_instance.parse(f)
-                host_specifier = "{0}:{1}".format(self.host, self.port)
-                source = ssh_config_instance.lookup(host_specifier)
+                source = ssh_config_instance.lookup(self.host)
         else:
             source = {}
 

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -31,16 +31,8 @@ class SCPConn(object):
 
     def establish_scp_conn(self):
         """Establish the secure copy connection."""
-        self.scp_conn = paramiko.SSHClient()
-        self.scp_conn.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.scp_conn.connect(hostname=self.ssh_ctl_chan.host,
-                              port=self.ssh_ctl_chan.port,
-                              username=self.ssh_ctl_chan.username,
-                              password=self.ssh_ctl_chan.password,
-                              key_filename=self.ssh_ctl_chan.key_file,
-                              look_for_keys=self.ssh_ctl_chan.use_keys,
-                              allow_agent=self.ssh_ctl_chan.allow_agent,
-                              timeout=self.ssh_ctl_chan.timeout)
+        self.scp_conn, ssh_connect_params = self.ssh_ctl_chan.build_ssh_client()
+        self.scp_conn.connect(**ssh_connect_params)
         self.scp_client = scp.SCPClient(self.scp_conn.get_transport())
 
     def scp_transfer_file(self, source_file, dest_file):


### PR DESCRIPTION
Hey, still plugging away with ProxyCommand :)

This commit adds support for passing through all ssh connection configuration to the scp_handler for use when creating a new ssh client.

I wasn't sure on the most consistent way to implement this, I've gone with returning the `ssh_connect_params` and `SSHClient` seperately, leaving the caller to then call `open` with them both. It could be neater just to call open within `build_ssh_client` (perhaps rename it).
Another option would be just copy pasta the block from base_connection too scp_handler...

Depends on 91450d1