### PR TITLE
Telnet connection improvement. Fix check_config_mode, check_enable_mode. EdgeCore switch support.

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -288,7 +288,7 @@ class BaseConnection(object):
                      delay_factor=1, max_loops=60):
         """Telnet login. Can be username/password or just password."""
         TELNET_RETURN = '\r\n'
-        debug = True
+        debug = False
         if debug:
             print("In telnet_login():")
         delay_factor = self.select_delay_factor(delay_factor)
@@ -838,7 +838,7 @@ class BaseConnection(object):
         output = self.read_until_prompt()
         if debug:
             print(output)
-        return check_string in output
+        return output.endswith(check_string)
 
     def enable(self, cmd='', pattern='password', re_flags=re.IGNORECASE):
         """Enter enable mode."""
@@ -871,7 +871,7 @@ class BaseConnection(object):
         output = self.read_until_pattern(pattern=pattern)
         if debug:
             print("check_config_mode: {}".format(repr(output)))
-        return check_string in output
+        return output.endswith(check_string)
 
     def config_mode(self, config_command='', pattern=''):
         """Enter into config_mode."""

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -73,4 +73,7 @@ class CiscoSSHConnection(CiscoBaseConnection):
 
 
 class CiscoTelnetConnection(CiscoBaseConnection):
-    pass
+
+    def __init__(self, **kwargs):
+        protocol = kwargs.pop('protocol', 'telnet')
+        super(CiscoTelnetConnection, self).__init__(protocol=protocol, **kwargs)

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -18,7 +18,7 @@ class CiscoBaseConnection(BaseConnection):
         """Exits enable (privileged exec) mode."""
         return super(CiscoBaseConnection, self).exit_enable_mode(exit_command=exit_command)
 
-    def check_config_mode(self, check_string=')#', pattern=''):
+    def check_config_mode(self, check_string='config)#', pattern=''):
         """
         Checks if the device is in configuration mode or not.
 

--- a/netmiko/edgecore/__init__.py
+++ b/netmiko/edgecore/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.edgecore.edgecore_es_series import EdgeCoreTelnet
+
+__all__ = ['EdgeCoreTelnet']

--- a/netmiko/edgecore/edgecore_es_series.py
+++ b/netmiko/edgecore/edgecore_es_series.py
@@ -7,4 +7,10 @@ from netmiko.cisco_base_connection import CiscoTelnetConnection
 
 
 class EdgeCoreTelnet(CiscoTelnetConnection):
-    pass
+
+    def session_preparation(self):
+        """Edge-Core requires enable mode to set terminal options."""
+        self.set_base_prompt()
+        self.disable_paging()
+        self.set_terminal_width(command='terminal width 80')
+

--- a/netmiko/edgecore/edgecore_es_series.py
+++ b/netmiko/edgecore/edgecore_es_series.py
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+"""Netmiko support for Edge-Core ES series switches."""
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from netmiko.cisco_base_connection import CiscoTelnetConnection
+
+
+class EdgeCoreTelnet(CiscoTelnetConnection):
+    pass

--- a/netmiko/edgecore/edgecore_es_series.py
+++ b/netmiko/edgecore/edgecore_es_series.py
@@ -14,3 +14,6 @@ class EdgeCoreTelnet(CiscoTelnetConnection):
         self.disable_paging()
         self.set_terminal_width(command='terminal width 80')
 
+    def config_mode(self, config_command='', pattern=''):
+        """Enter configuration mode."""
+        return super(EdgeCoreTelnet, self).config_mode(config_command='configure', pattern='')

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -32,9 +32,10 @@ from netmiko.aruba import ArubaSSH
 from netmiko.vyos import VyOSSSH
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.cisco import CiscoTpTcCeSSH
+from netmiko.edgecore import EdgeCoreTelnet
 
 # The keys of this dictionary are the supported device_types
-CLASS_MAPPER_BASE = {
+CLASS_MAPPER_SSH = {
     'cisco_ios': CiscoIosSSH,
     'cisco_xe': CiscoIosSSH,
     'cisco_asa': CiscoAsaSSH,
@@ -75,19 +76,26 @@ CLASS_MAPPER_BASE = {
 }
 
 # Also support keys that end in _ssh
+# Note: Protocol selection no longer rely on device_type but defined in connection class (e.g. CiscoTelnetConnection)
 new_mapper = {}
-for k, v in CLASS_MAPPER_BASE.items():
+for k, v in CLASS_MAPPER_SSH.items():
     new_mapper[k] = v
     alt_key = k + u"_ssh"
     new_mapper[alt_key] = v
+
 CLASS_MAPPER = new_mapper
 
 # Add telnet drivers
-CLASS_MAPPER['cisco_ios_telnet'] = CiscoIosTelnet
+CLASS_MAPPER_TELNET = {
+    'cisco_ios_telnet': CiscoIosTelnet,
+    'edge_core_telnet': EdgeCoreTelnet,
+}
+
+CLASS_MAPPER.update(CLASS_MAPPER_TELNET)
 
 platforms = list(CLASS_MAPPER.keys())
 platforms.sort()
-platforms_base = list(CLASS_MAPPER_BASE.keys())
+platforms_base = list(CLASS_MAPPER_SSH.keys()) + list(CLASS_MAPPER_TELNET.keys())
 platforms_base.sort()
 platforms_str = u"\n".join(platforms_base)
 platforms_str = u"\n" + platforms_str


### PR DESCRIPTION
Telnet connection improvement:

- login/password detection case insensitive, banners ignored (multiline)
- fix for switches that does not produce output for the first telnet connection read attempt

Fix check_config_mode, check_enable_mode:

- replaced `check_string in output` with `output.endswith(check_string)` - check_string can be present in prompt and checks will always return True.
- replaced cehck_string for check_config_mode for cisco from `)#` to `config)#` - same reason as above.

EdgeCore support:

- Telnet connection class for EdgeCore ES series switches. (Maybe not only ES series)
 