### PR TITLE
Fix ProxyCommand case

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -569,10 +569,10 @@ class BaseConnection(object):
         else:
             source = {}
 
-        if source.get('proxycommand'):
+        if "proxycommand" in source:
             proxy = paramiko.ProxyCommand(source['proxycommand'])
-        elif source.get('ProxyCommand'):
-            proxy = paramiko.ProxyCommand(source['proxycommand'])
+        elif "ProxyCommand" in source:
+            proxy = paramiko.ProxyCommand(source['ProxyCommand'])
         else:
             proxy = None
 


### PR DESCRIPTION
There's a typo in line 575, it should be `'ProxyCommand'` not `'proxycommand'`. This will fail for sure, as the previous test checked its existence and failed.