### PR TITLE
fixed problem which was produced by last symbol of prompt line

### DIFF
--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -6,6 +6,7 @@ from netmiko.cisco.cisco_xr_ssh import CiscoXrSSH
 from netmiko.cisco.cisco_wlc_ssh import CiscoWlcSSH
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
 from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
+from netmiko.cisco.cisco_fmc_ssh import CiscoFmcSSH
 
 __all__ = ['CiscoIosSSH', 'CiscoIosTelnet', 'CiscoAsaSSH', 'CiscoNxosSSH', 'CiscoXrSSH',
-           'CiscoWlcSSH', 'CiscoS300SSH', 'CiscoTpTcCeSSH', 'CiscoIosBase']
+           'CiscoWlcSSH', 'CiscoS300SSH', 'CiscoTpTcCeSSH', 'CiscoIosBase', 'CiscoFmcSSH']

--- a/netmiko/cisco/cisco_fmc_ssh.py
+++ b/netmiko/cisco/cisco_fmc_ssh.py
@@ -1,0 +1,14 @@
+"""Subclass specific to Cisco ASA."""
+
+from __future__ import unicode_literals
+import re
+import time
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class CiscoFmcSSH(CiscoSSHConnection):
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r'[>#]')
+        self.set_base_prompt()

--- a/netmiko/paloalto/paloalto_panos_ssh.py
+++ b/netmiko/paloalto/paloalto_panos_ssh.py
@@ -46,7 +46,12 @@ class PaloAltoPanosSSH(BaseConnection):
         """Exit configuration mode."""
         output = ""
         if self.check_config_mode():
-            output = self.send_command(exit_config, strip_prompt=False, strip_command=False)
+            # in configuration mode prompt ends with #
+            # while usual prompt ends with >
+            delay_factor = self.select_delay_factor(1)
+            prompt_conf = self.find_prompt(delay_factor=delay_factor).strip()
+            prompt_usual = prompt_conf[:-1] + '>' if prompt_conf[-1] == '#' else prompt_conf
+            output = self.send_command(exit_config, strip_prompt=False, strip_command=False, expect_string=prompt_usual)
             if self.check_config_mode():
                 raise ValueError("Failed to exit configuration mode")
         return output

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -6,6 +6,7 @@ from netmiko.cisco import CiscoNxosSSH
 from netmiko.cisco import CiscoXrSSH
 from netmiko.cisco import CiscoWlcSSH
 from netmiko.cisco import CiscoS300SSH
+from netmiko.cisco import CiscoFmcSSH
 from netmiko.eltex import EltexSSH
 from netmiko.arista import AristaSSH
 from netmiko.hp import HPProcurveSSH, HPComwareSSH
@@ -87,7 +88,8 @@ CLASS_MAPPER_BASE = {
     'cisco_tp': CiscoTpTcCeSSH,
     'generic_termserver': TerminalServerSSH,
     'mellanox_ssh': MellanoxSSH,
-    'pluribus': PluribusSSH
+    'pluribus': PluribusSSH,
+    'cisco_fmc_ssh': CiscoFmcSSH
 }
 
 # Also support keys that end in _ssh


### PR DESCRIPTION
for palo alto device command usual prompt ends with '>' while in configuration mode with '#'.
This differences produces the problem when in exit_config_mode method because it looking for a prompt which ends with '#' while real prompt ends with '>'