### PR TITLE
set terminal width - OneOS OneAccess

### DIFF
--- a/netmiko/oneaccess/oneaccess_oneos.py
+++ b/netmiko/oneaccess/oneaccess_oneos.py
@@ -19,6 +19,7 @@ class OneaccessOneOSBase(CiscoBaseConnection):
         self._test_channel_read()
         self.set_base_prompt()
         self.disable_paging(command="term len 0")
+        self.set_terminal_width(command="stty columns 255")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()


### PR DESCRIPTION
Include terminal width setting for OneOS Oneaccess.


(venv) mwallraf@camelus:~/netmiko/oneaccess/netmiko/tests$ bash test_oneaccess_oneos.sh
Starting tests...good luck:
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.5.3, pytest-2.9.1, py-1.7.0, pluggy-0.3.1 -- /home/mwallraf/netmiko/venv/bin/python3.5
cachedir: ../.cache
rootdir: /home/mwallraf/netmiko/oneaccess/netmiko, inifile:
plugins: pylama-7.4.3
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

========================================================================================= 12 passed in 35.28 seconds ==========================================================================================
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.5.3, pytest-2.9.1, py-1.7.0, pluggy-0.3.1 -- /home/mwallraf/netmiko/venv/bin/python3.5
cachedir: ../.cache
rootdir: /home/mwallraf/netmiko/oneaccess/netmiko, inifile:
plugins: pylama-7.4.3
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

========================================================================================== 7 passed in 51.02 seconds ==========================================================================================
(venv) mwallraf@camelus:~/netmiko/oneaccess/netmiko/tests$
(venv) mwallraf@camelus:~/netmiko/oneaccess/netmiko/tests$
(venv) mwallraf@camelus:~/netmiko/oneaccess/netmiko/tests$
(venv) mwallraf@camelus:~/netmiko/oneaccess/netmiko/tests$ bash test_oneaccess_oneos_telnet.sh
Starting tests...good luck:
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.5.3, pytest-2.9.1, py-1.7.0, pluggy-0.3.1 -- /home/mwallraf/netmiko/venv/bin/python3.5
cachedir: ../.cache
rootdir: /home/mwallraf/netmiko/oneaccess/netmiko, inifile:
plugins: pylama-7.4.3
collected 12 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_expect PASSED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED

========================================================================================= 12 passed in 42.31 seconds ==========================================================================================
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.5.3, pytest-2.9.1, py-1.7.0, pluggy-0.3.1 -- /home/mwallraf/netmiko/venv/bin/python3.5
cachedir: ../.cache
rootdir: /home/mwallraf/netmiko/oneaccess/netmiko, inifile:
plugins: pylama-7.4.3
collected 7 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode PASSED
test_netmiko_config.py::test_exit_config_mode PASSED
test_netmiko_config.py::test_command_set PASSED
test_netmiko_config.py::test_commands_from_file PASSED
test_netmiko_config.py::test_disconnect PASSED

========================================================================================== 7 passed in 57.52 seconds ==========================================================================================