### PR TITLE
Update save_config method params.

### DIFF
--- a/netmiko/alcatel/alcatel_aos_ssh.py
+++ b/netmiko/alcatel/alcatel_aos_ssh.py
@@ -40,6 +40,10 @@ class AlcatelAosSSH(CiscoSSHConnection):
         """No config mode on AOS"""
         return ""
 
-    def save_config(self, cmd="write memory flash-synchro", confirm=False):
+    def save_config(
+        self, cmd="write memory flash-synchro", confirm=False, confirm_response=""
+    ):
         """Save Config"""
-        return super(AlcatelAosSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(AlcatelAosSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/calix/calix_b6.py
+++ b/netmiko/calix/calix_b6.py
@@ -65,8 +65,10 @@ class CalixB6Base(CiscoSSHConnection):
         """Checks if the device is in configuration mode"""
         return super(CalixB6Base, self).check_config_mode(check_string=check_string)
 
-    def save_config(self, cmd="copy run start", confirm=False):
-        return super(CalixB6Base, self).save_config(cmd=cmd, confirm=confirm)
+    def save_config(self, cmd="copy run start", confirm=False, confirm_response=""):
+        return super(CalixB6Base, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class CalixB6SSH(CalixB6Base):

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -110,9 +110,11 @@ class CiscoAsaSSH(CiscoSSHConnection):
                 self.write_channel("login" + self.RETURN)
             i += 1
 
-    def save_config(self, cmd="write mem", confirm=False):
+    def save_config(self, cmd="write mem", confirm=False, confirm_response=""):
         """Saves Config"""
-        return super(CiscoAsaSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(CiscoAsaSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class CiscoAsaFileTransfer(CiscoFileTransfer):

--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -32,9 +32,11 @@ class CiscoIosBase(CiscoBaseConnection):
             check_string=check_string, pattern=pattern
         )
 
-    def save_config(self, cmd="write mem", confirm=False):
+    def save_config(self, cmd="write mem", confirm=False, confirm_response=""):
         """Saves Config Using Copy Run Start"""
-        return super(CiscoIosBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(CiscoIosBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class CiscoIosSSH(CiscoIosBase):

--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -18,10 +18,15 @@ class DellDNOS6Base(DellPowerConnectBase):
         self.clear_buffer()
 
     def save_config(
-        self, cmd="copy running-configuration startup-configuration", confirm=False
+        self,
+        cmd="copy running-configuration startup-configuration",
+        confirm=False,
+        confirm_response="",
     ):
         """Saves Config"""
-        return super(DellDNOS6SSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(DellDNOS6SSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class DellDNOS6SSH(DellDNOS6Base):

--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -24,7 +24,7 @@ class DellDNOS6Base(DellPowerConnectBase):
         confirm_response="",
     ):
         """Saves Config"""
-        return super(DellDNOS6SSH, self).save_config(
+        return super(DellDNOS6Base, self).save_config(
             cmd=cmd, confirm=confirm, confirm_response=""
         )
 

--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -24,7 +24,7 @@ class DellDNOS6Base(DellPowerConnectBase):
         confirm_response="",
     ):
         """Saves Config"""
-        return super(DellDNOS6Base, self).save_config(
+        return super(DellDNOS6SSH, self).save_config(
             cmd=cmd, confirm=confirm, confirm_response=""
         )
 

--- a/netmiko/dell/dell_force10_ssh.py
+++ b/netmiko/dell/dell_force10_ssh.py
@@ -7,7 +7,12 @@ class DellForce10SSH(CiscoSSHConnection):
     """Dell Force10 Driver - supports DNOS9."""
 
     def save_config(
-        self, cmd="copy running-configuration startup-configuration", confirm=False
+        self,
+        cmd="copy running-configuration startup-configuration",
+        confirm=False,
+        confirm_response="",
     ):
         """Saves Config"""
-        return super(DellForce10SSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(DellForce10SSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/dell/dell_os10_ssh.py
+++ b/netmiko/dell/dell_os10_ssh.py
@@ -10,10 +10,15 @@ class DellOS10SSH(CiscoSSHConnection):
     """Dell EMC Networking OS10 Driver - supports dellos10."""
 
     def save_config(
-        self, cmd="copy running-configuration startup-configuration", confirm=False
+        self,
+        cmd="copy running-configuration startup-configuration",
+        confirm=False,
+        confirm_response="",
     ):
         """Saves Config"""
-        return super(DellOS10SSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(DellOS10SSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class DellOS10FileTransfer(BaseFileTransfer):

--- a/netmiko/extreme/extreme_ers_ssh.py
+++ b/netmiko/extreme/extreme_ers_ssh.py
@@ -38,6 +38,8 @@ class ExtremeErsSSH(CiscoSSHConnection):
                 time.sleep(1 * delay_factor)
             i += 1
 
-    def save_config(self, cmd="save config", confirm=False):
+    def save_config(self, cmd="save config", confirm=False, confirm_response=""):
         """Save Config"""
-        return super(ExtremeErsSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(ExtremeErsSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/extreme/extreme_exos.py
+++ b/netmiko/extreme/extreme_exos.py
@@ -66,9 +66,13 @@ class ExtremeExosBase(CiscoSSHConnection):
         """No configuration mode on Extreme Exos."""
         return ""
 
-    def save_config(self, cmd="save configuration primary", confirm=False):
+    def save_config(
+        self, cmd="save configuration primary", confirm=False, confirm_response=""
+    ):
         """Saves configuration."""
-        return super(ExtremeExosBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(ExtremeExosBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class ExtremeExosSSH(ExtremeExosBase):

--- a/netmiko/extreme/extreme_netiron.py
+++ b/netmiko/extreme/extreme_netiron.py
@@ -3,9 +3,11 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
 class ExtremeNetironBase(CiscoSSHConnection):
-    def save_config(self, cmd="write memory", confirm=False):
+    def save_config(self, cmd="write memory", confirm=False, confirm_response=""):
         """Save Config"""
-        return super(ExtremeNetironBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(ExtremeNetironBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class ExtremeNetironSSH(ExtremeNetironBase):

--- a/netmiko/extreme/extreme_vsp_ssh.py
+++ b/netmiko/extreme/extreme_vsp_ssh.py
@@ -17,6 +17,8 @@ class ExtremeVspSSH(CiscoSSHConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def save_config(self, cmd="save config", confirm=False):
+    def save_config(self, cmd="save config", confirm=False, confirm_response=""):
         """Save Config"""
-        return super(ExtremeVspSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(ExtremeVspSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -80,9 +80,11 @@ class HPComwareBase(CiscoSSHConnection):
         """enable mode on Comware is system-view."""
         return self.check_config_mode(check_string=check_string)
 
-    def save_config(self, cmd="save force", confirm=False):
+    def save_config(self, cmd="save force", confirm=False, confirm_response=""):
         """Save Config."""
-        return super(HPComwareBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(HPComwareBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class HPComwareSSH(HPComwareBase):

--- a/netmiko/hp/hp_procurve.py
+++ b/netmiko/hp/hp_procurve.py
@@ -85,9 +85,11 @@ class HPProcurveBase(CiscoSSHConnection):
                 break
             count += 1
 
-    def save_config(self, cmd="write memory", confirm=False):
+    def save_config(self, cmd="write memory", confirm=False, confirm_response=""):
         """Save Config."""
-        return super(HPProcurveBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(HPProcurveBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class HPProcurveSSH(HPProcurveBase):

--- a/netmiko/huawei/huawei_ssh.py
+++ b/netmiko/huawei/huawei_ssh.py
@@ -85,7 +85,9 @@ class HuaweiSSH(CiscoSSHConnection):
 
     def save_config(self, cmd="save", confirm=False, confirm_response=""):
         """ Save Config for HuaweiSSH"""
-        return super(HuaweiSSH, self).save_config(cmd=cmd, confirm=confirm, confirm_response="")
+        return super(HuaweiSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class HuaweiVrpv8SSH(HuaweiSSH):

--- a/netmiko/huawei/huawei_ssh.py
+++ b/netmiko/huawei/huawei_ssh.py
@@ -85,7 +85,7 @@ class HuaweiSSH(CiscoSSHConnection):
 
     def save_config(self, cmd="save", confirm=False, confirm_response=""):
         """ Save Config for HuaweiSSH"""
-        return super(HuaweiSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(HuaweiSSH, self).save_config(cmd=cmd, confirm=confirm, confirm_response="")
 
 
 class HuaweiVrpv8SSH(HuaweiSSH):

--- a/netmiko/mrv/mrv_ssh.py
+++ b/netmiko/mrv/mrv_ssh.py
@@ -36,6 +36,8 @@ class MrvOptiswitchSSH(CiscoSSHConnection):
                 raise ValueError(msg)
         return output
 
-    def save_config(self, cmd="save config flash", confirm=False):
+    def save_config(self, cmd="save config flash", confirm=False, confirm_response=""):
         """Saves configuration."""
-        return super(MrvOptiswitchSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(MrvOptiswitchSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/oneaccess/oneaccess_oneos.py
+++ b/netmiko/oneaccess/oneaccess_oneos.py
@@ -24,9 +24,11 @@ class OneaccessOneOSBase(CiscoBaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def save_config(self, cmd="write mem", confirm=False):
+    def save_config(self, cmd="write mem", confirm=False, confirm_response=""):
         """Save config: write mem"""
-        return super(OneaccessOneOSBase, self).save_config(cmd=cmd, confirm=confirm)
+        return super(OneaccessOneOSBase, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )
 
 
 class OneaccessOneOSSSH(OneaccessOneOSBase):

--- a/netmiko/quanta/quanta_mesh_ssh.py
+++ b/netmiko/quanta/quanta_mesh_ssh.py
@@ -11,6 +11,6 @@ class QuantaMeshSSH(CiscoSSHConnection):
         """Enter configuration mode."""
         return super(QuantaMeshSSH, self).config_mode(config_command=config_command)
 
-    def save_config(self, cmd="copy running-config startup-config", confirm=False):
+    def save_config(self, cmd="copy running-config startup-config", confirm=False, confirm_response=""):
         """Saves Config"""
-        return super(QuantaMeshSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(QuantaMeshSSH, self).save_config(cmd=cmd, confirm=confirm, confirm_response="")

--- a/netmiko/quanta/quanta_mesh_ssh.py
+++ b/netmiko/quanta/quanta_mesh_ssh.py
@@ -11,6 +11,13 @@ class QuantaMeshSSH(CiscoSSHConnection):
         """Enter configuration mode."""
         return super(QuantaMeshSSH, self).config_mode(config_command=config_command)
 
-    def save_config(self, cmd="copy running-config startup-config", confirm=False, confirm_response=""):
+    def save_config(
+        self,
+        cmd="copy running-config startup-config",
+        confirm=False,
+        confirm_response="",
+    ):
         """Saves Config"""
-        return super(QuantaMeshSSH, self).save_config(cmd=cmd, confirm=confirm, confirm_response="")
+        return super(QuantaMeshSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )

--- a/netmiko/ubiquiti/edge_ssh.py
+++ b/netmiko/ubiquiti/edge_ssh.py
@@ -40,6 +40,8 @@ class UbiquitiEdgeSSH(CiscoSSHConnection):
         """Exit enable mode."""
         return super(UbiquitiEdgeSSH, self).exit_enable_mode(exit_command=exit_command)
 
-    def save_config(self, cmd="write memory", confirm=False):
+    def save_config(self, cmd="write memory", confirm=False, confirm_response=""):
         """Saves configuration."""
-        return super(UbiquitiEdgeSSH, self).save_config(cmd=cmd, confirm=confirm)
+        return super(UbiquitiEdgeSSH, self).save_config(
+            cmd=cmd, confirm=confirm, confirm_response=""
+        )


### PR DESCRIPTION
@carlniger @ktbyers 

Related to: https://github.com/nornir-automation/nornir/issues/352

Nornir's built-in Netmiko task expects Netmiko's `save_config` method to include the `confirm_response` parameter.  The decision in the aforementioned Nornir issue was to make all Netmiko network drivers have the same `save_config` method parameters.  

This PR makes that update ~~and fixes one small incorrect super parameter found while updating the method signatures.~~   I rolled back my change to the dell_dnos6 `super` method since things work fine with the way it was and I don't want to break something I don't understand.