### PR TITLE
Support huawei_vrpv8

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -90,6 +90,7 @@ CLASS_MAPPER_BASE = {
     'hp_comware': HPComwareSSH,
     'hp_procurve': HPProcurveSSH,
     'huawei': HuaweiSSH,
+    'huawei_vrpv8': HuaweiSSH,
     'juniper': JuniperSSH,
     'juniper_junos': JuniperSSH,
     'linux': LinuxSSH,


### PR DESCRIPTION
huawei_vrpv8 switch has been supported in networking-generic-switch
Support huawei_vrpv8 in netmiko as well

Otherwise, error reported like:
networking_generic_switch.devices.netmiko_devices.huawei_vrpv8:Huawei: Netmiko does not support device type huawei_vrpv8