### PR TITLE
Fix context manager exception handling

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -167,8 +167,6 @@ class BaseConnection(object):
     def __exit__(self, exc_type, exc_value, traceback):
         """Gracefully close connection on Context Manager exit."""
         self.disconnect()
-        if exc_type is not None:
-            raise exc_type(exc_value)
 
     def _modify_connection_params(self):
         """Modify connection parameters prior to SSH connection."""


### PR DESCRIPTION
When using a connection object as a context manager (via a with
statement), and the context raises an exception, the __exit__ method
should simply return a value other than True in order for the exception
to be raised. The current handling manually re-raises the exception, and
also creates a new exception object from the raised one in a way that
does not always work (e.g. if there are more than one arguments to the
exception's constructor). To resolve this we allow the context manager
to raise the exception.

Fixes: #601