### PR TITLE
Update SSH autodetect for Juniper EX series

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -90,7 +90,7 @@ SSH_MAPPER_BASE = {
     },
     'juniper_junos': {
         "cmd": "show version | match JUNOS",
-        "search_patterns": ["JUNOS Software Release"],
+        "search_patterns": ["JUNOS Software Release", "JUNOS .+ Software"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Added a pattern to SSH_MAPPER_BASE search_patterns for Junos that will match Juniper EX series switches. Here is a full show version from my device:

```
user@myswitch> show version 
fpc0:
--------------------------------------------------------------------------
Hostname: myswitch
Model: ex2200-24t-4g
Junos: 14.1X53-D26.2
JUNOS EX  Software Suite [14.1X53-D26.2]
JUNOS FIPS mode utilities [14.1X53-D26.2]
JUNOS Online Documentation [14.1X53-D26.2]
JUNOS EX 2200 Software Suite [14.1X53-D26.2]
JUNOS Web Management Platform Package [14.1X53-D26.2]

{master:0}
```