### PR TITLE
Use class instead of instance for key policies

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -291,9 +291,9 @@ class BaseConnection(object):
             self.protocol = "ssh"
 
             if not ssh_strict:
-                self.key_policy = paramiko.AutoAddPolicy()
+                self.key_policy = paramiko.AutoAddPolicy
             else:
-                self.key_policy = paramiko.RejectPolicy()
+                self.key_policy = paramiko.RejectPolicy
 
             # Options for SSH host_keys
             self.use_keys = use_keys


### PR DESCRIPTION
It turns out that using the instance does not work as expected
(sometimes).

According to the current docs, both instance or class are accepted, but
it seems to behave differently when using one or the other:

http://docs.paramiko.org/en/2.4/api/client.html?highlight=Policy#paramiko.client.SSHClient.set_missing_host_key_policy