### PR TITLE
remove _ssh from melanox in CLASS_MAPPER_BASE

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -93,7 +93,7 @@ CLASS_MAPPER_BASE = {
     'juniper': JuniperSSH,
     'juniper_junos': JuniperSSH,
     'linux': LinuxSSH,
-    'mellanox_ssh': MellanoxSSH,
+    'mellanox': MellanoxSSH,
     'mrv_optiswitch': MrvOptiswitchSSH,
     'netapp_cdot': NetAppcDotSSH,
     'ovs_linux': OvsLinuxSSH,


### PR DESCRIPTION
Except for melanox, there is no _ssh extension in CLASS_MAPPER_BASE, because the new_mapper loop that follows line 117-122 will add the _ssh extension anyway.
Because of that, instead of having "melanox" and "melanox_ssh" in CLASS_MAPPER, we get "melanox_ssh" and "melanox_ssh_ssh".
Not a big deal, but I'm creating a flask interface for netmiko and it looks strange in the drop-down list of available drivers :)