### PR TITLE
Add support for IP Infusion OcNOS

### DIFF
--- a/netmiko/ipinfusion/__init__.py
+++ b/netmiko/ipinfusion/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from netmiko.ipinfusion.ipinfusion_ocnos import IpinfusionOcnosSSH, IpinfusionOcNOSTelnet
+
+__all__ = ['IpinfusionOcnosSSH', 'IpinfusionOcNOSTelnet']

--- a/netmiko/ipinfusion/ipinfusion_ocnos.py
+++ b/netmiko/ipinfusion/ipinfusion_ocnos.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 import time
 import re
-from telnetlib import Telnet, IAC, DO, DONT, WILL, WONT, SB, SE, TTYPE
+from telnetlib import IAC, DO, DONT, WILL, WONT, SB, SE, TTYPE
 from netmiko.ssh_exception import NetMikoTimeoutException
 from netmiko.cisco_base_connection import CiscoBaseConnection
+
 
 class IpinfusionOcnosBase(CiscoBaseConnection):
     """Common Methods for IP Infusion OcNOS support."""
@@ -47,9 +48,11 @@ class IpinfusionOcnosBase(CiscoBaseConnection):
                 raise ValueError(msg)
         return output
 
+
 class IpinfusionOcnosSSH(IpinfusionOcnosBase):
     """IP Infusion OcNOS SSH driver."""
     pass
+
 
 class IpinfusionOcNOSTelnet(IpinfusionOcnosBase):
     """IP Infusion OcNOS  Telnet driver."""
@@ -71,7 +74,7 @@ class IpinfusionOcNOSTelnet(IpinfusionOcnosBase):
     def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
                      username_pattern=r"(?:user:|sername|login|user name)", pwd_pattern=r"assword:",
                      delay_factor=1, max_loops=20):
-        #set callback function to handle telnet options.
+        # set callback function to handle telnet options.
         self.remote_conn.set_option_negotiation_callback(self.process_option)
         return super(IpinfusionOcNOSTelnet, self).telnet_login(
             pri_prompt_terminator=pri_prompt_terminator,

--- a/netmiko/ipinfusion/ipinfusion_ocnos.py
+++ b/netmiko/ipinfusion/ipinfusion_ocnos.py
@@ -1,0 +1,80 @@
+from __future__ import unicode_literals
+import time
+import re
+from telnetlib import Telnet, IAC, DO, DONT, WILL, WONT, SB, SE, TTYPE
+from netmiko.ssh_exception import NetMikoTimeoutException
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+class IpinfusionOcnosBase(CiscoBaseConnection):
+    """Common Methods for IP Infusion OcNOS support."""
+    def session_preparation(self):
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging(command="terminal length 0")
+
+        # Clear the read buffer
+        time.sleep(.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def save_config(self, cmd='write', confirm=False):
+        """Saves Config Using write command"""
+        return super(IpinfusionOcnosBase, self).save_config(cmd=cmd, confirm=confirm)
+
+    def enable(self, cmd='enable', pattern='ssword', re_flags=re.IGNORECASE):
+        """Enter enable mode.
+
+        :param cmd: Device command to enter enable mode
+        :type cmd: str
+
+        :param pattern: pattern to search for indicating device is waiting for password
+        :type pattern: str
+
+        :param re_flags: Regular expression flags used in conjunction with pattern
+        :type re_flags: int
+        """
+        output = ""
+        msg = "Failed to enter enable mode. Please ensure you pass " \
+              "the 'secret' argument to ConnectHandler."
+        if not self.check_enable_mode():
+            self.write_channel(self.normalize_cmd(cmd))
+            try:
+                output += self.read_until_prompt_or_pattern(pattern=pattern, re_flags=re_flags)
+                self.write_channel(self.secret + self.TELNET_RETURN)
+                output += self.read_until_prompt()
+            except NetMikoTimeoutException:
+                raise ValueError(msg)
+            if not self.check_enable_mode():
+                raise ValueError(msg)
+        return output
+
+class IpinfusionOcnosSSH(IpinfusionOcnosBase):
+    """IP Infusion OcNOS SSH driver."""
+    pass
+
+class IpinfusionOcNOSTelnet(IpinfusionOcnosBase):
+    """IP Infusion OcNOS  Telnet driver."""
+
+    """
+    For all telnet options, re-implement the default telnetlib behaviour
+    and refuse to handle any options. If the server expresses interest in
+    'terminal type' option, then reply back with 'xterm' terminal type.
+    """
+    def process_option(self, tsocket, command, option):
+        if command == DO and option == TTYPE:
+            tsocket.sendall(IAC + WILL + TTYPE)
+            tsocket.sendall(IAC + SB + TTYPE + b'\0' + b'xterm' + IAC + SE)
+        elif command in (DO, DONT):
+            tsocket.sendall(IAC + WONT + option)
+        elif command in (WILL, WONT):
+            tsocket.sendall(IAC + DONT + option)
+
+    def telnet_login(self, pri_prompt_terminator='#', alt_prompt_terminator='>',
+                     username_pattern=r"(?:user:|sername|login|user name)", pwd_pattern=r"assword:",
+                     delay_factor=1, max_loops=20):
+        #set callback function to handle telnet options.
+        self.remote_conn.set_option_negotiation_callback(self.process_option)
+        return super(IpinfusionOcNOSTelnet, self).telnet_login(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            username_pattern=username_pattern, pwd_pattern=pwd_pattern,
+            delay_factor=delay_factor, max_loops=max_loops)

--- a/netmiko/ipinfusion/ipinfusion_ocnos.py
+++ b/netmiko/ipinfusion/ipinfusion_ocnos.py
@@ -17,9 +17,10 @@ class IpinfusionOcnosBase(CiscoBaseConnection):
         time.sleep(.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def save_config(self, cmd='write', confirm=False):
+    def save_config(self, cmd='write', confirm=False, confirm_response=''):
         """Saves Config Using write command"""
-        return super(IpinfusionOcnosBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(IpinfusionOcnosBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response)
 
     def enable(self, cmd='enable', pattern='ssword', re_flags=re.IGNORECASE):
         """Enter enable mode.

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -40,6 +40,7 @@ from netmiko.f5 import F5LtmSSH
 from netmiko.fortinet import FortinetSSH
 from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH
+from netmiko.ipinfusion import IpinfusionOcnosSSH, IpinfusionOcNOSTelnet
 from netmiko.juniper import JuniperSSH, JuniperTelnet
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
@@ -102,6 +103,7 @@ CLASS_MAPPER_BASE = {
     'hp_procurve': HPProcurveSSH,
     'huawei': HuaweiSSH,
     'huawei_vrpv8': HuaweiVrpv8SSH,
+    'ipinfusion_ocnos': IpinfusionOcnosSSH,
     'juniper': JuniperSSH,
     'juniper_junos': JuniperSSH,
     'linux': LinuxSSH,
@@ -155,6 +157,7 @@ CLASS_MAPPER['apresia_aeos_telnet'] = ApresiaAeosTelnet
 CLASS_MAPPER['arista_eos_telnet'] = AristaTelnet
 CLASS_MAPPER['hp_procurve_telnet'] = HPProcurveTelnet
 CLASS_MAPPER['hp_comware_telnet'] = HPComwareTelnet
+CLASS_MAPPER['ipinfusion_ocnos_telnet'] = IpinfusionOcNOSTelnet
 CLASS_MAPPER['juniper_junos_telnet'] = JuniperTelnet
 CLASS_MAPPER['paloalto_panos_telnet'] = PaloAltoPanosTelnet
 CLASS_MAPPER['calix_b6_telnet'] = CalixB6Telnet

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -182,3 +182,29 @@ calix_b6_ssh:
     - "access-list ethernet 999 permit ip"
     - "access-list ethernet 999 permit arp"
   config_verification: "find running-config 999"
+
+ipinfusion_ocnos:
+  version: "show version"
+  basic: "show ip interface eth0 brief"
+  extended_output: "show ip interface brief"   # requires paging to be disabled
+  config:
+    - "logging  level ospf 4"      # base command
+    - "no logging level ospf"
+    - "logging level ospf 5"      # something you can verify has changed
+  config_verification: "show logging level ospf"
+  save_config_cmd: 'write'
+  save_config_confirm: False
+  save_config_response: "[OK]"
+
+ipinfusion_ocnos_telnet:
+  version: "show version"
+  basic: "show ip interface eth0 brief"
+  extended_output: "show ip interface brief"   # requires paging to be disabled
+  config:
+    - "logging  level ospf 4"      # base command
+    - "no logging level ospf"
+    - "logging level ospf 5"      # something you can verify has changed
+  config_verification: "show logging level ospf"
+  save_config_cmd: 'write'
+  save_config_confirm: False
+  save_config_response: "[OK]"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -133,3 +133,25 @@ calix_b6_ssh:
   multiple_line_output: "rtcPwrUptimeTotal"
   cmd_response_init: "Building configuration...    Done"
   cmd_response_final: "access-list ethernet 999 permit ip"
+
+ipinfusion_ocnos:
+  base_prompt: rtr1
+  router_prompt: rtr1>
+  enable_prompt: rtr1#
+  interface_ip: 10.12.39.34
+  version_banner: "Software Product: OcNOS"
+  multiple_line_output: "lo                   127.0.0.1"
+  cmd_response_init: "ospfd                   2                           4"
+  cmd_response_final: "ospfd                   2                           5"
+  save_config: '[OK]'
+
+ipinfusion_ocnos_telnet:
+  base_prompt: rtr1
+  router_prompt: rtr1>
+  enable_prompt: rtr1#
+  interface_ip: 10.12.39.34
+  version_banner: "Software Product: OcNOS"
+  multiple_line_output: "lo                   127.0.0.1"
+  cmd_response_init: "ospfd                   2                           4"
+  cmd_response_final: "ospfd                   2                           5"
+  save_config: '[OK]'

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -119,3 +119,18 @@ calix_b6_ssh:
   username: cli
   password: occam
   secret: razor
+
+ipinfusion_ocnos:
+  device_type: ipinfusion_ocnos
+  ip: 10.12.39.34
+  username: ocnos
+  password: ocnos
+  secret: ocnos
+
+ipinfusion_ocnos_telnet:
+  device_type: ipinfusion_ocnos_telnet
+  ip: 10.12.39.34
+  username: ocnos
+  password: ocnos
+  secret: ocnos
+

--- a/tests/test_ipinfusion.sh
+++ b/tests/test_ipinfusion.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device ipinfusion_ocnos \
+&& py.test -v test_netmiko_config.py --test_device ipinfusion_ocnos \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE

--- a/tests/test_ipinfusion_telnet.sh
+++ b/tests/test_ipinfusion_telnet.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device ipinfusion_ocnos_telnet \
+&& py.test -v test_netmiko_config.py --test_device ipinfusion_ocnos_telnet \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE

--- a/tests/test_netmiko_config.py
+++ b/tests/test_netmiko_config.py
@@ -122,7 +122,7 @@ def test_save_confirm(net_connect, commands, expected_responses):
     confirm = commands['save_config_confirm']
     save_verify = expected_responses['save_config']
 
-    cmd_response = net_connect.save_config(confirm)
+    cmd_response = net_connect.save_config(confirm=confirm)
     assert save_verify in cmd_response
 
 def test_save_response(net_connect, commands, expected_responses):


### PR DESCRIPTION
Changes are done to support IP Infusion OcNOS for both telnet SSH and telnet connections. 
1. In case of telnet connection, need to handle telnet options specifically 'terminal type'. Hence have used set_option_negotiation_callback in order to handle telnet options. 
2. In case of enable password, need to write TELNET_RETURN("\r\n") along with the password. Hence have to override BaseConnection class's function.. BTW, why BaseConnection class, handles the writing of the password differently for the login password and enable password?? 
3. Attaching the test logs. However, due to issues with the save_config tests, those tests are failing. 
[test_ipinfusion.sh.txt](https://github.com/ktbyers/netmiko/files/2238759/test_ipinfusion.sh.txt)
[test_ipinfusion_telnet.sh.txt](https://github.com/ktbyers/netmiko/files/2238761/test_ipinfusion_telnet.sh.txt)


