### PR TITLE
  Privilege escalation ( "enable" mode) on HP Comware v5.x/v7.x before any other cli commands

### DIFF
--- a/netmiko/hp/hp_comware_ssh.py
+++ b/netmiko/hp/hp_comware_ssh.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from netmiko.cisco_base_connection import CiscoSSHConnection
 import re
 
+
 class HPComwareSSH(CiscoSSHConnection):
 
     def session_preparation(self):
@@ -19,22 +20,24 @@ class HPComwareSSH(CiscoSSHConnection):
     def priv_escalation(self):
         """ Privilege Escalation before entering config mode """
         try:
-            pass
             out_version = self.send_command_timing("display version")
-            match_v = re.search(r'Comware\s+Software,\s+Version\s+(.*),\sRelease\s+',out_version, re.I | re.M)
-            # send 'e' in case of "---- More ----" returned by "display version"
-            self.send_command_timing('e') 
+            # regex_v = re.compile(r"""Comware\s+Software,\s+Version\s+(.*),
+            # \sRelease\s+""", out_version, re.I | re.M | re.X)
+            # match_v = regex_v.search(out_version)
+            match_v = re.search(r'Comware\s+Software,\s+Version\s+(.*),\sRelease\s+', out_version, re.I | re.M)
+            self.send_command_timing('e')
+
             # Comware version 5.xx
             if match_v and match_v.group(1).startswith('5'):
                 priv_escalation_cmd = 'super'
-                self.send_command(priv_escalation_cmd, expect_string='Password:', auto_find_prompt=False) 
-                self.send_command(self.secret, expect_string='>', auto_find_prompt=False) 
+                self.send_command(priv_escalation_cmd, expect_string='Password:', auto_find_prompt=False)
+                self.send_command(self.secret, expect_string='>', auto_find_prompt=False)
             # Comware version 7.xx
             elif match_v and match_v.group(1).startswith('7'):
                 priv_escalation_cmd = 'super level-15'
-                self.send_command(priv_escalation_cmd, expect_string='Username:', auto_find_prompt=False) 
-                self.send_command(self.username, expect_string='Password:', auto_find_prompt=False) 
-                self.send_command(self.secret, expect_string='>', auto_find_prompt=False) 
+                self.send_command(priv_escalation_cmd, expect_string='Username:', auto_find_prompt=False)
+                self.send_command(self.username, expect_string='Password:', auto_find_prompt=False)
+                self.send_command(self.secret, expect_string='>', auto_find_prompt=False)
         except Exception as e:
             raise e
 

--- a/netmiko/hp/hp_comware_ssh.py
+++ b/netmiko/hp/hp_comware_ssh.py
@@ -21,29 +21,38 @@ class HPComwareSSH(CiscoSSHConnection):
         """ Privilege Escalation before entering config mode """
         try:
             out_version = self.send_command_timing("display version")
-            # regex_v = re.compile(r"""Comware\s+Software,\s+Version\s+(.*),
-            # \sRelease\s+""", out_version, re.I | re.M | re.X)
-            # match_v = regex_v.search(out_version)
-            match_v = re.search(r'Comware\s+Software,\s+Version\s+(.*),\sRelease\s+', out_version, re.I | re.M)
+            regex_v = re.compile(r"""Comware\s+Software,\s+Version\s+(.*),
+            \sRelease\s+""", re.X)
+            match_v = regex_v.search(out_version, re.I | re.M)
             self.send_command_timing('e')
 
             # Comware version 5.xx
             if match_v and match_v.group(1).startswith('5'):
                 priv_escalation_cmd = 'super'
-                self.send_command(priv_escalation_cmd, expect_string='Password:', auto_find_prompt=False)
-                self.send_command(self.secret, expect_string='>', auto_find_prompt=False)
+                self.send_command(
+                        priv_escalation_cmd,
+                        expect_string='Password:', auto_find_prompt=False)
+                self.send_command(
+                        self.secret,
+                        expect_string='>', auto_find_prompt=False)
             # Comware version 7.xx
             elif match_v and match_v.group(1).startswith('7'):
                 priv_escalation_cmd = 'super level-15'
-                self.send_command(priv_escalation_cmd, expect_string='Username:', auto_find_prompt=False)
-                self.send_command(self.username, expect_string='Password:', auto_find_prompt=False)
-                self.send_command(self.secret, expect_string='>', auto_find_prompt=False)
+                self.send_command(
+                        priv_escalation_cmd,
+                        expect_string='Username:', auto_find_prompt=False)
+                self.send_command(
+                        self.username,
+                        expect_string='Password:', auto_find_prompt=False)
+                self.send_command(
+                        self.secret, expect_string='>', auto_find_prompt=False)
         except Exception as e:
             raise e
 
     def config_mode(self, config_command='system-view'):
         """Enter configuration mode."""
-        return super(HPComwareSSH, self).config_mode(config_command=config_command)
+        return super(
+                HPComwareSSH, self).config_mode(config_command=config_command)
 
     def exit_config_mode(self, exit_config='return'):
         """Exit config mode."""
@@ -60,8 +69,9 @@ class HPComwareSSH(CiscoSSHConnection):
 
         Used as delimiter for stripping of trailing prompt in output.
 
-        Should be set to something that is general and applies in multiple contexts. For Comware
-        this will be the router prompt with < > or [ ] stripped off.
+        Should be set to something that is general and applies in multiple
+        contexts. For Comware this will be the router prompt with < > or [ ]
+        stripped off.
 
         This will be set on logging in, but not when entering system-view
         """


### PR DESCRIPTION
Hello All,

Let's suppose we have RADIUS/AAA configuration and we don't have permission to use some cli commands, but we have user with full rights for the device. ... so we need to escalate our privileges before other commands.

For that purpose : 
   - Add priv_escalation() to hp_comware_ssh.py  
        - priv_escalation() should be executed before "screen-length disable"
        - priv_excalation() depends on comware version v5.x or v7.x 
	modified:   netmiko/hp/hp_comware_ssh.py