### PR TITLE
Expanding telnet_login username_pattern to add "ser:" and "ogin"

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -345,7 +345,7 @@ class BaseConnection(object):
         return self._read_channel_expect(combined_pattern, re_flags=re_flags)
 
     def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
-                     username_pattern=r"sername", pwd_pattern=r"assword",
+                     username_pattern=r"ser:|sername|ogin", pwd_pattern=r"assword",
                      delay_factor=1, max_loops=60):
         """Telnet login. Can be username/password or just password."""
         TELNET_RETURN = '\r\n'


### PR DESCRIPTION
As discussed here: https://github.com/ktbyers/netmiko/issues/496
I've added "ser:" and "ogin" to the existing "sername" under Telnet_login so it works with reverse telnet and different prompts.
I thought that "ser" would be too short and generic so added the ":" just like it pops up on the Quanta LB9 running Broadcom ICOS/Fastpath.