### PR TITLE
Update file_md5 function of scp_handler.py

### DIFF
--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -254,10 +254,11 @@ class BaseFileTransfer(object):
 
     def file_md5(self, file_name):
         """Compute MD5 hash of file."""
+        md5_hash = hashlib.md5()
         with open(file_name, "rb") as f:
-            file_contents = f.read()
-            file_hash = hashlib.md5(file_contents).hexdigest()
-        return file_hash
+            for byte_block in iter(lambda: f.read(4096),b""):
+                md5_hash.update(byte_block)
+        return md5_hash.hexdigest()
 
     @staticmethod
     def process_md5(md5_output, pattern=r"=\s+(\S+)"):


### PR DESCRIPTION
file_md5 function throwing a Memory Error when reading +400MB files concurrently.  This change improves handling of large files.

Details:
This is my first ever github contribution.  I'm using normir to push ios files to cisco ISR4000 routers.  When normir calls netmiko_file_transfer multiple times in parallel, the IOS file on my machine ends up getting md5 summed in parallel too.  Changes allowed 10 md5sums of the same file in parallel.  (I did not test higher numbers of parallel jobs but it was failing at 2 parallel jobs before making the change.)