### PR TITLE
add netapp device support

### DIFF
--- a/netmiko/netapp/__init__.py
+++ b/netmiko/netapp/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.netapp.netapp_cdot_ssh import NetAppcDotSSH
+
+__all__ = ['NetAppcDotSSH']

--- a/netmiko/netapp/netapp_cdot_ssh.py
+++ b/netmiko/netapp/netapp_cdot_ssh.py
@@ -1,0 +1,40 @@
+from __future__ import unicode_literals
+
+import time
+
+from netmiko.base_connection import BaseConnection
+
+
+class NetAppcDotSSH(BaseConnection):
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.set_base_prompt()
+        self.disable_paging(command="\nrows 0\n")
+
+    def send_command_with_y(self, *args, **kwargs):
+        output = self.send_command_timing(*args, **kwargs)
+
+        if '{y|n}' in output:
+            output += self.send_command_timing('y',
+                                               strip_prompt=False, strip_command=False)
+        return output
+
+    def check_config_mode(self, check_string='*>'):
+        return super(NetAppcDotSSH, self).check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command='set -privilege diagnostic -confirmations off'):
+        return super(NetAppcDotSSH, self).config_mode(config_command=config_command)
+
+    def exit_config_mode(self, exit_config='set -privilege admin -confirmations off'):
+        return super(NetAppcDotSSH, self).exit_config_mode(exit_config=exit_config)
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on NetApp."""
+        pass
+
+    def check_enable_mode(self, *args, **kwargs):
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        pass

--- a/netmiko/netapp/netapp_cdot_ssh.py
+++ b/netmiko/netapp/netapp_cdot_ssh.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import time
-
 from netmiko.base_connection import BaseConnection
 
 

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -36,6 +36,7 @@ from netmiko.juniper import JuniperSSH
 from netmiko.linux import LinuxSSH
 from netmiko.mellanox import MellanoxSSH
 from netmiko.mrv import MrvOptiswitchSSH
+from netmiko.netapp import NetAppcDotSSH
 from netmiko.ovs import OvsLinuxSSH
 from netmiko.paloalto import PaloAltoPanosSSH
 from netmiko.pluribus import PluribusSSH
@@ -88,6 +89,7 @@ CLASS_MAPPER_BASE = {
     'linux': LinuxSSH,
     'mellanox_ssh': MellanoxSSH,
     'mrv_optiswitch': MrvOptiswitchSSH,
+    'netapp_cdot': NetAppcDotSSH,
     'ovs_linux': OvsLinuxSSH,
     'paloalto_panos': PaloAltoPanosSSH,
     'pluribus': PluribusSSH,


### PR DESCRIPTION
Adding support for NetApp Device
Tested with Version Ontap9.0

■config test
(venv)[tests]$ py.test -v test_netmiko_config.py --test_device  netapp_cdot
========================================================================= test session starts ==========================================================================
platform linux2 -- Python 2.7.12, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/koumiyata/netmiko-netapp/venv/bin/python2.7
cachedir: ../.cache
rootdir: /home/koumiyata/git/netmiko-maker/netmiko, inifile:
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

======================================================================= 7 passed in 9.48 seconds =======================================================================


■show test
(venv)[tests]$ py.test -v test_netmiko_show.py --test_device  netapp_cdot
========================================================================= test session starts ==========================================================================
platform linux2 -- Python 2.7.12, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/koumiyata/netmiko-netapp/venv/bin/python2.7
cachedir: ../.cache
rootdir: /home/koumiyata/git/netmiko-maker/netmiko, inifile:
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

====================================================================== 12 passed in 21.26 seconds ======================================================================

