### PR TITLE
Add generic prompt pattern for check_config_mode

### DIFF
--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -22,6 +22,16 @@ class CiscoIosBase(CiscoBaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
+    def check_config_mode(self, check_string=")#", pattern="#"):
+        """
+        Checks if the device is in configuration mode or not.
+
+        Cisco IOS devices abbreviate the prompt at 20 chars in config mode
+        """
+        return super(CiscoIosBase, self).check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
+
     def save_config(self, cmd="write mem", confirm=False):
         """Saves Config Using Copy Run Start"""
         return super(CiscoIosBase, self).save_config(cmd=cmd, confirm=confirm)

--- a/netmiko/cisco/cisco_nxos_ssh.py
+++ b/netmiko/cisco/cisco_nxos_ssh.py
@@ -23,6 +23,12 @@ class CiscoNxosSSH(CiscoSSHConnection):
         newline = re.compile(r"(\r\r\n|\r\n)")
         return newline.sub(self.RESPONSE_RETURN, a_string).replace("\r", "")
 
+    def check_config_mode(self, check_string=")#", pattern="#"):
+        """Checks if the device is in configuration mode or not."""
+        return super(CiscoNxosSSH, self).check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
+
 
 class CiscoNxosFileTransfer(CiscoFileTransfer):
     """Cisco NXOS SCP File Transfer driver."""


### PR DESCRIPTION
Somewhat analogous to changes made in #820.

By providing a simple default prompt pattern in `check_config_mode`, it can typically return much faster than when no pattern was specified. As calling `send_config_set()` results in calling `check_config_mode()` four times, this change correspondingly makes `send_config_set()` that much faster - in my testing, with simple config CLI, as much as 65% faster.