### PR TITLE
fix base_connection is_alive() to work with telnet connections

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -283,7 +283,7 @@ class BaseConnection(object):
                 # Try sending IAC + NOP (IAC is telnet way of sending command
                 # IAC = Interpret as Command (it comes before the NOP)
                 log.debug("Sending IAC + NOP")
-                self.device.write_channel(telnetlib.IAC + telnetlib.NOP)
+                self.write_channel(telnetlib.IAC + telnetlib.NOP)
                 return True
             except AttributeError:
                 return False


### PR DESCRIPTION
Appears to be a typo in this code that causes `is_alive()` on telnet connections to always return `False`, as `self.device` is not defined / AttributeError, hence the exception is always hit. The `write_channel()` call is presumably meant to go on `self` directly, where it can work.