### PR TITLE
Added special_login_handler() to HuaweiSSH to handle password change request

### DIFF
--- a/netmiko/huawei/huawei_ssh.py
+++ b/netmiko/huawei/huawei_ssh.py
@@ -87,6 +87,16 @@ class HuaweiSSH(CiscoSSHConnection):
         """ Save Config for HuaweiSSH"""
         return super(HuaweiSSH, self).save_config(cmd=cmd, confirm=confirm)
 
+    def special_login_handler(self):
+        """Handle password change request by ignoring it"""
+
+        pattern = "The password needs to be changed. Change now? [Y/N]"
+        output = self.read_until_prompt_or_pattern(re.escape(pattern))
+        if output.find(pattern) > -1:
+            self.write_channel("N\n")
+            self._read_channel_expect(pattern="N\n")
+        return output
+
 
 class HuaweiVrpv8SSH(HuaweiSSH):
     def commit(self, comment="", delay_factor=1):


### PR DESCRIPTION
In Huawei devices that have password configured for the first time (no AAA is used), the devices will always ask for password change. This PR handles this situation by ignoring (answering "`N`") when such prompt appears.

**Note**: Leaving the prompt unattended for 15 seconds, it will be ignored by the router. However, it takes much longer.