### PR TITLE
To pass banner motd post login

### DIFF
--- a/netmiko/extreme/extreme_wing_ssh.py
+++ b/netmiko/extreme/extreme_wing_ssh.py
@@ -6,11 +6,10 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 class ExtremeWingSSH(CiscoSSHConnection):
     """Extreme WiNG support."""
     def session_preparation(self):
-        self.set_base_prompt(pri_prompt_terminator='>',
-                             alt_prompt_terminator='#',
-                             delay_factor=2)
+        """Pass banner motd if used, disable paging and set Max term width"""
+        self._test_channel_read(pattern=">|#")
+        self.set_base_prompt()
         self.disable_paging(command="no page")
         self.set_terminal_width(command='terminal width 512')
-        # Clear the read buffer
         time.sleep(.3 * self.global_delay_factor)
         self.clear_buffer()


### PR DESCRIPTION
Today I was facing issue with Extreme WiNG device that set ` banner motd xxxxx` for after SSH login.
And fixed it.
And pass tox test all py version as well. 
Merging or direct fixing master code, depend on.  I am OK anyhow.
Thank you very much for the continually developing netmiko.