### PR TITLE
Add support for ASA terminal width

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -124,9 +124,7 @@ class CiscoAsaSSH(CiscoSSHConnection):
         if not hasattr(self, "prev_term_width"):
             output = self.send_command("show run | i terminal width")
             if output:
-                if "511" in output.split()[-1]:
-                    return None
-                else:
+                if not "511" in output.split()[-1]:
                     self.prev_term_width = output.split()[-1]
             else:
                 self.prev_term_width = 80

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -107,6 +107,42 @@ class CiscoAsaSSH(CiscoSSHConnection):
         """Saves Config"""
         return super(CiscoAsaSSH, self).save_config(cmd=cmd, confirm=confirm)
 
+    def set_terminal_width(self, command="", delay_factor=1):
+        """
+        On ASAs, terminal width is set in global configuration mode. First,
+        we should check to see if we can access config mode. If we can't,
+        then don't do anything. If we can and the current terminal width
+        is not already 511, store the current terminal width as an attribute
+        of this object so that it can be restored when our session is complete.
+        """
+        if not super(CiscoAsaSSH, self).check_config_mode():
+            try:
+                super(CiscoAsaSSH, self).config_mode()
+            except ValueError:
+                # Unable to access global config mode
+                return None
+        if not hasattr(self, "prev_term_width"):
+            output = self.send_command("show run | i terminal width")
+            if output:
+                if "511" in output.split()[-1]:
+                    return None
+                else:
+                    self.prev_term_width = output.split()[-1]
+            else:
+                self.prev_term_width = 80
+        super(CiscoAsaSSH, self).set_terminal_width(command=command)
+        super(CiscoAsaSSH, self).exit_config_mode()
+    
+    def cleanup(self):
+        """
+        Gracefully exit the SSH session. On ASAs, we need to try to restore
+        the user-configured terminal width before exiting the session.
+        """
+        try:
+            self.set_terminal_width(command="terminal width {}".format(self.prev_term_width))
+        except AttributeError:
+            pass
+        super(CiscoAsaSSH, self).cleanup()
 
 class CiscoAsaFileTransfer(CiscoFileTransfer):
     """Cisco ASA SCP File Transfer driver."""


### PR DESCRIPTION
Added code in ASA subclass that fixes #281 using the steps described within the issue.

Tested using a Cisco ASA 5508 running 9.4(4)20 with `terminal width 55` set in running-config. Below code was used to test:

```
from netmiko import ConnectHandler

asa_device = {"device_type": "cisco_asa", "ip": "10.122.160.155", "username": "admin", "password": "cisco!123"}
asa_conn = ConnectHandler(**asa_device)
print(asa_conn.send_command("show run | i terminal width"))
asa_conn.cleanup()
```
Output from the script:
```
C:\Users\chart2\Documents\Python\netmiko>python asa_test.py
terminal width 511
```

Output from the device after test script was run:
```
asa# show version | i Software|Hardware
Cisco Adaptive Security Appliance Software Version 9.4(4)20 
Hardware:   ASA5508, 8192 MB RAM, CPU Atom C2000 series 2000 MHz, 1 CPU (8 cores)
asa# show run | i terminal width
terminal width 55
```

The only possible bug I can see with the changes made in this PR is if configuration commands sent during the SSH session involve changing the terminal width. For example, let's say that an ASA starts with an initial terminal width of 80. A user uses netmiko to SSH into the ASA and change the terminal width to 450. Netmiko will change the terminal width to 511, store the previously-configured value of 80 as an attribute of the session, and then configure the terminal width to be 450 as the user requested. However, *if* the user calls the `cleanup()` method, the previously-configured value of 80 will be restored, thus overwriting the user's changes.

The obvious workaround to this issue would be to not call the `cleanup()` method at the end of a script, which I think we can all agree is less than desirable. Perhaps we can change the `send_command()` method (and all necessary related methods) to check to see if `terminal width XXX` is part of the commands sent, and if so, change `self.prev_term_width` to the user's defined value?

## Unit Test Results

```
C:\Users\chart2\Documents\Python\netmiko\tests>py.test -v test_netmiko_show.py --test_device cisco_asa_21
============================= test session starts =============================
platform win32 -- Python 3.6.4, pytest-3.6.3, py-1.5.4, pluggy-0.6.0 -- c:\users\chart2\appdata\local\programs\python\python36-32\python.exe
cachedir: ..\.pytest_cache
rootdir: C:\Users\chart2\Documents\Python\netmiko, inifile:
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED                         [  8%]
test_netmiko_show.py::test_ssh_connect PASSED                            [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                         [ 25%]
test_netmiko_show.py::test_send_command_timing PASSED                    [ 33%]
test_netmiko_show.py::test_send_command_expect PASSED                    [ 41%]
test_netmiko_show.py::test_base_prompt PASSED                            [ 50%]
test_netmiko_show.py::test_strip_prompt PASSED                           [ 58%]
test_netmiko_show.py::test_strip_command PASSED                          [ 66%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                    [ 75%]
test_netmiko_show.py::test_clear_buffer PASSED                           [ 83%]
test_netmiko_show.py::test_enable_mode PASSED                            [ 91%]
test_netmiko_show.py::test_disconnect PASSED                             [100%]

========================= 12 passed in 58.23 seconds ==========================

C:\Users\chart2\Documents\Python\netmiko\tests>py.test -v test_netmiko_show.py --test_device cisco_asa_21
============================= test session starts =============================
platform win32 -- Python 3.6.4, pytest-3.6.3, py-1.5.4, pluggy-0.6.0 -- c:\users\chart2\appdata\local\programs\python\python36-32\python.exe
cachedir: ..\.pytest_cache
rootdir: C:\Users\chart2\Documents\Python\netmiko, inifile:
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED                         [  8%]
test_netmiko_show.py::test_ssh_connect PASSED                            [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                         [ 25%]
test_netmiko_show.py::test_send_command_timing PASSED                    [ 33%]
test_netmiko_show.py::test_send_command_expect PASSED                    [ 41%]
test_netmiko_show.py::test_base_prompt PASSED                            [ 50%]
test_netmiko_show.py::test_strip_prompt PASSED                           [ 58%]
test_netmiko_show.py::test_strip_command PASSED                          [ 66%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                    [ 75%]
test_netmiko_show.py::test_clear_buffer PASSED                           [ 83%]
test_netmiko_show.py::test_enable_mode PASSED                            [ 91%]
test_netmiko_show.py::test_disconnect PASSED                             [100%]

========================= 12 passed in 58.23 seconds ==========================
```