### PR TITLE
Huawei fix save confirm issue

### DIFF
--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -213,9 +213,9 @@ class CiscoBaseConnection(BaseConnection):
         """Saves Config."""
         self.enable()
         if confirm:
-            output = self.send_command_timing(command_string=cmd)
+            output = self.send_command_timing(command_string=cmd, strip_prompt=False, strip_command=False)
             if confirm_response:
-                output += self.send_command_timing(confirm_response)
+                output += self.send_command_timing(confirm_response, strip_prompt=False, strip_command=False)
             else:
                 # Send enter by default
                 output += self.send_command_timing(self.RETURN)

--- a/netmiko/huawei/huawei_ssh.py
+++ b/netmiko/huawei/huawei_ssh.py
@@ -83,9 +83,11 @@ class HuaweiSSH(CiscoSSHConnection):
 
         return self.base_prompt
 
-    def save_config(self, cmd="save", confirm=False, confirm_response=""):
+    def save_config(self, cmd="save", confirm=True, confirm_response="y"):
         """ Save Config for HuaweiSSH"""
-        return super(HuaweiSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(HuaweiSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
 
 
 class HuaweiVrpv8SSH(HuaweiSSH):


### PR DESCRIPTION
Huawei prompts as follows on save:

```
<HOSTNAME>save
 Warning: The current configuration will be written to the device. 
 Are you sure to continue?[Y/N]:Y
  It will take several minutes to save configuration file, please wait.........
  Configuration file had been saved successfully
  Note: The configuration file will take effect after being activated
<HOSTNAME>
```

Note, some huawei devices prompt using lower-case 'y/n'