### PR TITLE
Fix is_alive() for telnet Issue #763

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -303,7 +303,7 @@ class BaseConnection(object):
                 # Try sending IAC + NOP (IAC is telnet way of sending command
                 # IAC = Interpret as Command (it comes before the NOP)
                 log.debug("Sending IAC + NOP")
-                self.write_channel(telnetlib.IAC + telnetlib.NOP)
+                self.remote_conn.sock.sendall(telnetlib.IAC + telnetlib.NOP)
                 return True
             except AttributeError:
                 return False


### PR DESCRIPTION
Python's telnetlib escaped the IAC+NOP sequence that was being sent to the host.  On some devices this led to a disconnect on subsequent calls to find_prompt().