### PR TITLE
Adding cisco_wlc ability to return auth exception

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -15,7 +15,6 @@ class CiscoWlcSSH(BaseConnection):
 
     def special_login_handler(self, delay_factor=1):
         """WLC presents with the following on login (in certain OS versions)
-        
 
         login as: user
 

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -24,10 +24,6 @@ class CiscoWlcSSH(BaseConnection):
 
         Password:****
         """
-        password_length = len(self.password)
-        if password_length > 25:
-            raise ValueError('The supplied password of [{}]'.format(str(password_length))) +
-                             ' is greater than the maximum supported length of [25] for Cisco WLC.'
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)
@@ -39,6 +35,12 @@ class CiscoWlcSSH(BaseConnection):
                     self.write_channel(self.username + self.RETURN)
                 elif 'Password' in output:
                     self.write_channel(self.password + self.RETURN)
+                    self.clear_buffer()
+                    self.write_channel(self.RETURN)
+                    time.sleep(delay_factor * 1)
+                    output = self.read_channel()
+                    if 'User' in output:
+                        
                     break
                 time.sleep(delay_factor * 1)
             else:

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -24,6 +24,8 @@ class CiscoWlcSSH(BaseConnection):
         Password:****
         """
         password_length = len(self.password)
+        if password_length > 25:
+            raise ValueError('The supplied password of [{}] is greater than the maximum supported length of [25] for Cisco WLC.'.format(str(lenPassword)))
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -23,7 +23,7 @@ class CiscoWlcSSH(BaseConnection):
 
         Password:****
         """
-        password_length = len(password)
+        password_length = len(self.password)
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -13,7 +13,7 @@ class CiscoWlcSSH(BaseConnection):
     """Netmiko Cisco WLC support."""
 
     def special_login_handler(self, delay_factor=1):
-        """WLC presents with the following on login (in certain OS versions)
+        """WLC presents with the following on login (in certain OS versions), maximum password length is 25 on Aireos
 
         login as: user
 
@@ -23,6 +23,7 @@ class CiscoWlcSSH(BaseConnection):
 
         Password:****
         """
+        password_length = len(password)
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -36,7 +36,7 @@ class CiscoWlcSSH(BaseConnection):
                     self.write_channel(self.username + self.RETURN)
                 elif 'Password' in output:
                     self.write_channel(self.password + self.RETURN)
-                    if 'User:' in self.find_prompt():
+                    if 'User:' == self.find_prompt():
                         raise NetMikoAuthenticationException('Unable to authenticate.')
                     break
                 time.sleep(delay_factor * 1)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -13,7 +13,8 @@ class CiscoWlcSSH(BaseConnection):
     """Netmiko Cisco WLC support."""
 
     def special_login_handler(self, delay_factor=1):
-        """WLC presents with the following on login (in certain OS versions), maximum password length is 25 on Aireos
+        """WLC presents with the following on login (in certain OS versions),
+        maximum password length is 25 on Aireos
 
         login as: user
 

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -25,7 +25,8 @@ class CiscoWlcSSH(BaseConnection):
         """
         password_length = len(self.password)
         if password_length > 25:
-            raise ValueError('The supplied password of [{}] is greater than the maximum supported length of [25] for Cisco WLC.'.format(str(lenPassword)))
+            raise ValueError('The supplied password of [{}] is greater '.format(str(password_length))) +
+                             'than the maximum supported length of [25] for Cisco WLC.'
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -13,8 +13,7 @@ class CiscoWlcSSH(BaseConnection):
     """Netmiko Cisco WLC support."""
 
     def special_login_handler(self, delay_factor=1):
-        """WLC presents with the following on login (in certain OS versions),
-        maximum password length is 25 on Aireos
+        """WLC presents with the following on login (in certain OS versions), maximum password length is 25 on Aireos
 
         login as: user
 
@@ -26,8 +25,8 @@ class CiscoWlcSSH(BaseConnection):
         """
         password_length = len(self.password)
         if password_length > 25:
-            raise ValueError('The supplied password of [{}] is greater '.format(str(password_length))) +
-                             'than the maximum supported length of [25] for Cisco WLC.'
+            raise ValueError('The supplied password of [{}]'.format(str(password_length))) +
+                             ' is greater than the maximum supported length of [25] for Cisco WLC.'
         delay_factor = self.select_delay_factor(delay_factor)
         i = 0
         time.sleep(delay_factor * .5)


### PR DESCRIPTION
Previously cisco_wlc did not have a built in method of returning an authentication exception if incorrect credentials were provided.  It would raise ValueError: Router prompt not found: 'User:' is misleading if the issue is due to an incorrect login credentials.  This will now return an exception only if the password prompt occurs but then returns back to the user prompt.