### PR TITLE
Added argument to send_command() method to prevent normalising the command_string

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -742,7 +742,7 @@ class BaseConnection(object):
 
     def send_command(self, command_string, expect_string=None,
                      delay_factor=1, max_loops=500, auto_find_prompt=True,
-                     strip_prompt=True, strip_command=True):
+                     strip_prompt=True, strip_command=True, normalize_command=True):
         '''
         Send command to network device retrieve output until router_prompt or expect_string
 
@@ -774,7 +774,9 @@ class BaseConnection(object):
         else:
             search_pattern = expect_string
 
-        command_string = self.normalize_cmd(command_string)
+        if normalize_command:
+            command_string = self.normalize_cmd(command_string)
+
         if debug:
             print("Command is: {0}".format(command_string))
             print("Search to stop receiving data is: '{0}'".format(search_pattern))


### PR DESCRIPTION
I added an optional  `normalize_command` argument to the `send_command()` method. The motivation was to be able to send "commands" to the device that are not NEWLINE terminated. For example, with Cisco IOS pressing the ? key will invoke the help feature.

Example in Python
```python
net_connect = ConnectHandler(...)
net_connect.enable()
net_connect.send_command("conf t", expect_string="\(config\)#")

# Send "no cdp ?"
output = net_connect.send_command("no cdp ?", expect_string="\(config\)# no cdp",
                                   normalize_command=False)
```