### PR TITLE
Vyos handle additional fail message during commit

### DIFF
--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -62,7 +62,7 @@ class VyOSSSH(CiscoSSHConnection):
 
         """
         delay_factor = self.select_delay_factor(delay_factor)
-        error_marker = 'Failed to generate committed config'
+        error_marker = ['Failed to generate committed config', 'Commit failed']
         command_string = 'commit'
 
         if comment:
@@ -72,7 +72,7 @@ class VyOSSSH(CiscoSSHConnection):
         output += self.send_command_expect(command_string, strip_prompt=False,
                                            strip_command=False, delay_factor=delay_factor)
 
-        if error_marker in output:
+        if any(x in output for x in error_marker):
             raise ValueError('Commit failed with following errors:\n\n{}'.format(output))
         return output
 


### PR DESCRIPTION
Hello ,
I've just noticed on a vyos device situation when commit failed but library didn't notice.

For example we can have this situation when we set hostname with underscore and try to commit 

"vagrant@saltsettest# commit
[ system host-name saltvy_osaa2 ]
invalid host name saltvy_osaa2

[[system host-name]] failed
Commit failed
[edit]"

This change also looks for sentence " Commit failed" 