### PR TITLE
add hp procurve telnet functionality

### DIFF
--- a/netmiko/hp/__init__.py
+++ b/netmiko/hp/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from netmiko.hp.hp_procurve_ssh import HPProcurveSSH
+from netmiko.hp.hp_procurve_ssh import HPProcurveSSH, HPProcurveTelnet
 from netmiko.hp.hp_comware_ssh import HPComwareSSH, HPComwareTelnet
 
-__all__ = ['HPProcurveSSH', 'HPComwareSSH', 'HPComwareTelnet']
+__all__ = ['HPProcurveSSH', 'HPProcurveTelnet', 'HPComwareSSH', 'HPComwareTelnet']

--- a/netmiko/hp/hp_procurve_ssh.py
+++ b/netmiko/hp/hp_procurve_ssh.py
@@ -7,7 +7,7 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 from netmiko import log
 
 
-class HPProcurveSSH(CiscoSSHConnection):
+class HPProcurveBase(CiscoSSHConnection):
 
     def session_preparation(self):
         """
@@ -77,4 +77,22 @@ class HPProcurveSSH(CiscoSSHConnection):
 
     def save_config(self, cmd='write memory', confirm=False):
         """Save Config."""
-        return super(HPProcurveSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(HPProcurveBase, self).save_config(cmd=cmd, confirm=confirm)
+
+
+class HPProcurveSSH(HPProcurveBase):
+    pass
+
+
+class HPProcurveTelnet(HPProcurveBase):
+    def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
+                     username_pattern=r"Login Name:", pwd_pattern=r"assword",
+                     delay_factor=1, max_loops=60):
+        """Telnet login. Can be username/password or just password."""
+        super(HPProcurveTelnet, self).telnet_login(
+                pri_prompt_terminator=pri_prompt_terminator,
+                alt_prompt_terminator=alt_prompt_terminator,
+                username_pattern=username_pattern,
+                pwd_pattern=pwd_pattern,
+                delay_factor=delay_factor,
+                max_loops=max_loops)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -36,7 +36,7 @@ from netmiko.extreme import ExtremeWingSSH
 from netmiko.extreme import ExtremeTelnet
 from netmiko.f5 import F5LtmSSH
 from netmiko.fortinet import FortinetSSH
-from netmiko.hp import HPProcurveSSH, HPComwareSSH, HPComwareTelnet
+from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH
 from netmiko.juniper import JuniperSSH, JuniperTelnet
 from netmiko.juniper import JuniperFileTransfer
@@ -147,6 +147,7 @@ CLASS_MAPPER['brocade_fastiron_telnet'] = RuckusFastironTelnet
 CLASS_MAPPER['brocade_netiron_telnet'] = BrocadeNetironTelnet
 CLASS_MAPPER['cisco_ios_telnet'] = CiscoIosTelnet
 CLASS_MAPPER['arista_eos_telnet'] = AristaTelnet
+CLASS_MAPPER['hp_procurve_telnet'] = HPProcurveTelnet
 CLASS_MAPPER['hp_comware_telnet'] = HPComwareTelnet
 CLASS_MAPPER['juniper_junos_telnet'] = JuniperTelnet
 CLASS_MAPPER['calix_b6_telnet'] = CalixB6Telnet

--- a/tests/test_hp_telnet.sh
+++ b/tests/test_hp_telnet.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device hp_procurve_telnet \
+&& py.test -v test_netmiko_config.py --test_device hp_procurve_telnet \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
Test output:

```
vagrant@web:/vagrant/tests$ ./test_hp_telnet.sh
Starting tests...good luck:
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python
cachedir: ../.cache
rootdir: /vagrant, inifile:
collected 12 items
test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED
======================================================================================================== 12 passed in 63.85 seconds =========================================================================================================
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python
cachedir: ../.cache
rootdir: /vagrant, inifile:
collected 7 items
test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED
========================================================================================================= 7 passed in 63.58 seconds =========================================================================================================
```