### PR TITLE
Raising exception for insanely long passwords

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -24,6 +24,8 @@ class CiscoWlcSSH(BaseConnection):
         Password:****
         """
         password_length = len(self.password)
+        if password_length > 25:
+            raise ValueError('The supplied password of [{}] is greater than the maximum supported length of [25] for Cisco WLC.'.format(str(lenPassword)))
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -23,7 +23,7 @@ class CiscoWlcSSH(BaseConnection):
 
         Password:****
         """
-        password_length = len(password)
+        password_length = len(self.password)
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -13,7 +13,7 @@ class CiscoWlcSSH(BaseConnection):
     """Netmiko Cisco WLC support."""
 
     def special_login_handler(self, delay_factor=1):
-        """WLC presents with the following on login (in certain OS versions)
+        """WLC presents with the following on login (in certain OS versions), maximum password length is 25 on Aireos
 
         login as: user
 
@@ -23,6 +23,7 @@ class CiscoWlcSSH(BaseConnection):
 
         Password:****
         """
+        password_length = len(password)
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)


### PR DESCRIPTION
Cisco WLCs support a maximum password length of 25 characters.  This change will prevent the script from continuing into the self.find_prompt method and crashing when the prompt cannot be found.
