### PR TITLE
Dell s4048 ssh autodetect support

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -106,6 +106,12 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    'dell_force10': {
+        "cmd": "show version | grep Type",
+        "search_patterns": ["S4048-ON"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
 }
 
 


### PR DESCRIPTION
Dell s4048 SSH support for 'ssh_autodetect.py'. It works as documentation suggests.

i.e.:

```
from netmiko.ssh_autodetect import SSHDetect
from netmiko.ssh_dispatcher import ConnectHandler

remote_device = {'device_type': 'autodetect',
                 'host': '1.1.1.1',
                 'secret': 'test',
                 'username': 'test',
                 'password': 'test'}
                 
guesser = SSHDetect(**remote_device)
best_match = guesser.autodetect()
print(best_match)
print(guesser.potential_matches)
remote_device['device_type'] = best_match
connection = ConnectHandler(**remote_device)
connection.enable()
hostname = connection.send_command('show run | grep hostname')
print(hostname)
connection.disconnect()
```
