### PR TITLE
Support directly using paramiko PKey objects for SSH key authentication

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -36,12 +36,12 @@ class BaseConnection(object):
     """
     def __init__(self, ip='', host='', username='', password='', secret='', port=None,
                  device_type='', verbose=False, global_delay_factor=1, use_keys=False,
-                 key_file=None, allow_agent=False, ssh_strict=False, system_host_keys=False,
-                 alt_host_keys=False, alt_key_file='', ssh_config_file=None, timeout=100,
-                 session_timeout=60, blocking_timeout=8, keepalive=0, default_enter=None,
-                 response_return=None, serial_settings=None, fast_cli=False, session_log=None,
-                 session_log_record_writes=False, session_log_file_mode='write',
-                 allow_auto_change=False):
+                 key_file=None, priv_key=None, allow_agent=False, ssh_strict=False,
+                 system_host_keys=False, alt_host_keys=False, alt_key_file='',
+                 ssh_config_file=None, timeout=100, session_timeout=60, blocking_timeout=8,
+                 keepalive=0, default_enter=None, response_return=None, serial_settings=None,
+                 fast_cli=False, session_log=None, session_log_record_writes=False,
+                 session_log_file_mode='write', allow_auto_change=False):
         """
         Initialize attributes for establishing connection to target device.
 
@@ -82,6 +82,9 @@ class BaseConnection(object):
 
         :param key_file: Filename path of the SSH key file to use.
         :type key_file: str
+
+        :param priv_key: SSH key object to use.
+        :type priv_key: paramiko.PKey
 
         :param allow_agent: Enable use of SSH key-agent.
         :type allow_agent: bool
@@ -238,6 +241,7 @@ class BaseConnection(object):
             # Options for SSH host_keys
             self.use_keys = use_keys
             self.key_file = key_file
+            self.priv_key = priv_key
             self.allow_agent = allow_agent
             self.system_host_keys = system_host_keys
             self.alt_host_keys = alt_host_keys
@@ -686,6 +690,7 @@ class BaseConnection(object):
             'look_for_keys': self.use_keys,
             'allow_agent': self.allow_agent,
             'key_filename': self.key_file,
+            'pkey': self.priv_key,
             'timeout': self.timeout,
         }
 


### PR DESCRIPTION
This PR adds support for using a Paramiko PKey subclass (RSAKey etc) for key authentication, as an alternative to Paramiko extracting the key itself from a file.