### PR TITLE
Allow support for Cisco WLC/AireOS grep include command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Python 2.7, 3.5, 3.6
 - Alcatel AOS6/AOS8
 - Apresia Systems AEOS
 - Calix B6
-- Cisco WLC
+- Cisco AireOS (Wireless LAN Controllers)
 - Dell OS9 (Force10)
 - Dell OS10
 - Dell PowerConnect

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -57,7 +57,7 @@ class CiscoWlcSSH(BaseConnection):
         kwargs["delay_factor"] = self.select_delay_factor(delay_factor)
         output = self.send_command_timing(*args, **kwargs)
 
-        if 'Press any key' in output or 'Press Enter to' in output:
+        if "Press any key" in output or "Press Enter to" in output:
             new_args = list(args)
             if len(args) == 1:
                 new_args[0] = self.RETURN

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -57,7 +57,7 @@ class CiscoWlcSSH(BaseConnection):
         kwargs["delay_factor"] = self.select_delay_factor(delay_factor)
         output = self.send_command_timing(*args, **kwargs)
 
-        if "Press Enter to" in output:
+        if 'Press any key' in output or 'Press Enter to' in output:
             new_args = list(args)
             if len(args) == 1:
                 new_args[0] = self.RETURN


### PR DESCRIPTION
This should allow the `grep include "<regex>" "<command>"` command in aireOS CLI on Cisco WLCs while using `send_command_w_enter`
Previously netmiko would hang and wait here.

Also recommending Cisco WLC be renamed to Cisco AireOS since Cisco has released the 9800 WLC line which is running IOS-XE