### PR TITLE
Support DNOS6

### DIFF
--- a/netmiko/dell/__init__.py
+++ b/netmiko/dell/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
+from netmiko.dell.dell_dnos6 import DellDNOS6SSH
+from netmiko.dell.dell_dnos6 import DellDNOS6Telnet
 from netmiko.dell.dell_force10_ssh import DellForce10SSH
 from netmiko.dell.dell_powerconnect import DellPowerConnectSSH
 from netmiko.dell.dell_powerconnect import DellPowerConnectTelnet
 
-__all__ = ['DellForce10SSH', 'DellPowerConnectSSH', 'DellPowerConnectTelnet']
+__all__ = ['DellDNOS6SSH', 'DellDNOS6Telnet', 'DellForce10SSH',
+           'DellPowerConnectSSH', 'DellPowerConnectTelnet']

--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -1,0 +1,29 @@
+"""Dell N2/3/4000 base driver- supports DNOS6."""
+from __future__ import unicode_literals
+from netmiko.dell.dell_powerconnect import DellPowerConnectBase
+
+
+class DellDNOS6Base(DellPowerConnectBase):
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging(command="terminal length 0")
+        self.set_terminal_width()
+        # Clear the read buffer
+        time.sleep(.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def save_config(self, cmd='copy running-configuration startup-configuration', confirm=False):
+        """Saves Config"""
+        return super(DellDNOS6SSH, self).save_config(cmd=cmd, confirm=confirm)
+
+
+class DellDNOS6SSH(DellDNOS6Base):
+    pass
+
+
+class DellDNOS6Telnet(DellDNOS6Base):
+    pass

--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -1,6 +1,7 @@
 """Dell N2/3/4000 base driver- supports DNOS6."""
 from __future__ import unicode_literals
 from netmiko.dell.dell_powerconnect import DellPowerConnectBase
+import time
 
 
 class DellDNOS6Base(DellPowerConnectBase):

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -84,6 +84,7 @@ CLASS_MAPPER_BASE = {
     'cisco_xr': CiscoXrSSH,
     'coriant': CoriantSSH,
     'dell_dnos6': DellDNOS6SSH,
+    'dell_dnos9': DellForce10SSH,
     'dell_force10': DellForce10SSH,
     'dell_powerconnect': DellPowerConnectSSH,
     'eltex': EltexSSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -24,6 +24,8 @@ from netmiko.cisco import CiscoTpTcCeSSH
 from netmiko.cisco import CiscoWlcSSH
 from netmiko.cisco import CiscoXrSSH, CiscoXrFileTransfer
 from netmiko.coriant import CoriantSSH
+from netmiko.dell import DellDNOS6SSH
+from netmiko.dell import DellDNOS6Telnet
 from netmiko.dell import DellForce10SSH
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
@@ -81,6 +83,7 @@ CLASS_MAPPER_BASE = {
     'cisco_xe': CiscoIosSSH,
     'cisco_xr': CiscoXrSSH,
     'coriant': CoriantSSH,
+    'dell_dnos6': DellDNOS6SSH,
     'dell_force10': DellForce10SSH,
     'dell_powerconnect': DellPowerConnectSSH,
     'eltex': EltexSSH,
@@ -143,6 +146,7 @@ CLASS_MAPPER['brocade_netiron_telnet'] = BrocadeNetironTelnet
 CLASS_MAPPER['cisco_ios_telnet'] = CiscoIosTelnet
 CLASS_MAPPER['arista_eos_telnet'] = AristaTelnet
 CLASS_MAPPER['juniper_junos_telnet'] = JuniperTelnet
+CLASS_MAPPER['dell_dnos6_telnet'] = DellDNOS6Telnet
 CLASS_MAPPER['dell_powerconnect_telnet'] = DellPowerConnectTelnet
 CLASS_MAPPER['generic_termserver_telnet'] = TerminalServerTelnet
 CLASS_MAPPER['extreme_telnet'] = ExtremeTelnet


### PR DESCRIPTION
Almost like PowerConnect, but password auth via SSH actually happens on on SSH level.

This also aliases DNOS9, the successor of F10OS, to the F10OS implementation.