### PR TITLE
Add Mellanox MLNX-OS Switch support

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -100,7 +100,12 @@ class CiscoWlcSSH(BaseConnection):
         Cisco WLC uses "config paging disable" to disable paging
         """
         self._test_channel_read()
-        self.set_base_prompt()
+
+        try:
+            self.set_base_prompt()
+        except ValueError:
+            raise ValueError("Incorrect username and/or password.")
+
         self.disable_paging(command="config paging disable")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)

--- a/netmiko/mellanox/__init__.py
+++ b/netmiko/mellanox/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
 from netmiko.mellanox.mellanox_ssh import MellanoxSSH
+from netmiko.mellanox.mellanox__mlnxos_ssh import MellanoxMlnxosSSH
 
-__all__ = ["MellanoxSSH"]
+__all__ = ["MellanoxSSH", "MellanoxMlnxosSSH"]

--- a/netmiko/mellanox/mellanox__mlnxos_ssh.py
+++ b/netmiko/mellanox/mellanox__mlnxos_ssh.py
@@ -1,0 +1,97 @@
+# Copyright 2019 IBM Corp
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Mellanox MLNX-OS Switch support."""
+from __future__ import unicode_literals
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko import log
+import time
+
+
+class MellanoxMlnxosSSH(CiscoSSHConnection):
+    """Mellanox MLNX-OS Switch support."""
+
+    def check_enable_mode(self, check_string="#"):
+        """Check if in enable mode. Return boolean."""
+        return super(MellanoxMlnxosSSH, self).check_enable_mode(
+            check_string=check_string
+        )
+
+    def enable(self, ena_cmd="enable", pattern="#"):
+        """Enter into enable mode."""
+        output = ""
+        if not self.check_enable_mode():
+            self.write_channel(self.normalize_cmd(ena_cmd))
+            output = self.read_until_pattern(pattern=pattern)
+            if not self.check_enable_mode():
+                raise ValueError("Failed to enter enable mode.")
+        return output
+
+    def exit_enable_mode(self, exit_command="disable"):
+        """Exits enable (privileged exec) mode."""
+        return super(MellanoxMlnxosSSH, self).exit_enable_mode(
+            exit_command=exit_command
+        )
+
+    def config_mode(self, config_command="config term", pattern="#"):
+        """Enter into config_mode."""
+        output = ""
+        if not self.check_config_mode():
+            self.write_channel(self.normalize_cmd(config_command))
+            output = self.read_until_pattern(pattern=pattern)
+            if not self.check_config_mode():
+                raise ValueError("Failed to enter configuration mode.")
+        return output
+
+    def check_config_mode(self, check_string="(config", pattern=r"#"):
+        return super(MellanoxMlnxosSSH, self).check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
+
+    def disable_paging(self, command="terminal length 999", delay_factor=1):
+        """Disable paging default to a Cisco CLI method."""
+        delay_factor = self.select_delay_factor(delay_factor)
+        time.sleep(delay_factor * 0.1)
+        self.clear_buffer()
+        command = self.normalize_cmd(command)
+        log.debug("In disable_paging")
+        log.debug("Command: {0}".format(command))
+        self.write_channel(command)
+        output = self.read_until_prompt()
+        if self.ansi_escape_codes:
+            output = self.strip_ansi_escape_codes(output)
+        log.debug("{0}".format(output))
+        log.debug("Exiting disable_paging")
+        return output
+
+    def exit_config_mode(self, exit_config="exit", pattern="#"):
+        """Exit from configuration mode."""
+        output = ""
+        if self.check_config_mode():
+            self.write_channel(self.normalize_cmd(exit_config))
+            output = self.read_until_pattern(pattern=pattern)
+            if not self.check_enable_mode():
+                raise ValueError("Failed to exit configuration mode")
+        log.debug("exit_config_mode: {0}".format(output))
+        return output
+
+    def save_config(
+        self, cmd="configuration write", confirm=False, confirm_response=""
+    ):
+        """Save Config on Mellanox devices Enters and Leaves Config Mode"""
+        output = self.enable()
+        output += self.config_mode()
+        output += self.send_command(cmd)
+        output += self.exit_config_mode()
+        return output

--- a/netmiko/mellanox/mellanox__mlnxos_ssh.py
+++ b/netmiko/mellanox/mellanox__mlnxos_ssh.py
@@ -1,17 +1,3 @@
-# Copyright 2019 IBM Corp
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 """Mellanox MLNX-OS Switch support."""
 from __future__ import unicode_literals
 from netmiko.cisco_base_connection import CiscoSSHConnection

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -70,6 +70,7 @@ from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.vyos import VyOSSSH
 from netmiko.oneaccess import OneaccessOneOSTelnet, OneaccessOneOSSSH
+from netmiko.mellanox import MellanoxMlnxosSSH
 
 
 # The keys of this dictionary are the supported device_types
@@ -146,6 +147,7 @@ CLASS_MAPPER_BASE = {
     "vyatta_vyos": VyOSSSH,
     "vyos": VyOSSSH,
     "oneaccess_oneos": OneaccessOneOSSSH,
+    "mellanox_mlnxos": MellanoxMlnxosSSH,
 }
 
 FILE_TRANSFER_MAP = {

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -74,7 +74,6 @@ from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.vyos import VyOSSSH
-from netmiko.oneaccess import OneaccessOneOSTelnet, OneaccessOneOSSSH
 from netmiko.mellanox import MellanoxMlnxosSSH
 
 


### PR DESCRIPTION
The original content of netmiko/mellanox was not working with Mellanox MLNX-OS based switches, like SX1410, SX1700. I guess the original code is for the older devices.
I tested what I made here from OpenStack's networking-generic-switch Neutron plugin.