### PR TITLE
Prevent mp_queue deadlock in multiprocess_example

### DIFF
--- a/examples/multiprocess_example.py
+++ b/examples/multiprocess_example.py
@@ -16,6 +16,7 @@ with warnings.catch_warnings(record=True) as w:
     import paramiko
 
 import multiprocessing
+import time
 from datetime import datetime
 
 import netmiko

--- a/examples/multiprocess_example.py
+++ b/examples/multiprocess_example.py
@@ -94,14 +94,16 @@ def main():
         # start the work process
         p.start()
 
+    # retrieve all the data from the queue
+    results = []
+    while any(p.is_alive() for p in processes):
+        time.sleep(0.5)
+        while not mp_queue.empty():
+            results.append(mp_queue.get())
+            
     # wait until the child processes have completed
     for p in processes:
         p.join()
-
-    # retrieve all the data from the queue
-    results = []
-    for p in processes:
-        results.append(mp_queue.get())
 
     print_output(results)
 


### PR DESCRIPTION
The mp_queue will reach its size limit and create a deadlock for large number of returned results.