### PR TITLE
added the ability to login to a ios device that has enable mode  from…

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -243,6 +243,10 @@ class BaseConnection(object):
 
             self._modify_connection_params()
             self.establish_connection()
+
+            #clears the line when trying to enter enable mode from console server
+            self.write_channel("\r")
+                
             self.session_preparation()
 
     def __enter__(self):


### PR DESCRIPTION
Currently, there will be a timeout when trying too login to a device (ios) with an enable password from a console server using netmiko. I am aware that using the 'terminal_server' device_type and `redispatch()` can fix this problem. However, this is an issue when using Napalm. Clearing the line before attempting to send the enable password will prevent the session from timing out.