### PR TITLE
Add a config command rate-limiter

### DIFF
--- a/netmiko/arbiter.py
+++ b/netmiko/arbiter.py
@@ -1,5 +1,3 @@
-
-
 class CommandBufferArbiter:
     """
     Acts as a send command rate limiter that maintains the “command buffer” at bucket_size number of commands.
@@ -30,7 +28,7 @@ class CommandBufferArbiter:
         # lines that have yet to be checked for prompts
         self.pending_lines = []
         # The current line that has not yet been completed with a terminating EOL
-        self.incomplete_line = ''
+        self.incomplete_line = ""
 
     def get_token(self, output):
         """
@@ -83,28 +81,27 @@ class CommandBufferArbiter:
 
         :return: str all of the processed output
         """
-        completed_and_pending_lines = "\n".join(self.completed_lines + self.pending_lines)
-        return "{}\n{}".format(
-            completed_and_pending_lines,
-            self.incomplete_line
+        completed_and_pending_lines = "\n".join(
+            self.completed_lines + self.pending_lines
         )
+        return "{}\n{}".format(completed_and_pending_lines, self.incomplete_line)
 
     def _process_output(self, output):
         log.debug("Arbiter ingest output:\n%s", output)
         output_lines = output.splitlines()
 
         # If the output starts with a new line, close out the incomplete line
-        if output.startswith('\n'):
+        if output.startswith("\n"):
             output_lines.insert(0, self.incomplete_line)
-            self.incomplete_line = ''
+            self.incomplete_line = ""
 
         if output_lines:
             # Concatenate the incomplete line with the first line in the output
             output_lines[0] = self.incomplete_line + output_lines[0]
-            self.incomplete_line = ''
+            self.incomplete_line = ""
 
             # Consider the last line incomplete if the output does not end with a new line
-            if not output.endswith('\n'):
+            if not output.endswith("\n"):
                 self.incomplete_line = output_lines.pop()
 
         self.pending_lines.extend(output_lines)
@@ -125,7 +122,7 @@ class CommandBufferArbiter:
             log.debug("Arbiter found prompt in incomplete_line")
             self._acknowledge_command()
             self.completed_lines.append(self.incomplete_line)
-            self.incomplete_line = ''
+            self.incomplete_line = ""
 
     def _process_timer(self):
         # If our timer has expired, acknowledge one command

--- a/netmiko/arbiter.py
+++ b/netmiko/arbiter.py
@@ -4,10 +4,10 @@ from netmiko import log
 
 class CommandBufferArbiter:
     """
-    Acts as a send command rate limiter that maintains the “command buffer” at bucket_size number
+    Acts as a send command rate limiter that maintains the command buffer at bucket_size number
     of commands. It would allow sending of bucket_size commands, when it sees X prompts come back,
-    it allows another X command(s). If it doesn’t see a prompt come back in some time, it figures
-    “I must have missed it” and sends another command. This continues until the config set is
+    it allows another X command(s). If it does not see a prompt come back in some time, it figures
+    it must have missed it and sends another command. This continues until the config set is
     depleted.
     """
 
@@ -15,7 +15,7 @@ class CommandBufferArbiter:
         """
         :param connection: Connection object
 
-        :param bucket_size: Number of commands that can be executed without acknowledging the prompt
+        :param bucket_size: Number of commands that can be sent without acknowledging the prompt
         :type bucket_size: int
 
         :param timeout: Seconds before it expires an unacknowledged_command

--- a/netmiko/arbiter.py
+++ b/netmiko/arbiter.py
@@ -1,0 +1,140 @@
+
+
+class CommandBufferArbiter:
+    """
+    Acts as a send command rate limiter that maintains the “command buffer” at bucket_size number of commands.
+    It would allow sending of bucket_size commands, when it sees X prompts come back, it allows another X command(s).
+    If it doesn’t see a prompt come back in some time, it figures “I must have missed it” and sends another command.
+    This continues until the config set is depleted.
+    """
+
+    def __init__(self, connection, bucket_size=10, timeout=10):
+        """
+        :param connection: Connection object
+
+        :param bucket_size: The number of commands that can be executed without acknowledging the prompt
+        :type bucket_size: int
+
+        :param timeout: The amount of seconds before giving up looking for the prompt and allow another command to be sent
+        :type timeout: int
+        """
+        self.connection = connection
+        self.bucket_size = bucket_size
+        self.timeout = timeout
+
+        self.unacknowledged_commands = 0
+        self.timer = None
+
+        # lines that have already been checked for prompts
+        self.completed_lines = []
+        # lines that have yet to be checked for prompts
+        self.pending_lines = []
+        # The current line that has not yet been completed with a terminating EOL
+        self.incomplete_line = ''
+
+    def get_token(self, output):
+        """
+        Get permission from the Arbiter to send one command
+
+        :param output: Connection.read_channel() would be directed here
+        :type output: str
+
+        :return: boolean - if a command can be sent
+        """
+        self.timer = time.time()
+
+        self._process_output(output)
+
+        log.debug(
+            "Arbiter completed_lines: %s, pending_lines: %s, incomplete_line: %s, unacknowledged_commands: %s",
+            len(self.completed_lines),
+            len(self.pending_lines),
+            self.incomplete_line,
+            self.unacknowledged_commands,
+        )
+
+        if self.unacknowledged_commands < self.bucket_size:
+            self.unacknowledged_commands += 1
+            log.debug("Arbiter granted token")
+            return True
+
+        return False
+
+    def is_done(self, output):
+        """
+        Process a batch of output and return True when the Arbiter appears done
+
+        :param output: Connection.read_channel() would be directed here
+        :type output: str
+
+        :return: boolean True when the Arbiter appears done
+        """
+        self._process_output(output)
+        log.debug(
+            "Arbiter checking if done - unacknowledged_commands: %s",
+            self.unacknowledged_commands,
+            self.incomplete_line,
+        )
+        return not bool(self.unacknowledged_commands)
+
+    def all_output(self):
+        """
+        Builds a string containing all of the processed output
+
+        :return: str all of the processed output
+        """
+        completed_and_pending_lines = "\n".join(self.completed_lines + self.pending_lines)
+        return "{}\n{}".format(
+            completed_and_pending_lines,
+            self.incomplete_line
+        )
+
+    def _process_output(self, output):
+        log.debug("Arbiter ingest output:\n%s", output)
+        output_lines = output.splitlines()
+
+        # If the output starts with a new line, close out the incomplete line
+        if output.startswith('\n'):
+            output_lines.insert(0, self.incomplete_line)
+            self.incomplete_line = ''
+
+        if output_lines:
+            # Concatenate the incomplete line with the first line in the output
+            output_lines[0] = self.incomplete_line + output_lines[0]
+            self.incomplete_line = ''
+
+            # Consider the last line incomplete if the output does not end with a new line
+            if not output.endswith('\n'):
+                self.incomplete_line = output_lines.pop()
+
+        self.pending_lines.extend(output_lines)
+
+        self._count_prompts()
+        self._process_timer()
+
+    def _count_prompts(self):
+        while self.pending_lines:
+            line = self.pending_lines.pop(0)
+            # for every prompt we see, reset the timer, subtract from unacknowledged_commands
+            if self.connection.line_has_prompt(line):
+                self._acknowledge_command()
+            self.completed_lines.append(line)
+
+        # If self.incomplete_line contains a prompt
+        if self.connection.line_has_prompt(self.incomplete_line):
+            log.debug("Arbiter found prompt in incomplete_line")
+            self._acknowledge_command()
+            self.completed_lines.append(self.incomplete_line)
+            self.incomplete_line = ''
+
+    def _process_timer(self):
+        # If our timer has expired, acknowledge one command
+        if time.time() - self.timer > self.timeout:
+            if self.unacknowledged_commands:
+                log.warning("Arbiter expiring an unacknowledged_command")
+                self._acknowledge_command()
+            self.timer = time.time()
+
+    def _acknowledge_command(self):
+        self.unacknowledged_commands -= min(1, self.unacknowledged_commands)
+        self.timer = time.time()

--- a/netmiko/arbiter.py
+++ b/netmiko/arbiter.py
@@ -1,19 +1,24 @@
+import time
+from netmiko import log
+
+
 class CommandBufferArbiter:
     """
-    Acts as a send command rate limiter that maintains the “command buffer” at bucket_size number of commands.
-    It would allow sending of bucket_size commands, when it sees X prompts come back, it allows another X command(s).
-    If it doesn’t see a prompt come back in some time, it figures “I must have missed it” and sends another command.
-    This continues until the config set is depleted.
+    Acts as a send command rate limiter that maintains the “command buffer” at bucket_size number
+    of commands. It would allow sending of bucket_size commands, when it sees X prompts come back,
+    it allows another X command(s). If it doesn’t see a prompt come back in some time, it figures
+    “I must have missed it” and sends another command. This continues until the config set is
+    depleted.
     """
 
     def __init__(self, connection, bucket_size=10, timeout=10):
         """
         :param connection: Connection object
 
-        :param bucket_size: The number of commands that can be executed without acknowledging the prompt
+        :param bucket_size: Number of commands that can be executed without acknowledging the prompt
         :type bucket_size: int
 
-        :param timeout: The amount of seconds before giving up looking for the prompt and allow another command to be sent
+        :param timeout: Seconds before it expires an unacknowledged_command
         :type timeout: int
         """
         self.connection = connection
@@ -44,7 +49,7 @@ class CommandBufferArbiter:
         self._process_output(output)
 
         log.debug(
-            "Arbiter completed_lines: %s, pending_lines: %s, incomplete_line: %s, unacknowledged_commands: %s",
+            "Arbiter completed/pending/incomplete_lines: %s/%s/%s, unacknowledged_commands: %s",
             len(self.completed_lines),
             len(self.pending_lines),
             self.incomplete_line,

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -30,6 +30,7 @@ from netmiko.ssh_exception import (
     NetMikoAuthenticationException,
 )
 from netmiko.utilities import write_bytes, check_serial_port, get_structured_data
+from netmiko.arbiter import CommandBufferArbiter
 
 
 class BaseConnection(object):

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1567,8 +1567,15 @@ class BaseConnection(object):
         log.debug("{}".format(output))
         return output
 
-    def send_config_set_with_arbiter(self, config_commands=None, exit_config_mode=True, delay_factor=1,
-                                     config_mode_command=None, bucket_size=10, timeout=10):
+    def send_config_set_with_arbiter(
+        self,
+        config_commands=None,
+        exit_config_mode=True,
+        delay_factor=1,
+        config_mode_command=None,
+        bucket_size=10,
+        timeout=10,
+    ):
         """
         Send configuration commands down the SSH channel using a rate-limiter to control
         how quickly to send commands.
@@ -1603,23 +1610,19 @@ class BaseConnection(object):
 
         delay_factor = self.select_delay_factor(delay_factor)
         if config_commands is None:
-            return ''
+            return ""
 
         if isinstance(config_commands, string_types):
             config_commands = (config_commands,)
 
-        if not hasattr(config_commands, '__iter__'):
+        if not hasattr(config_commands, "__iter__"):
             raise ValueError("Invalid argument passed into send_config_set")
 
         # Send config commands
         cfg_mode_args = (config_mode_command,) if config_mode_command else tuple()
         output = self.config_mode(*cfg_mode_args)
 
-        cba = CommandBufferArbiter(
-            self,
-            bucket_size=bucket_size,
-            timeout=timeout,
-        )
+        cba = CommandBufferArbiter(self, bucket_size=bucket_size, timeout=timeout)
 
         for command in config_commands:
             while not cba.get_token(self._sanitize_output(self.read_channel())):

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1601,10 +1601,10 @@ class BaseConnection(object):
         :param config_mode_command: The command to enter into config mode
         :type config_mode_command: str
 
-        :param bucket_size: The number of commands that can be executed without acknowledging the prompt
+        :param bucket_size: Number of commands that can be sent without acknowledging the prompt
         :type bucket_size: int
 
-        :param timeout: The amount of seconds before giving up looking for the prompt and allow another command to be sent
+        :param timeout: Seconds before it expires an unacknowledged_command
         :type timeout: int
         """
         from netmiko.py23_compat import string_types

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -224,6 +224,12 @@ class CiscoBaseConnection(BaseConnection):
             output = self.send_command(command_string=cmd)
         return output
 
+    def line_has_prompt(self, line):
+        log.debug("Arbiter - looking for %s at the start of %s", self.base_prompt[:16], line)
+        if line.startswith(self.base_prompt[:16]):
+            return True
+        return False
+
 
 class CiscoSSHConnection(CiscoBaseConnection):
     pass

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -225,7 +225,9 @@ class CiscoBaseConnection(BaseConnection):
         return output
 
     def line_has_prompt(self, line):
-        log.debug("Arbiter - looking for %s at the start of %s", self.base_prompt[:16], line)
+        log.debug(
+            "Arbiter - looking for %s at the start of %s", self.base_prompt[:16], line
+        )
         if line.startswith(self.base_prompt[:16]):
             return True
         return False

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from netmiko.base_connection import BaseConnection
 from netmiko.scp_handler import BaseFileTransfer
 from netmiko.ssh_exception import NetMikoAuthenticationException
+from netmiko import log
 import re
 import time
 

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -1,0 +1,23 @@
+
+
+def test_arbiter():
+    from netmiko.arbiter import CommandBufferArbiter
+
+    cba = CommandBufferArbiter(
+        FakeConnection(),
+        bucket_size=10,
+    )
+
+    for _ in range(cba.bucket_size):
+        assert cba.get_token('') is True
+    assert cba.get_token('') is False
+    assert cba.get_token('prompt') is True
+    assert cba.get_token('') is False
+
+    assert cba.all_output() == "prompt\n"
+
+
+class FakeConnection:
+    @staticmethod
+    def line_has_prompt(line):
+        return True if line == 'prompt' else False

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -1,18 +1,13 @@
-
-
 def test_arbiter():
     from netmiko.arbiter import CommandBufferArbiter
 
-    cba = CommandBufferArbiter(
-        FakeConnection(),
-        bucket_size=10,
-    )
+    cba = CommandBufferArbiter(FakeConnection(), bucket_size=10)
 
     for _ in range(cba.bucket_size):
-        assert cba.get_token('') is True
-    assert cba.get_token('') is False
-    assert cba.get_token('prompt') is True
-    assert cba.get_token('') is False
+        assert cba.get_token("") is True
+    assert cba.get_token("") is False
+    assert cba.get_token("prompt") is True
+    assert cba.get_token("") is False
 
     assert cba.all_output() == "prompt\n"
 
@@ -20,4 +15,4 @@ def test_arbiter():
 class FakeConnection:
     @staticmethod
     def line_has_prompt(line):
-        return True if line == 'prompt' else False
+        return True if line == "prompt" else False


### PR DESCRIPTION
Rate-limits commands sent on the channel based on prompts seen.

Arbiter is a send command rate limiter that maintains the command buffer at `bucket_size` number of commands. It would allow sending of bucket_size commands, when it sees X prompts come back, it allows another X command(s). If it doesn’t see a prompt come back in some time, it figures “I must have missed it” and sends another command. This continues until the config set is depleted.

ref #1058

Recent relevant article: https://blog.ipspace.net/2019/01/not-so-fast-ansible-cisco-ios-cant-keep.html  
