### PR TITLE
Add driver for MileGate devices of vendor Keymile

### DIFF
--- a/netmiko/keymile/__init__.py
+++ b/netmiko/keymile/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+from netmiko.keymile.keymile_ssh import KeymileSSH
+from netmiko.keymile.keymile_nos_ssh import KeymileNOSSSH
+
+__all__ = ["KeymileSSH", "KeymileNOSSSH"]

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -40,6 +40,7 @@ class KeymileNOSSSH(CiscoIosBase):
 
     def _test_channel_read(self, count=40, pattern=""):
         """Try to read the channel (generally post login) verify you receive data back.
+        Addition: check for substring 'Login incorrect' in output
 
         :param count: the number of times to check the channel for data
         :type count: int
@@ -91,5 +92,6 @@ class KeymileNOSSSH(CiscoIosBase):
             raise NetMikoTimeoutException("Timed out waiting for data")
 
     def special_login_handler(self, delay_factor=1):
-        """Handler for devices like WLC, Extreme ERS that throw up characters prior to login."""
+        """Since Keymile NOS always returns 'True' on paramiko.connect() we
+        check the output for substring 'Login incorrect' after connecting"""
         self._test_channel_read(pattern=r">")

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -1,6 +1,5 @@
 import time
 import re
-import socket
 
 
 from netmiko.cisco.cisco_ios import CiscoIosBase
@@ -67,7 +66,8 @@ class KeymileNOSSSH(CiscoIosBase):
                 for line in new_data.split(self.RETURN):
                     if "Login incorrect" in line:
                         self.paramiko_cleanup()
-                        msg = "Authentication failure: unable to connect {device_type} {ip}:{port}".format(
+                        msg = "Authentication failure: unable to connect"
+                        msg += "{device_type} {ip}:{port}".format(
                             device_type=self.device_type, ip=self.host, port=self.port
                         )
                         msg += self.RETURN + "Login incorrect"

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -17,15 +17,6 @@ class KeymileNOSSSH(CiscoIosBase):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    # def check_enable_mode(self, check_string="#"):
-    #    return super(KeymileNOSSSH, self).check_enable_mode(check_string=check_string)
-
-    # def enable(self, cmd="enable"):
-    #    return super(KeymileNOSSSH, self).enable(cmd=cmd)
-
-    # def exit_enable_mode(self, exit_command="exit"):
-    #    return super(KeymileNOSSSH, self).exit_enable_mode(exit_command=exit_command)
-
     def _test_channel_read(self, count=40, pattern=""):
         """Try to read the channel (generally post login) verify you receive data back.
         Addition: check for substring 'Login incorrect' in output

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -1,4 +1,3 @@
-import re
 import time
 
 from netmiko.cisco.cisco_ios import CiscoIosBase

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -1,0 +1,35 @@
+import re
+import time
+
+from netmiko.cisco.cisco_ios import CiscoIosBase
+
+
+class KeymileNOSSSH(CiscoIosBase):
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r">")
+        self.set_base_prompt()
+        self.disable_paging()
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_config_mode(self, check_string="", pattern=""):
+        """Keymile doesn't use config mode."""
+        pass
+
+    def config_mode(self, config_command="", pattern=""):
+        """Keymile doesn't use config mode."""
+        pass
+
+    def exit_config_mode(self, exit_config="", pattern=""):
+        """Keymile doesn't use config mode."""
+        pass
+
+    def check_enable_mode(self, check_string="#"):
+        return super(KeymileNOSSSH, self).check_enable_mode(check_string=check_string)
+
+    def enable(self, cmd="enable"):
+        return super(KeymileNOSSSH, self).enable(cmd=cmd)
+
+    def exit_enable_mode(self, exit_command="exit"):
+        return super(KeymileNOSSSH, self).exit_enable_mode(exit_command=exit_command)

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -17,26 +17,14 @@ class KeymileNOSSSH(CiscoIosBase):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def check_config_mode(self, check_string="", pattern=""):
-        """Keymile doesn't use config mode."""
-        pass
+    # def check_enable_mode(self, check_string="#"):
+    #    return super(KeymileNOSSSH, self).check_enable_mode(check_string=check_string)
 
-    def config_mode(self, config_command="", pattern=""):
-        """Keymile doesn't use config mode."""
-        pass
+    # def enable(self, cmd="enable"):
+    #    return super(KeymileNOSSSH, self).enable(cmd=cmd)
 
-    def exit_config_mode(self, exit_config="", pattern=""):
-        """Keymile doesn't use config mode."""
-        pass
-
-    def check_enable_mode(self, check_string="#"):
-        return super(KeymileNOSSSH, self).check_enable_mode(check_string=check_string)
-
-    def enable(self, cmd="enable"):
-        return super(KeymileNOSSSH, self).enable(cmd=cmd)
-
-    def exit_enable_mode(self, exit_command="exit"):
-        return super(KeymileNOSSSH, self).exit_enable_mode(exit_command=exit_command)
+    # def exit_enable_mode(self, exit_command="exit"):
+    #    return super(KeymileNOSSSH, self).exit_enable_mode(exit_command=exit_command)
 
     def _test_channel_read(self, count=40, pattern=""):
         """Try to read the channel (generally post login) verify you receive data back.

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -1,6 +1,13 @@
 import time
+import re
+import socket
+
 
 from netmiko.cisco.cisco_ios import CiscoIosBase
+from netmiko.ssh_exception import (
+    NetMikoTimeoutException,
+    NetMikoAuthenticationException,
+)
 
 
 class KeymileNOSSSH(CiscoIosBase):
@@ -32,3 +39,58 @@ class KeymileNOSSSH(CiscoIosBase):
 
     def exit_enable_mode(self, exit_command="exit"):
         return super(KeymileNOSSSH, self).exit_enable_mode(exit_command=exit_command)
+
+    def _test_channel_read(self, count=40, pattern=""):
+        """Try to read the channel (generally post login) verify you receive data back.
+
+        :param count: the number of times to check the channel for data
+        :type count: int
+
+        :param pattern: Regular expression pattern used to determine end of channel read
+        :type pattern: str
+        """
+
+        def _increment_delay(main_delay, increment=1.1, maximum=8):
+            """Increment sleep time to a maximum value."""
+            main_delay = main_delay * increment
+            if main_delay >= maximum:
+                main_delay = maximum
+            return main_delay
+
+        i = 0
+        delay_factor = self.select_delay_factor(delay_factor=0)
+        main_delay = delay_factor * 0.1
+        time.sleep(main_delay * 10)
+        new_data = ""
+        while i <= count:
+            new_data += self._read_channel_timing()
+            if new_data:
+                for line in new_data.split(self.RETURN):
+                    if "Login incorrect" in line:
+                        self.paramiko_cleanup()
+                        msg = "Authentication failure: unable to connect {device_type} {ip}:{port}".format(
+                            device_type=self.device_type, ip=self.host, port=self.port
+                        )
+                        msg += self.RETURN + "Login incorrect"
+                        raise NetMikoAuthenticationException(msg)
+
+                if pattern:
+                    if re.search(pattern, new_data):
+                        break
+                else:
+                    # no pattern but data
+                    break
+            else:
+                self.write_channel(self.RETURN)
+            main_delay = _increment_delay(main_delay)
+            time.sleep(main_delay)
+            i += 1
+
+        if new_data:
+            return ""
+        else:
+            raise NetMikoTimeoutException("Timed out waiting for data")
+
+    def special_login_handler(self, delay_factor=1):
+        """Handler for devices like WLC, Extreme ERS that throw up characters prior to login."""
+        self._test_channel_read(pattern=r">")

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -13,7 +13,6 @@ from netmiko.ssh_exception import (
 class KeymileNOSSSH(CiscoIosBase):
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
-        self._test_channel_read(pattern=r">")
         self.set_base_prompt()
         self.disable_paging()
         time.sleep(0.3 * self.global_delay_factor)

--- a/netmiko/keymile/keymile_ssh.py
+++ b/netmiko/keymile/keymile_ssh.py
@@ -1,0 +1,76 @@
+import re
+import time
+
+from netmiko.ssh_exception import NetMikoTimeoutException
+from netmiko.cisco.cisco_ios import CiscoIosBase
+from netmiko import log
+
+
+class KeymileSSH(CiscoIosBase):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_enter", "\r\n")
+        return super(KeymileSSH, self).__init__(**kwargs)
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r">")
+        self.set_base_prompt()
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def disable_paging(self, *args, **kwargs):
+        """Keymile doesn't use paging."""
+        return ""
+
+    def check_config_mode(self, check_string="", pattern=""):
+        """Keymile doesn't use config mode."""
+        return False
+
+    def config_mode(self, config_command="", pattern=""):
+        """Keymile doesn't use config mode."""
+        pass
+
+    def exit_config_mode(self, exit_config="", pattern=""):
+        """Keymile doesn't use config mode."""
+        pass
+
+    def check_enable_mode(self, check_string=""):
+        """Keymile doesn't use enable mode."""
+        return False
+
+    def enable(self, cmd="", pattern="", re_flags=re.IGNORECASE):
+        """Keymile doesn't use enable mode."""
+        pass
+
+    def exit_enable_mode(self, exit_command="exit"):
+        """Keymile doesn't use enable mode."""
+        pass
+
+    def strip_prompt(self, a_string):
+        """Remove appending empty line and prompt from output"""
+        self._write_session_log(a_string)
+        a_string = a_string[:-1]
+        return super(KeymileSSH, self).strip_prompt(a_string=a_string)
+
+    def send_command(self, *args, **kwargs):
+        """make "cd /path" work"""
+        if len(args) >= 1:
+            command_string = args[0]
+        else:
+            command_string = kwargs["command_string"]
+
+        if "cd" in command_string:
+            dest = command_string.split(" ", 1)[1]
+            self.base_prompt = dest
+            kwargs["expect_string"] = dest
+
+        output = super(KeymileSSH, self).send_command(*args, **kwargs)
+        return output
+
+    def set_base_prompt(self, pri_prompt_terminator=">"):
+        """ set prompt termination  to >"""
+        prompt = super(KeymileSSH, self).set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator
+        )
+        self.base_prompt = prompt
+        return self.base_prompt

--- a/netmiko/keymile/keymile_ssh.py
+++ b/netmiko/keymile/keymile_ssh.py
@@ -1,9 +1,7 @@
 import re
 import time
 
-from netmiko.ssh_exception import NetMikoTimeoutException
 from netmiko.cisco.cisco_ios import CiscoIosBase
-from netmiko import log
 
 
 class KeymileSSH(CiscoIosBase):

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -53,6 +53,7 @@ from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH, HuaweiTelnet
 from netmiko.ipinfusion import IpInfusionOcNOSSSH, IpInfusionOcNOSTelnet
 from netmiko.juniper import JuniperSSH, JuniperTelnet
 from netmiko.juniper import JuniperFileTransfer
+from netmiko.keymile import KeymileSSH, KeymileNOSSSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
 from netmiko.mikrotik import MikrotikRouterOsSSH
 from netmiko.mikrotik import MikrotikSwitchOsSSH
@@ -134,6 +135,8 @@ CLASS_MAPPER_BASE = {
     "ipinfusion_ocnos": IpInfusionOcNOSSSH,
     "juniper": JuniperSSH,
     "juniper_junos": JuniperSSH,
+    "keymile": KeymileSSH,
+    "keymile_nos": KeymileNOSSSH,
     "linux": LinuxSSH,
     "mikrotik_routeros": MikrotikRouterOsSSH,
     "mikrotik_switchos": MikrotikSwitchOsSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -267,3 +267,10 @@ keymile_nos:
   version: "show version"
   basic: "show ip interface brief | include br328"
   extended_output: "show interface"
+  config:
+      - "log login enable"
+  config_verification: "show running-config | include log"
+  save_config_cmd: 'write memory'
+  save_config_confirm: True
+  save_config_response: '[OK]'
+

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -246,3 +246,14 @@ mikrotik_routeros:
   config_verification: '/ip upnp interfaces print'
   save_config_confirm: False
   save_config_response: ">"
+
+keymile:
+  version: "show version"
+  basic: "get /cfgm/IP_Address"
+  extended_output: "ls"   # requires paging to be disabled
+
+keymile_nos:
+  version: "show version"
+  basic: "show ip interface brief | include br328"
+  extended_output: "show interface"   # requires paging to be disabled
+

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -188,3 +188,18 @@ mikrotik_routeros:
   cmd_response_init: "Flags: X "
   cmd_response_final: "0   bridge1"
 
+keymile:
+  base_prompt: /
+  router_prompt: /> 
+  enable_prompt: /> 
+  interface_ip: 1.2.3.4
+  version_banner: "---===### CLI Release R2A21, Build 2018-12-21 ###===---"
+  multiple_line_output: "Equipment State"
+
+keymile_nos:
+  base_prompt: KDKB1251
+  router_prompt: KDKB1251> 
+  enable_prompt: KDKB1251# 
+  interface_ip: 1.2.3.5 
+  version_banner: "NOS version 2.09 #0001"
+  multiple_line_output: "Interface br328"

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -154,4 +154,15 @@ mikrotik_routeros:
   username: admin
   password: ""
 
+keymile:
+  device_type: keymile
+  ip: 1.2.3.4
+  username: TEST
+  password: TEST
+
+keymile_nos:
+  device_type: keymile_nos
+  ip: 1.2.3.5
+  username: TEST
+  password: TEST
 


### PR DESCRIPTION
* Add KeymileSSH for Keymile "MileGate 2300" devices.
  Custom shell with path in prompt.
  Operating system identifies as "CLI Release R2A21".
  Unit tests for show cmds are passing. 
[test_netmiko_show.py_keymile.log](https://github.com/ktbyers/netmiko/files/3182506/test_netmiko_show.py_keymile.log)


* Add KeymileNOSSSH for "MileGate 2112" devices.
  Shell behaves like "cisco_ios" with modifications.
  Operating System identifies as "NOS Version 2.09".
  Unit tests for show commands are passing.
[test_netmiko_show.py_keymile_nos.log](https://github.com/ktbyers/netmiko/files/3182507/test_netmiko_show.py_keymile_nos.log)
[test_netmiko_show.py_keymile_nos_2.log](https://github.com/ktbyers/netmiko/files/3182508/test_netmiko_show.py_keymile_nos_2.log)



