### PR TITLE
Issue #430: read_until_prompt_or_pattern does not apply timeout or sleep

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -320,18 +320,10 @@ class BaseConnection(object):
 
     def read_until_prompt_or_pattern(self, pattern='', re_flags=0):
         """Read until either self.base_prompt or pattern is detected. Return ALL data available."""
-        output = ''
-        if not pattern:
-            pattern = re.escape(self.base_prompt)
-        base_prompt_pattern = re.escape(self.base_prompt)
-        while True:
-            try:
-                output += self.read_channel()
-                if re.search(pattern, output, flags=re_flags) or re.search(base_prompt_pattern,
-                                                                           output, flags=re_flags):
-                    return output
-            except socket.timeout:
-                raise NetMikoTimeoutException("Timed-out reading channel, data not available.")
+        combined_pattern = re.escape(self.base_prompt)
+        if pattern:
+            combined_pattern += "|{}".format(pattern)
+        return self._read_channel_expect(combined_pattern, re_flags=re_flags)
 
     def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
                      username_pattern=r"sername", pwd_pattern=r"assword",


### PR DESCRIPTION
The read_until_prompt_or_pattern method in base_connection.BaseConnection reads
data from the connection in a tight loop reading data from the device, waiting
for the prompt or another pattern to be received. There are a couple of issues
with this.

1. There is no way to break out of the loop - no timeout mechanism is applied,
so we can get stuck here indefinitely if the device does not send the expected
pattern or prompt.

2. There is no delay between successive calls to the read_channel method. This
can lead to excessive CPU use as the process spins.  It also has a negative
impact when used in tandem with cooperative multitasking libraries such as
eventlet (as used by OpenStack, in which the networking-generic-switch package
uses netmiko and where I observed this issue).

The _read_channel_expect method used by read_until_prompt and
read_until_pattern avoids these issues by applying a timeout to the read and
sleeping between each read.

This change resolves the issue by combining the prompt and pattern into a
combined regular expression and waiting for it to appear using
_read_channel_expect.