### PR TITLE
Changing raise to use NetMikoAuthenticationExceptiom

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import time
 import re
 
+from netmiko.ssh_exception import NetMikoAuthenticationException
 from netmiko.base_connection import BaseConnection
 from netmiko.py23_compat import string_types
 from netmiko import log
@@ -104,7 +105,8 @@ class CiscoWlcSSH(BaseConnection):
         try:
             self.set_base_prompt()
         except ValueError:
-            raise ValueError("Incorrect username and/or password.")
+            msg = "Authentication failed: {}".format(self.host)
+            raise NetMikoAuthenticationException(msg)
 
         self.disable_paging(command="config paging disable")
         # Clear the read buffer


### PR DESCRIPTION
ValueError("Incorrect username and/or password.") can be misleading for WLC as they do not handle authentication well.  Being more generic accounts for un/pw issues, authentication fail (AAA) and max password length (25 characters) would be more accurate and using the predefined exceptions netlike exceptions.