### PR TITLE
Add support for Dell PowerConnect where Telnet is used.  

### DIFF
--- a/netmiko/dell/__init__.py
+++ b/netmiko/dell/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from netmiko.dell.dell_force10_ssh import DellForce10SSH
 from netmiko.dell.dell_powerconnect_ssh import DellPowerConnectSSH
+from netmiko.dell.dell_powerconnect_telnet import DellPowerConnectTelnet
 
-__all__ = ['DellForce10SSH', 'DellPowerConnectSSH']
+__all__ = ['DellForce10SSH', 'DellPowerConnectSSH', 'DellPowerConnectTelnet']

--- a/netmiko/dell/dell_powerconnect_telnet.py
+++ b/netmiko/dell/dell_powerconnect_telnet.py
@@ -1,14 +1,17 @@
 """Dell Telnet Driver."""
 from __future__ import unicode_literals
 from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko.ssh_exception import NetMikoAuthenticationException
 
-import time,re
+import time
+import re
+
 
 class DellPowerConnectTelnet(CiscoSSHConnection):
     def disable_paging(self, command="terminal length 0", delay_factor=1):
-        print ("MADE IT HERE:")
+        print("MADE IT HERE:")
         """Must be in enable mode to disable paging."""
-        self.enable()  
+        self.enable()
         debug = True
         delay_factor = self.select_delay_factor(delay_factor)
         time.sleep(delay_factor * .1)
@@ -25,6 +28,7 @@ class DellPowerConnectTelnet(CiscoSSHConnection):
             print(output)
             print("Exiting disable_paging")
         return output
+
 
     def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
                      username_pattern=r"User:", pwd_pattern=r"assword",

--- a/netmiko/dell/dell_powerconnect_telnet.py
+++ b/netmiko/dell/dell_powerconnect_telnet.py
@@ -1,0 +1,71 @@
+"""Dell Telnet Driver."""
+from __future__ import unicode_literals
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+import time,re
+
+class DellPowerConnectTelnet(CiscoSSHConnection):
+    def disable_paging(self, command="terminal length 0", delay_factor=1):
+        print ("MADE IT HERE:")
+        """Must be in enable mode to disable paging."""
+        self.enable()  
+        debug = True
+        delay_factor = self.select_delay_factor(delay_factor)
+        time.sleep(delay_factor * .1)
+        self.clear_buffer()
+        command = self.normalize_cmd(command)
+        if debug:
+            print("In disable_paging")
+            print("Command: {}".format(command))
+        self.write_channel(command)
+        output = self.read_until_prompt()
+        if self.ansi_escape_codes:
+            output = self.strip_ansi_escape_codes(output)
+        if debug:
+            print(output)
+            print("Exiting disable_paging")
+        return output
+
+    def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
+                     username_pattern=r"User:", pwd_pattern=r"assword",
+                     delay_factor=1, max_loops=60):
+        """Telnet login. Can be username/password or just password."""
+        TELNET_RETURN = '\r\n'
+
+        delay_factor = self.select_delay_factor(delay_factor)
+        time.sleep(1 * delay_factor)
+
+        output = ''
+        return_msg = ''
+        i = 1
+        while i <= max_loops:
+            try:
+                output = self.read_channel()
+                return_msg += output
+
+                # Search for username pattern / send username
+                if re.search(username_pattern, output):
+                    self.write_channel(self.username + TELNET_RETURN)
+                    time.sleep(1 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+
+                # Search for password pattern / send password
+                if re.search(pwd_pattern, output):
+                    self.write_channel(self.password + TELNET_RETURN)
+                    time.sleep(.5 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+                    if pri_prompt_terminator in output or alt_prompt_terminator in output:
+                        return return_msg
+
+                # Check if proper data received
+                if pri_prompt_terminator in output or alt_prompt_terminator in output:
+                    return return_msg
+
+                self.write_channel(TELNET_RETURN)
+                time.sleep(.5 * delay_factor)
+                i += 1
+            except EOFError:
+                msg = "Telnet login failed: {0}".format(self.host)
+                raise NetMikoAuthenticationException(msg)

--- a/netmiko/dell/dell_powerconnect_telnet.py
+++ b/netmiko/dell/dell_powerconnect_telnet.py
@@ -29,7 +29,6 @@ class DellPowerConnectTelnet(CiscoSSHConnection):
             print("Exiting disable_paging")
         return output
 
-
     def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
                      username_pattern=r"User:", pwd_pattern=r"assword",
                      delay_factor=1, max_loops=60):

--- a/netmiko/mellanox/mellanox_ssh.py
+++ b/netmiko/mellanox/mellanox_ssh.py
@@ -39,7 +39,6 @@ class MellanoxSSH(CiscoSSHConnection):
             print("Exiting disable_paging")
         return output
 
-
     def exit_config_mode(self, exit_config='exit', pattern='#'):
         """Exit from configuration mode."""
         debug = False

--- a/netmiko/mellanox/mellanox_ssh.py
+++ b/netmiko/mellanox/mellanox_ssh.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from netmiko.cisco_base_connection import CiscoSSHConnection
 import time
 
+
 class MellanoxSSH(CiscoSSHConnection):
 
     def config_mode(self, config_command='config term', pattern='#'):
@@ -17,7 +18,7 @@ class MellanoxSSH(CiscoSSHConnection):
 
     def check_config_mode(self, check_string='(config)', pattern=r'[>|#]'):
         return super(MellanoxSSH, self).check_config_mode(check_string=check_string,
-                                                                  pattern=pattern)
+                                                          pattern=pattern)
 
     def disable_paging(self, command="terminal length 999", delay_factor=1):
         """Disable paging default to a Cisco CLI method."""
@@ -37,6 +38,7 @@ class MellanoxSSH(CiscoSSHConnection):
             print(output)
             print("Exiting disable_paging")
         return output
+
 
     def exit_config_mode(self, exit_config='exit', pattern='#'):
         """Exit from configuration mode."""

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -26,6 +26,7 @@ from netmiko.extreme import ExtremeSSH
 from netmiko.alcatel import AlcatelSrosSSH
 from netmiko.dell import DellForce10SSH
 from netmiko.dell import DellPowerConnectSSH
+from netmiko.dell import DellPowerConnectTelnet
 from netmiko.paloalto import PaloAltoPanosSSH
 from netmiko.quanta import QuantaMeshSSH
 from netmiko.aruba import ArubaSSH
@@ -74,6 +75,7 @@ CLASS_MAPPER_BASE = {
     'fortinet': FortinetSSH,
     'dell_force10': DellForce10SSH,
     'dell_powerconnect': DellPowerConnectSSH,
+    'dell_powerconnect_telnet': DellPowerConnectTelnet,
     'paloalto_panos': PaloAltoPanosSSH,
     'quanta_mesh': QuantaMeshSSH,
     'aruba_os': ArubaSSH,


### PR DESCRIPTION
Tested with Dell 8024.

```
# py.test -v test_netmiko_config.py --test_device dell_powerconnect_telnet -x
=====================test session starts ==================
platform linux -- Python 3.5.2, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /usr/local/bin/python3.5
cachedir: .cache
rootdir: /usr/local/lib/python3.5/site-packages/netmiko-1.2.8-py3.5.egg/tests, inifile:
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

==================7 passed in 14.49 seconds ==================
# py.test -v test_netmiko_show.py --test_device dell_powerconnect_telnet -x
=====================test session starts ==================
platform linux -- Python 3.5.2, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /usr/local/bin/python3.5
cachedir: .cache
rootdir: /usr/local/lib/python3.5/site-packages/netmiko-1.2.8-py3.5.egg/tests, inifile:
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

==================12 passed in 29.00 seconds ==================
```