### PR TITLE
fix first character removed in brocade_netiron_telnet

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -862,7 +862,7 @@ class BaseConnection(object):
             new_output = output_lines[1:]
             return self.RESPONSE_RETURN.join(new_output)
         else:
-            command_length = len(command_string)
+            command_length = len(command_string)-1
             return output[command_length:]
 
     def normalize_linefeeds(self, a_string):


### PR DESCRIPTION
Thanks for implementing telnet support with Brocade! (`brocade_netiron_telnet`). While testing it I realized the first character gets removed from the output
```
$ python netmiko_cisco.py | grep Mode
ystem Mode: MLX
```
with the PR:
```
$ python netmiko_cisco.py | grep Mode
System Mode: MLX
```
the client code is:
```
#!/usr/bin/python
import sys
sys.path.append('/home/ckishimo/python/devel/git/telnet/netmiko')
from netmiko import ConnectHandler
debug = True       
mlx = {
    'device_type': 'brocade_netiron_telnet',
    'ip':   'xxxx',
    'username': 'xxxx',
    'password': 'xxxxx',
    'port' : 23,          # optional, defaults to 22
    'secret': 'xxxxx',   # optional, defaults to ''
    'verbose': True,      # optional, defaults to False
}
net_connect = ConnectHandler(**mlx)
output = net_connect.send_command('show version')
print(output)
```
Please let me know. Thanks