### PR TITLE
Clear the devices line when logging into a box

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -243,6 +243,10 @@ class BaseConnection(object):
 
             self._modify_connection_params()
             self.establish_connection()
+            
+            #clears the line when trying to enter enable mode
+            self.write_channel("\r")
+            
             self.session_preparation()
 
     def __enter__(self):


### PR DESCRIPTION
Edited base_connection so that the line is cleared when the device is not already in enable mode. This fixes the error 'netmiko.ssh_exception.NetMikoTimeoutException: Timed out waiting for data' when the device is not in enable mode.