### PR TITLE
Issue 647: File transfer fails on dir() command on IOS

### DIFF
--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -160,6 +160,9 @@ class CiscoBaseConnection(BaseConnection):
             if '% Invalid' not in output:
                 return file_system
 
+        if not self.check_enable_mode():
+            raise NetMikoAuthenticationException('Must be in eanble mode')
+
         raise ValueError("An error occurred in dynamically determining remote file "
                          "system: {} {}".format(cmd, output))
 

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -160,9 +160,6 @@ class CiscoBaseConnection(BaseConnection):
             if '% Invalid' not in output:
                 return file_system
 
-        if not self.check_enable_mode():
-            raise NetMikoAuthenticationException('Must be in eanble mode')
-
         raise ValueError("An error occurred in dynamically determining remote file "
                          "system: {} {}".format(cmd, output))
 

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -61,7 +61,7 @@ class BaseFileTransfer(object):
         self.direction = direction
 
         if not ssh_conn.check_enable_mode():
-            raise NetMikoAuthenticationException('Must be in eanble mode')
+            raise NetMikoAuthenticationException('Must be in enable mode')
 
         if not file_system:
             self.file_system = self.ssh_ctl_chan._autodetect_fs()

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -9,6 +9,7 @@ Currently only supports Cisco IOS and Cisco ASA.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from netmiko.ssh_exception import NetMikoAuthenticationException
 
 import re
 import os
@@ -58,6 +59,9 @@ class BaseFileTransfer(object):
         self.source_file = source_file
         self.dest_file = dest_file
         self.direction = direction
+
+        if not ssh_conn.check_enable_mode():
+            raise NetMikoAuthenticationException('Must be in eanble mode')
 
         if not file_system:
             self.file_system = self.ssh_ctl_chan._autodetect_fs()


### PR DESCRIPTION
Hi Kirk,

I added a check whether one is in enable mode to `BaseFileTransfer.__init__()`. I hope this is the right spot as this check is probably vendor specific.

Markus