### PR TITLE
Add Calix B6 Device Support

### DIFF
--- a/netmiko/calix/__init__.py
+++ b/netmiko/calix/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.calix.calix_b6_ssh import CalixB6SSH
+
+__all__ = ['CalixB6SSH']

--- a/netmiko/calix/calix_b6_ssh.py
+++ b/netmiko/calix/calix_b6_ssh.py
@@ -82,7 +82,7 @@ class CalixB6SSH(CiscoSSHConnection):
         """Enter configuration mode."""
         return super(CalixB6SSH, self).config_mode(config_command=config_command)
 
-    def exit_config_mode(self, exit_config='exit', pattern=''):
+    def exit_config_mode(self, exit_config='exit\r\r\nend', pattern=''):
         """Exit from configuration mode."""
         return super(CalixB6SSH, self).exit_config_mode(exit_config=exit_config,
                                                                  pattern=pattern)

--- a/netmiko/calix/calix_b6_ssh.py
+++ b/netmiko/calix/calix_b6_ssh.py
@@ -1,11 +1,8 @@
 """Calix B6 SSH Driver for Netmiko"""
 from __future__ import unicode_literals
-
 import time
 from os import path
-
 from paramiko import SSHClient
-
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
@@ -77,11 +74,11 @@ class CalixB6SSH(CiscoSSHConnection):
         self.disable_paging()
         self.set_terminal_width(command="terminal width 511")
 
-    def check_config_mode(self, check_string=')#'):
+    def check_config_mode(self, check_string=')#', pattern=''):
         """Checks if the device is in configuration mode"""
         return super(CalixB6SSH, self).check_config_mode(check_string=check_string)
 
-    def config_mode(self, config_command='config t'):
+    def config_mode(self, config_command='config t', pattern=''):
         """Enter configuration mode."""
         return super(CalixB6SSH, self).config_mode(config_command=config_command)
 

--- a/netmiko/calix/calix_b6_ssh.py
+++ b/netmiko/calix/calix_b6_ssh.py
@@ -1,9 +1,12 @@
 """Calix B6 SSH Driver for Netmiko"""
 from __future__ import unicode_literals
-from netmiko.cisco_base_connection import CiscoSSHConnection
-from paramiko import SSHClient
-from os import path
+
 import time
+from os import path
+
+from paramiko import SSHClient
+
+from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
 class SSHClient_noauth(SSHClient):
@@ -32,9 +35,9 @@ class CalixB6SSH(CiscoSSHConnection):
 
         # Load host_keys for better SSH security
         if self.system_host_keys:
-                        remote_conn_pre.load_system_host_keys()
+            remote_conn_pre.load_system_host_keys()
         if self.alt_host_keys and path.isfile(self.alt_key_file):
-                        remote_conn_pre.load_host_keys(self.alt_key_file)
+            remote_conn_pre.load_host_keys(self.alt_key_file)
 
         # Default is to automatically add untrusted hosts (make sure appropriate for your env)
         remote_conn_pre.set_missing_host_key_policy(self.key_policy)
@@ -84,5 +87,4 @@ class CalixB6SSH(CiscoSSHConnection):
 
     def exit_config_mode(self, exit_config='exit\r\r\nend', pattern=''):
         """Exit from configuration mode."""
-        return super(CalixB6SSH, self).exit_config_mode(exit_config=exit_config,
-                                                                 pattern=pattern)
+        return super(CalixB6SSH, self).exit_config_mode(exit_config=exit_config, pattern=pattern)

--- a/netmiko/calix/calix_b6_ssh.py
+++ b/netmiko/calix/calix_b6_ssh.py
@@ -73,3 +73,16 @@ class CalixB6SSH(CiscoSSHConnection):
         self.set_base_prompt()
         self.disable_paging()
         self.set_terminal_width(command="terminal width 511")
+
+    def check_config_mode(self, check_string=')#'):
+        """Checks if the device is in configuration mode"""
+        return super(CalixB6SSH, self).check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command='config t'):
+        """Enter configuration mode."""
+        return super(CalixB6SSH, self).config_mode(config_command=config_command)
+
+    def exit_config_mode(self, exit_config='exit', pattern=''):
+        """Exit from configuration mode."""
+        return super(CalixB6SSH, self).exit_config_mode(exit_config=exit_config,
+                                                                 pattern=pattern)

--- a/netmiko/calix/calix_b6_ssh.py
+++ b/netmiko/calix/calix_b6_ssh.py
@@ -1,0 +1,75 @@
+"""Calix B6 SSH Driver for Netmiko"""
+from __future__ import unicode_literals
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from paramiko import SSHClient
+from os import path
+import time
+
+
+class SSHClient_noauth(SSHClient):
+    def _auth(self, username, *args):
+        self._transport.auth_none(username)
+        return
+
+
+class CalixB6SSH(CiscoSSHConnection):
+    """Calix B6 SSH driver
+
+    These devices use SSH auth type (none) for cli user. Override SSH _auth method.
+    """
+
+    def _build_ssh_client(self):
+        """Prepare for Paramiko SSH connection.
+
+        See base_connection.py file for any updates.
+        """
+        # Create instance of SSHClient object
+        # If username is cli, we use noauth
+        if not self.use_keys:
+            remote_conn_pre = SSHClient_noauth()
+        else:
+            remote_conn_pre = SSHClient()
+
+        # Load host_keys for better SSH security
+        if self.system_host_keys:
+                        remote_conn_pre.load_system_host_keys()
+        if self.alt_host_keys and path.isfile(self.alt_key_file):
+                        remote_conn_pre.load_host_keys(self.alt_key_file)
+
+        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
+        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
+        return remote_conn_pre
+
+    def special_login_handler(self, delay_factor=1):
+        """
+        Calix B6 presents with the following on login:
+
+        login as:
+        Password: ****
+        """
+        delay_factor = self.select_delay_factor(delay_factor)
+        i = 0
+        time.sleep(delay_factor * .25)
+        output = ""
+        while i <= 12:
+            output = self.read_channel()
+            if output:
+                if 'login as:' in output:
+                    self.write_channel(self.username + '\n')
+                elif 'Password:' in output:
+                    self.write_channel(self.password + '\n')
+                    break
+                time.sleep(delay_factor * 0.5)
+            else:
+                self.write_channel('\n')
+                time.sleep(delay_factor * 1)
+            i += 1
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established.
+        Just need to override set_terminal_width"""
+        self.ansi_escape_codes = True
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging()
+        self.set_terminal_width(command="terminal width 511")

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -12,6 +12,7 @@ from netmiko.avaya import AvayaVspSSH
 from netmiko.brocade import BrocadeFastironSSH
 from netmiko.brocade import BrocadeNetironSSH
 from netmiko.brocade import BrocadeNosSSH
+from netmiko.calix import CalixB6SSH
 from netmiko.checkpoint import CheckPointGaiaSSH
 from netmiko.ciena import CienaSaosSSH
 from netmiko.cisco import CiscoAsaSSH
@@ -62,6 +63,7 @@ CLASS_MAPPER_BASE = {
     'brocade_vdx': BrocadeNosSSH,
     'brocade_vyos': VyOSSSH,
     'checkpoint_gaia': CheckPointGaiaSSH,
+    'calix_b6': CalixB6SSH,
     'ciena_saos': CienaSaosSSH,
     'cisco_asa': CiscoAsaSSH,
     'cisco_ios': CiscoIosBase,

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
               'netmiko/aruba',
               'netmiko/avaya',
               'netmiko/brocade',
+              'netmiko/calix',
               'netmiko/ciena',
               'netmiko/cisco',
               'netmiko/dell',


### PR DESCRIPTION
(netmiko) C:\Users\rtetzloff\Python Projects\netmiko\tests>py.test -v test_netmiko_show.py --test_device calix_b6
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- c:\users\rtetzloff\netmiko\scripts\python.exe
cachedir: ..\.cache
rootdir: C:\Users\rtetzloff\Python Projects\netmiko, inifile:
collected 12 items 

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

========================= 12 passed in 37.99 seconds ==========================

(netmiko) C:\Users\rtetzloff\Python Projects\netmiko\tests>py.test -v test_netmiko_config.py --test_device calix_b6
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- c:\users\rtetzloff\netmiko\scripts\python.exe
cachedir: ..\.cache
rootdir: C:\Users\rtetzloff\Python Projects\netmiko, inifile:
collected 7 items 

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

========================== 7 passed in 18.48 seconds ==========================
