### PR TITLE
Compatibility with Huawei USG devices running software version 5

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -73,7 +73,7 @@ class BaseConnection(object):
         :type ssh_strict: bool
         :param system_host_keys: Load host keys from the user's 'known_hosts' file.
         :type system_host_keys: bool
-        :param alt_host_keys: If `True` host keys will be loaded from the file specified in 
+        :param alt_host_keys: If `True` host keys will be loaded from the file specified in
                 'alt_key_file'.
         :type alt_host_keys: bool
         :param alt_key_file: SSH host key file to use (if alt_host_keys=True).

--- a/netmiko/huawei/__init__.py
+++ b/netmiko/huawei/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
 from netmiko.huawei.huawei_ssh import HuaweiSSH
+from netmiko.huawei.huawei_usgv5_ssh import Huawei_usgv5_SSH
 
-__all__ = ['HuaweiSSH']
+__all__ = ['HuaweiSSH','Huawei_usgv5_SSH']

--- a/netmiko/huawei/__init__.py
+++ b/netmiko/huawei/__init__.py
@@ -2,4 +2,4 @@ from __future__ import unicode_literals
 from netmiko.huawei.huawei_ssh import HuaweiSSH
 from netmiko.huawei.huawei_usgv5_ssh import Huawei_usgv5_SSH
 
-__all__ = ['HuaweiSSH','Huawei_usgv5_SSH']
+__all__ = ['HuaweiSSH', 'Huawei_usgv5_SSH']

--- a/netmiko/huawei/huawei_usgv5_ssh.py
+++ b/netmiko/huawei/huawei_usgv5_ssh.py
@@ -1,0 +1,80 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+import time
+import re
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class Huawei_usgv5_SSH(CiscoSSHConnection):
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.set_base_prompt()
+        self.disable_paging(command="screen-length 0 temporary\n")
+
+    def config_mode(self, config_command='system-view'):
+        """Enter configuration mode."""
+        return super(Huawei_usgv5_SSH, self).config_mode(config_command=config_command)
+
+    def exit_config_mode(self, exit_config='return'):
+        """Exit configuration mode."""
+        return super(Huawei_usgv5_SSH, self).exit_config_mode(exit_config=exit_config)
+
+    def check_config_mode(self, check_string=']'):
+        """Checks whether in configuration mode. Returns a boolean."""
+        return super(Huawei_usgv5_SSH, self).check_config_mode(check_string=check_string)
+
+    def set_base_prompt(self, pri_prompt_terminator='>', alt_prompt_terminator=']',
+                        delay_factor=1):
+        '''
+        Sets self.base_prompt
+
+        Used as delimiter for stripping of trailing prompt in output.
+
+        Should be set to something that is general and applies in multiple contexts. For Comware
+        this will be the router prompt with < > or [ ] stripped off.
+
+        This will be set on logging in, but not when entering system-view
+        '''
+        debug = False
+        if debug:
+            print("In set_base_prompt")
+
+        delay_factor = self.select_delay_factor(delay_factor)
+        self.clear_buffer()
+        self.write_channel("\n")
+        time.sleep(.5 * delay_factor)
+
+        prompt = self.read_channel()
+        prompt = self.normalize_linefeeds(prompt)
+
+        # If multiple lines in the output take the last line
+        prompt = prompt.split('\n')[-1]
+        prompt = prompt.strip()
+
+        # Check that ends with a valid terminator character
+        if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
+            raise ValueError("Router prompt not found: {0}".format(prompt))
+		
+		
+       # Strip off leading and trailing terminator
+       
+       #The prompt will be different based on which mode the device is in (normal or high availability)
+       	
+        if re.match("(^<)", prompt):
+            prompt = prompt[1:-1]	   
+            prompt = prompt.strip()
+            
+        else:
+            prompt = prompt[6:-1]
+            prompt = prompt.strip()
+            
+            
+        self.base_prompt = prompt
+
+        if debug:
+            print("prompt: {}".format(self.base_prompt))
+
+        return self.base_prompt
+		
+	

--- a/netmiko/huawei/huawei_usgv5_ssh.py
+++ b/netmiko/huawei/huawei_usgv5_ssh.py
@@ -55,26 +55,23 @@ class Huawei_usgv5_SSH(CiscoSSHConnection):
         # Check that ends with a valid terminator character
         if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
             raise ValueError("Router prompt not found: {0}".format(prompt))
-		
-		
-       # Strip off leading and trailing terminator
-       
-       #The prompt will be different based on which mode the device is in (normal or high availability)
-       	
+
+        """
+        Strip off leading and trailing terminator
+        The prompt will be different based on which mode the device is in:
+        normal or high availability
+        """
         if re.match("(^<)", prompt):
-            prompt = prompt[1:-1]	   
+            prompt = prompt[1:-1]
             prompt = prompt.strip()
-            
+
         else:
             prompt = prompt[6:-1]
             prompt = prompt.strip()
-            
-            
+
         self.base_prompt = prompt
 
         if debug:
             print("prompt: {}".format(self.base_prompt))
 
         return self.base_prompt
-		
-	

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -37,7 +37,7 @@ from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.mellanox import MellanoxSSH
 from netmiko.pluribus import PluribusSSH
-
+from netmiko.huawei import Huawei_usgv5_SSH
 
 # The keys of this dictionary are the supported device_types
 CLASS_MAPPER_BASE = {
@@ -82,7 +82,8 @@ CLASS_MAPPER_BASE = {
     'cisco_tp': CiscoTpTcCeSSH,
     'generic_termserver': TerminalServerSSH,
     'mellanox_ssh': MellanoxSSH,
-    'pluribus': PluribusSSH
+    'pluribus': PluribusSSH,
+    'huawei_usgv5': Huawei_usgv5_SSH,
 }
 
 # Also support keys that end in _ssh


### PR DESCRIPTION
This code adds support for new devices: the Huawei USG series (tested on version 5). The code in huawei_usgv5_ssh.py is the same as in huawei_ssh.py, with the exception of an if/else statement that will check in which mode the prompt is situated (high availability or not).

I tested it with following code:

`from netmiko import ConnectHandler

net_connect = ConnectHandler(device_type='huawei_usgv5', ip='ip address', username='user', password='password')
net_connect.set_base_prompt()
config_commands=["interface GigabitEthernet 0/0/4", "ip add 10.0.0.60 24", "interface GigabitEthernet 0/0/5", "ip add 10.0.1.61 24"]
output = net_connect.send_config_set(config_commands)
`
=> this works (when device is in high availability, as well as when it isn't)
output:
system-view
Enter system view, return user view with Ctrl+Z.
HRP_M[FW1]interface GigabitEthernet 0/0/4 (+B)
HRP_M[FW1-GigabitEthernet0/0/4]ip add 10.0.0.60 24
HRP_M[FW1-GigabitEthernet0/0/4]interface GigabitEthernet 0/0/5 (+B)
HRP_M[FW1-GigabitEthernet0/0/5]ip add 10.0.1.61 24
HRP_M[FW1-GigabitEthernet0/0/5]return
HRP_M[FW1]