### PR TITLE
Adds Ciena SAOS support (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Enterasys
 Extreme  
 F5 LTM  
 Fortinet  
-
+Ciena SAOS
 
 <br>
 ## Tutorials:

--- a/netmiko/ciena/__init__.py
+++ b/netmiko/ciena/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.ciena.ciena_saos_ssh import CienaSaosSSH
+
+__all__ = ['CienaSaosSSH']

--- a/netmiko/ciena/ciena_saos_ssh.py
+++ b/netmiko/ciena/ciena_saos_ssh.py
@@ -1,0 +1,15 @@
+"""Ciena SAOS support."""
+from __future__ import print_function
+from __future__ import unicode_literals
+import re
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class CienaSaosSSH(CiscoSSHConnection):
+    """Ciena SAOS support."""
+    def session_preparation(self):
+        self.set_base_prompt()
+        self.disable_paging(command="system shell session set more off\n")
+
+    def enable(self, *args, **kwargs):
+        pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -31,6 +31,7 @@ from netmiko.quanta import QuantaMeshSSH
 from netmiko.aruba import ArubaSSH
 from netmiko.vyos import VyOSSSH
 from netmiko.ubiquiti import UbiquitiEdgeSSH
+from netmiko.ciena import CienaSaosSSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -70,6 +71,7 @@ CLASS_MAPPER_BASE = {
     'quanta_mesh': QuantaMeshSSH,
     'aruba_os': ArubaSSH,
     'ubiquiti_edge': UbiquitiEdgeSSH,
+    'ciena_saos': CienaSaosSSH,
 }
 
 # Also support keys that end in _ssh

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
               'netmiko/paloalto',
               'netmiko/quanta',
               'netmiko/vyos',
+              'netmiko/ciena',
               'netmiko/aruba'],
     install_requires=['paramiko>=1.13.0', 'scp>=0.10.0', 'pyyaml'],
     extras_require={


### PR DESCRIPTION
This adds support for Ciena SAOS carrier Ethernet switches. SAOS does not have enable or config mode.