### PR TITLE
Increase default delay factor for BaseConnection.set_base_prompt()

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -576,7 +576,7 @@ class BaseConnection(object):
         return output
 
     def set_base_prompt(self, pri_prompt_terminator='#',
-                        alt_prompt_terminator='>', delay_factor=1):
+                        alt_prompt_terminator='>', delay_factor=10):
         """
         Sets self.base_prompt
 


### PR DESCRIPTION
When establishing new connection to Cisco switch devices connection is failing with Exception: "Router prompt not found: <last line of welcome message>"
I found that on those Cisco switches there is a delay (~1 sec.) between "welcome message" and "prompt message". By increasing default delay factor for BaseConnection.set_base_prompt() I managed to connect to those devices. 