### PR TITLE
Break if the output is repated & Fix send_command_w_enter method

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -806,6 +806,8 @@ class BaseConnection(object):
         # Keep reading data until search_pattern is found (or max_loops)
         i = 1
         output = ''
+        count_repeated_output = 0
+        last_len = 0
         while i <= max_loops:
             new_data = self.read_channel()
             if new_data:
@@ -826,6 +828,16 @@ class BaseConnection(object):
                     break
             else:
                 time.sleep(delay_factor * .2)
+
+            if last_len == len(output):
+                count_repeated_output += 1
+            else:
+                count_repeated_output = 0
+            
+            if count_repeated_output == 20:
+                break
+
+            last_len = len(output)
             i += 1
         else:   # nobreak
             raise IOError("Search pattern never detected in send_command_expect: {0}".format(

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -58,6 +58,9 @@ class CiscoWlcSSH(BaseConnection):
         output = self.send_command(*args, **kwargs)
 
         if 'Press Enter to' in output:
+            # Expect 'Cisco Controller', default prompt
+            kwargs['auto_find_prompt'] = False
+
             new_args = list(args)
             if len(args) == 1:
                 new_args[0] = self.RETURN


### PR DESCRIPTION
We should break the loop if the output of the channel is not increasing, we can use `delay_factor` parameter if the commad could take time to start returning output.

For `send_command_w_enter` we expect the default prompt, _Cisco Controller_