### PR TITLE
Allow parallel read/write over the same netmiko session

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -166,6 +166,10 @@ class BaseConnection(object):
             raise exc_type(exc_value)
 
     def _timeout_exceeded(self, start, msg='Timeout exceeded!'):
+        """
+        Raise NetMikoTimeoutException if waiting too much in the
+        serving queue.
+        """
         if not start:
             return False  # reference not specified, noth to compare => no error
         if time.time() - start > self.session_timeout:
@@ -175,6 +179,8 @@ class BaseConnection(object):
 
     def _lock_netmiko_session(self, start=None):
         """
+        Try acquiring the netmiko session. If not available,
+        wait in the queue till the channel is available again.
         """
         if not start:
             start = time.time()
@@ -187,6 +193,7 @@ class BaseConnection(object):
 
     def _unlock_netmiko_session(self):
         """
+        Release the channel at the end of the task.
         """
         if self.__session_locker.locked():
             self.__session_locker.release()

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -261,11 +261,14 @@ class BaseConnection(object):
             if self.protocol == 'ssh':
                 try:
                     # If no data available will wait timeout seconds trying to read
+                    self._lock_netmiko_session()
                     new_data = self.remote_conn.recv(MAX_BUFFER).decode('utf-8', 'ignore')
                     log.debug("_read_channel_expect read_data: {}".format(new_data))
                     output += new_data
                 except socket.timeout:
                     raise NetMikoTimeoutException("Timed-out reading channel, data not available.")
+                finally:
+                    self._unlock_netmiko_session()
             elif self.protocol == 'telnet':
                 output += self.read_channel()
             if re.search(pattern, output, flags=re_flags):

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -176,7 +176,7 @@ class BaseConnection(object):
                and not self._timeout_exceeded(start, 'The netmiko channel is not available!')):
                 # will wait here till the SSH channel is free again and ready to receive requests
                 # if stays too much, _timeout_exceeded will raise NetMikoTimeoutException
-                time.sleep(0.01)
+                time.sleep(.1)
         return True  # ready to go now
 
     def _unlock_netmiko_session(self):

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -167,9 +167,11 @@ class BaseConnection(object):
             raise NetMikoTimeoutException(msg)
         return False
 
-    def _lock_netmiko_session(self, start):
+    def _lock_netmiko_session(self, start=None):
         """
         """
+        if not start:
+            start = time.time()
         while (not self.__session_locker.acquire(False)
                and not self._timeout_exceeded(start, 'The netmiko channel is not available!')):
                 # will wait here till the SSH channel is free again and ready to receive requests
@@ -195,6 +197,7 @@ class BaseConnection(object):
 
     def write_channel(self, out_data):
         """Generic handler that will write to both SSH and telnet channel."""
+        self._lock_netmiko_session()
         try:
             self._write_channel(out_data)
         finally:
@@ -219,6 +222,7 @@ class BaseConnection(object):
     def read_channel(self):
         """Generic handler that will read all the data from an SSH or telnet channel."""
         output = ""
+        self._lock_netmiko_session()
         try:
             output = self._read_channel()
         finally:


### PR DESCRIPTION
Ref: https://github.com/napalm-automation/napalm-ios/pull/120

With these changes, the library will be able to handle parallel read / write operations independently over the same SSH / Telnet session. However, the limitation will be that in case there's a high number of concomitant commands, `NetMikoTimeoutException` is raised as there's no mechanism to uniquely identify each request. Basically parallel requests are queued and served sequentially when the channel is again ready.
Commands executed over a different SSH session would not be affected by this, being handled in a separate netmiko instance.

The end user, or the developer should not see any change, and should not make any changes to their code.

I have tested this on a couple of Cisco 2811s using the napalm-ios driver and seems to work fine.

I have moved the logic from `write_channel` and `read_channel` into `_ write_channel` and `_ read_channel` helpers; the public methods call the corresponding helpers and will unlock the channel before returning. So in case there's any exception it will be also forwarded and the channel is unlocked before returning. @ktbyers please let me know if this hierarchical change would be too much, or we should simply move everything from `read_channel` and `write_channel` directly under the try-finally block?