### PR TITLE
Changing prompt_pattern on Telnet_login to avoid false positives and max_loops to 10

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -344,9 +344,9 @@ class BaseConnection(object):
             combined_pattern += "|{}".format(pattern)
         return self._read_channel_expect(combined_pattern, re_flags=re_flags)
 
-    def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
+    def telnet_login(self, prompt_pattern=r">[\s]*$|#[\s]*$",
                      username_pattern=r"sername", pwd_pattern=r"assword",
-                     delay_factor=1, max_loops=60):
+                     delay_factor=1, max_loops=10):
         """Telnet login. Can be username/password or just password."""
         TELNET_RETURN = '\r\n'
 
@@ -374,11 +374,11 @@ class BaseConnection(object):
                     time.sleep(.5 * delay_factor)
                     output = self.read_channel()
                     return_msg += output
-                    if pri_prompt_terminator in output or alt_prompt_terminator in output:
+                    if re.search(prompt_pattern, output):
                         return return_msg
 
                 # Check if proper data received
-                if pri_prompt_terminator in output or alt_prompt_terminator in output:
+                if re.search(prompt_pattern, output):
                     return return_msg
 
                 self.write_channel(TELNET_RETURN)
@@ -393,7 +393,7 @@ class BaseConnection(object):
         time.sleep(.5 * delay_factor)
         output = self.read_channel()
         return_msg += output
-        if pri_prompt_terminator in output or alt_prompt_terminator in output:
+        if re.search(prompt_pattern, output):
             return return_msg
 
         msg = "Telnet login failed: {0}".format(self.host)


### PR DESCRIPTION
To fix the problem with terminal servers using ">" outside the real prompt as discussed here:
https://github.com/ktbyers/netmiko/pull/524
Also reducing max_loops from 60 to 10 on the login just as a suggestion to speed-up failures and to avoid blocking ports that record multiple failed login attempts in a short period of time.
Tested with Avocent, cisco, and juniper.