### PR TITLE
Cisco WLC User fix

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -30,7 +30,7 @@ class CiscoWlcSSH(BaseConnection):
         while i <= 12:
             output = self.read_channel()
             if output:
-                if "login as" in output or "User" in output:
+                if "login as" in output or "User:" in output:
                     self.write_channel(self.username + self.RETURN)
                 elif "Password" in output:
                     self.write_channel(self.password + self.RETURN)


### PR DESCRIPTION
Qualify prompt a bit fuller so that usernames that have "User" in the string don't fail WLC login.