### PR TITLE
change default password --> None

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -44,7 +44,7 @@ class BaseConnection(object):
         ip="",
         host="",
         username="",
-        password="",
+        password=None,
         secret="",
         port=None,
         device_type="",
@@ -279,11 +279,13 @@ class BaseConnection(object):
         # determine if telnet or SSH
         if "_telnet" in device_type:
             self.protocol = "telnet"
+            self.password = password or ""
             self._modify_connection_params()
             self.establish_connection()
             self._try_session_preparation()
         elif "_serial" in device_type:
             self.protocol = "serial"
+            self.password = password or ""
             self._modify_connection_params()
             self.establish_connection()
             self._try_session_preparation()


### PR DESCRIPTION
Opening this as a conversation starter...

I ran into an issue where an ssh key was being viewed as invalid (despite it working from terminal) due to Paramiko not liking recent OpenSSH 7.8+ default key gen settings (see this [SO post](https://stackoverflow.com/questions/53600581/ssh-key-generated-by-ssh-keygen-is-not-recognized-by-paramiko)). Dropping down into Paramiko I got a descriptive exception raised but in Netmiko it was simply "invalid authentication" this ultimately was because netmiko passed an empty string as a password to Paramiko -- Paramiko tried my key (and failed), then tried an empty string as a password which of course failed. 

This PR is basically trying to ensure we dont hide useful Paramiko exceptions with respect to ssh keys. In order to not break any serial/telnet things in the base class I set those back to an empty string if the user leaves them as `None`.  For ssh if no key or password is provided Paramiko will simply raise `No authentication methods available` which seems reasonable to me.

One other thing that may be worth discussing is that `password` is a required arg upstream in napalm -- if its set as an empty string for users of napalm since they have to have *something* there, this "fix" is mostly useless.
