### PR TITLE
fixing strip_prompt accuracy

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1153,8 +1153,8 @@ class BaseConnection(object):
         response_list = a_string.split(self.RESPONSE_RETURN)
         last_line = response_list[-1]
         if self.base_prompt in last_line:
-            mod_line = re.sub(self.base_prompt+".*","",last_line).strip()
-            return self.RESPONSE_RETURN.join(response_list[:-1]+[mod_line])
+            mod_line = re.sub(self.base_prompt+".*","",last_line)
+            return self.RESPONSE_RETURN.join(response_list[:-1]+[mod_line]).strip()
         else:
             return a_string
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1153,7 +1153,8 @@ class BaseConnection(object):
         response_list = a_string.split(self.RESPONSE_RETURN)
         last_line = response_list[-1]
         if self.base_prompt in last_line:
-            return self.RESPONSE_RETURN.join(response_list[:-1])
+            mod_line = re.sub(self.base_prompt+".*","",last_line).strip()
+            return self.RESPONSE_RETURN.join(response_list[:-1]+[mod_line])
         else:
             return a_string
 


### PR DESCRIPTION
Instead of stripping whole line containing the base_prompt, output should be removed anything after the base_prompt, but not before.

Existing Issue: For below output from IOS-XR
```
(Pdb) output
'\nThu Jun  6 15:32:01.736 IST\n===============================================================\nLocation     Altitude Value (Meters)    Source         \n---------------------------------------------------------------\n0/RP0/CPU0            907          RP/0/RP0/CPU0:ECR7#'
```

Reformatted so it is readable:

```

Thu Jun  6 15:32:01.736 IST
===============================================================
Location     Altitude Value (Meters)    Source         
---------------------------------------------------------------
0/RP0/CPU0            907          RP/0/RP0/CPU0:ECR7#
```

part of output `0/RP0/CPU0            907          ` got stripped down; It is not necessary to strip entire line, instead we could strip down the characters from the prompt and after only; keeping the outputs before the prompt. 

Please suggest if any better options to handle this while using `strip_prompt=True`

Cheers