### PR TITLE
add dellemc isilon device support

### DIFF
--- a/netmiko/dellemc/__init__.py
+++ b/netmiko/dellemc/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.dellemc.dellemc_isilon_ssh import DellEmcIsilonSSH
+
+__all__ = ['DellEmcIsilonSSH']

--- a/netmiko/dellemc/dellemc_isilon_ssh.py
+++ b/netmiko/dellemc/dellemc_isilon_ssh.py
@@ -80,7 +80,8 @@ class DellEmcIsilonSSH(BaseConnection):
         delay_factor = self.select_delay_factor(delay_factor=1)
         output = ""
         if not self.check_config_mode():
-            output += self.send_command_timing(config_command, strip_prompt=False, strip_command=False)
+            output += self.send_command_timing(config_command, strip_prompt=False,
+                                               strip_command=False)
             if 'Password:' in output:
                 output = self.write_channel(self.normalize_cmd(self.secret))
             self.set_prompt(prompt_terminator="#")

--- a/netmiko/dellemc/dellemc_isilon_ssh.py
+++ b/netmiko/dellemc/dellemc_isilon_ssh.py
@@ -1,0 +1,95 @@
+from __future__ import unicode_literals
+
+import time
+import re
+
+from netmiko.base_connection import BaseConnection
+
+
+class DellEmcIsilonSSH(BaseConnection):
+    def set_base_prompt(self, pri_prompt_terminator='$',
+                        alt_prompt_terminator='#', delay_factor=1):
+        """Determine base prompt."""
+        return super(DellEmcIsilonSSH, self).set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            delay_factor=delay_factor)
+
+    def strip_ansi_escape_codes(self, string_buffer):
+        """Remove Null code"""
+        output = re.sub(r'\x00', '', string_buffer)
+
+        """Remove ansi_codes"""
+        code_cursor_position = chr(27) + r'\[m'
+        code_erase_display = chr(27) + r'\[J'
+
+        code_set = [code_cursor_position, code_erase_display]
+        for ansi_esc_code in code_set:
+            output = re.sub(ansi_esc_code, '', output)
+        return super(DellEmcIsilonSSH, self).strip_ansi_escape_codes(output)
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
+        self.zsh_mode()
+        prompt = self.find_prompt(delay_factor=1)
+        f = open("/tmp/hoge.txt", "a")
+        f.write(prompt)
+        f.close()
+        self.set_base_prompt()
+        # Clear the read buffer
+        time.sleep(.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def zsh_mode(self, delay_factor=1, prompt_terminator="$"):
+        """Run zsh command to unity the environment"""
+        delay_factor = self.select_delay_factor(delay_factor)
+        self.clear_buffer()
+        command = self.RETURN + "zsh" + self.RETURN
+        self.write_channel(command)
+        time.sleep(1 * delay_factor)
+        self.set_prompt()
+        self.clear_buffer()
+
+    def set_prompt(self, prompt_terminator="$"):
+        prompt = "PROMPT='%m{}'".format(prompt_terminator)
+        command = self.RETURN + prompt + self.RETURN
+        self.write_channel(command)
+
+    def disable_paging(self, *args, **kwargs):
+        """ Isilon doesn't have paging by default."""
+        pass
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on Isilon."""
+        pass
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on Isilon."""
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        """No enable mode on Isilon."""
+        pass
+
+    def check_config_mode(self, check_string='#'):
+        return super(DellEmcIsilonSSH, self).check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command='sudo su'):
+        """Attempt to become root."""
+        delay_factor = self.select_delay_factor(delay_factor=1)
+        output = ""
+        if not self.check_config_mode():
+            output += self.send_command_timing(config_command, strip_prompt=False, strip_command=False)
+            if 'Password:' in output:
+                output = self.write_channel(self.normalize_cmd(self.secret))
+            self.set_prompt(prompt_terminator="#")
+            time.sleep(1 * delay_factor)
+            self.set_base_prompt()
+            if not self.check_config_mode():
+                raise ValueError("Failed to configuration mode")
+        return output
+
+    def exit_config_mode(self, exit_config='exit'):
+        """Exit enable mode."""
+        return super(DellEmcIsilonSSH, self).exit_config_mode(exit_config=exit_config)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -26,6 +26,7 @@ from netmiko.coriant import CoriantSSH
 from netmiko.dell import DellForce10SSH
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
+from netmiko.dellemc import DellEmcIsilonSSH
 from netmiko.eltex import EltexSSH
 from netmiko.enterasys import EnterasysSSH
 from netmiko.extreme import ExtremeSSH
@@ -80,6 +81,7 @@ CLASS_MAPPER_BASE = {
     'coriant': CoriantSSH,
     'dell_force10': DellForce10SSH,
     'dell_powerconnect': DellPowerConnectSSH,
+    'dellemc_isilon': DellEmcIsilonSSH,
     'eltex': EltexSSH,
     'enterasys': EnterasysSSH,
     'extreme': ExtremeSSH,


### PR DESCRIPTION
Adding support for DellEMC Isilon device.
The CLI of isilon device is similar to linux
```
$ py.test -v test_netmiko_show.py --test_device dellemc_isilon
========================================================================= test session starts ==========================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /tmp/venv/bin/python2.7
cachedir: ../.cache
rootdir: /home/koumiyata/git/netmiko, inifile:
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED                                                                                                                 [  8%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                    [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                 [ 25%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                            [ 33%]
test_netmiko_show.py::test_send_command_expect PASSED                                                                                                            [ 41%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                    [ 50%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                   [ 58%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                  [ 66%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                            [ 75%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                   [ 83%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                    [ 91%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                     [100%]

====================================================================== 12 passed in 31.75 seconds ======================================================================


$ py.test -v test_netmiko_config.py --test_device dellemc_isilon
========================================================================= test session starts ==========================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /tmp/venv/bin/python2.7
cachedir: ../.cache
rootdir: /home/koumiyata/git/netmiko, inifile:
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                  [ 14%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                  [ 28%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                  [ 42%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                             [ 57%]
test_netmiko_config.py::test_command_set PASSED                                                                                                                  [ 71%]
test_netmiko_config.py::test_commands_from_file PASSED                                                                                                           [ 85%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                   [100%]

====================================================================== 7 passed in 27.66 seconds =======================================================================
$
```