### PR TITLE
Ruckus FastIron/ICX telnet truncation fix

### DIFF
--- a/netmiko/ruckus/ruckus_fastiron.py
+++ b/netmiko/ruckus/ruckus_fastiron.py
@@ -57,7 +57,7 @@ class RuckusFastironBase(CiscoSSHConnection):
             )
             raise ValueError(msg)
 
-    def save_config(self, cmd="write mem", confirm=False):
+    def save_config(self, cmd="write mem", confirm=False, confirm_response=""):
         """Saves configuration."""
         return super(RuckusFastironBase, self).save_config(cmd=cmd, confirm=confirm)
 

--- a/netmiko/ruckus/ruckus_fastiron.py
+++ b/netmiko/ruckus/ruckus_fastiron.py
@@ -68,6 +68,27 @@ class RuckusFastironTelnet(RuckusFastironBase):
         kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
         super(RuckusFastironTelnet, self).__init__(*args, **kwargs)
 
+    def strip_command(self, command_string, output):
+        """
+        Modified strip_command for Ruckus FastIron telnet connections
+
+        :param command_string: The command string sent to the device
+        :type command_string: str
+
+        :param output: The returned output as a result of the command string sent to the device
+        :type output: str
+        """
+        backspace_char = "\x08"
+
+        # Check for line wrap (remove backspaces)
+        if backspace_char in output:
+            output = output.replace(backspace_char, "")
+            output_lines = output.split(self.RESPONSE_RETURN)
+            new_output = output_lines[1:]
+            return self.RESPONSE_RETURN.join(new_output)
+        else:
+            return output
+
 
 class RuckusFastironSSH(RuckusFastironBase):
     pass


### PR DESCRIPTION
`strip_command()` from `BaseConnection()` class doesn't need to remove the command string from `send_command()` output when connecting to Ruckus FastIron via telnet. Currently strips characters from beginning of the output even though command string is not in output.