### PR TITLE
Add FastIron to SSH Autodetect #1076

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -151,9 +151,15 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
-    "brocade": {
+    "brocade_netiron": {
         "cmd": "show version",
-        "search_patterns": [r"Brocade Communications Systems"],
+        "search_patterns": [r"NetIron"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "extreme_slx": {
+        "cmd": "show version",
+        "search_patterns": [r"SLX-OS Operating System Software"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -157,6 +157,12 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "brocade_fastiron": {
+        "cmd": "show version",
+        "search_patterns": [r"FGS"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "extreme_slx": {
         "cmd": "show version",
         "search_patterns": [r"SLX-OS Operating System Software"],

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -140,6 +140,7 @@ SSH_MAPPER_BASE = {
             r"JUNOS Software Release",
             r"JUNOS .+ Software",
             r"JUNOS OS Kernel",
+            r"JUNOS Base Version",
         ],
         "priority": 99,
         "dispatch": "_autodetect_std",
@@ -147,6 +148,14 @@ SSH_MAPPER_BASE = {
     "linux": {
         "cmd": "uname -a",
         "search_patterns": [r"Linux"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "brocade": {
+        "cmd": "show version",
+        "search_patterns": [
+            r"Brocade Communications Systems",
+        ],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -153,9 +153,7 @@ SSH_MAPPER_BASE = {
     },
     "brocade": {
         "cmd": "show version",
-        "search_patterns": [
-            r"Brocade Communications Systems",
-        ],
+        "search_patterns": [r"Brocade Communications Systems"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Adding another option to the SSH Autodetect. Unfortunately there's not much to go on for the old FastIron platform we have. Matching on "FGS" will get this particular model but there seemed to be nothing else I could find that would differentiate this from any other router. 