### PR TITLE
extend cisco_nxos device type to accomodate for cisco ucs

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -91,7 +91,7 @@ SSH_MAPPER_BASE = {
     },
     "cisco_nxos": {
         "cmd": "show version",
-        "search_patterns": [r"Cisco Nexus Operating System", r"NX-OS", r"Firmware Version"],
+        "search_patterns": [r"Cisco Nexus Operating System", r"NX-OS", r"Firmware Version\s*-*"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -91,7 +91,7 @@ SSH_MAPPER_BASE = {
     },
     "cisco_nxos": {
         "cmd": "show version",
-        "search_patterns": [r"Cisco Nexus Operating System", r"NX-OS"],
+        "search_patterns": [r"Cisco Nexus Operating System", r"NX-OS", r"Firmware Version"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Cisco UCS will output similar to the following to show version command: 
```

Firmware Version     
-------------------- 
2.0(6d)            

```

@ktbyers  - Show version output.