### PR TITLE
first draft support for pyats/genie

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -29,7 +29,12 @@ from netmiko.ssh_exception import (
     NetMikoTimeoutException,
     NetMikoAuthenticationException,
 )
-from netmiko.utilities import write_bytes, check_serial_port, get_structured_data
+from netmiko.utilities import (
+    write_bytes,
+    check_serial_port,
+    get_structured_data,
+    get_structured_data_genie,
+)
 
 
 class BaseConnection(object):
@@ -1098,6 +1103,7 @@ class BaseConnection(object):
         strip_command=True,
         normalize=True,
         use_textfsm=False,
+        use_genie=False,
     ):
         """Execute command_string on the SSH channel using a delay-based mechanism. Generally
         used for show commands.
@@ -1123,6 +1129,9 @@ class BaseConnection(object):
 
         :param use_textfsm: Process command output through TextFSM template (default: False).
         :type normalize: bool
+
+        :param use_genie: Process command output through PyATS/Genie parser (default: False).
+        :type normalize: bool
         """
         output = ""
         delay_factor = self.select_delay_factor(delay_factor)
@@ -1140,8 +1149,15 @@ class BaseConnection(object):
             command_string=command_string,
             strip_prompt=strip_prompt,
         )
+        if use_textfsm and use_genie:
+            print("TextFSM and Genie are mutually exclusive. Using TextFSM as default.")
+            use_genie = False
         if use_textfsm:
             output = get_structured_data(
+                output, platform=self.device_type, command=command_string.strip()
+            )
+        if use_genie:
+            output = get_structured_data_genie(
                 output, platform=self.device_type, command=command_string.strip()
             )
         return output
@@ -1197,6 +1213,7 @@ class BaseConnection(object):
         strip_command=True,
         normalize=True,
         use_textfsm=False,
+        use_genie=False,
     ):
         """Execute command_string on the SSH channel using a pattern-based mechanism. Generally
         used for show commands. By default this method will keep waiting to receive data until the
@@ -1227,6 +1244,9 @@ class BaseConnection(object):
         :type normalize: bool
 
         :param use_textfsm: Process command output through TextFSM template (default: False).
+        :type normalize: bool
+
+        :param use_genie: Process command output through PyATS/Genie parser (default: False).
         :type normalize: bool
         """
         # Time to delay in each read loop
@@ -1304,8 +1324,15 @@ class BaseConnection(object):
             command_string=command_string,
             strip_prompt=strip_prompt,
         )
+        if use_textfsm and use_genie:
+            print("TextFSM and Genie are mutually exclusive. Using TextFSM as default.")
+            use_genie = False
         if use_textfsm:
             output = get_structured_data(
+                output, platform=self.device_type, command=command_string.strip()
+            )
+        if use_genie:
+            output = get_structured_data_genie(
                 output, platform=self.device_type, command=command_string.strip()
             )
         return output

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -283,5 +283,5 @@ def get_structured_data_genie(raw_output, platform, command):
         parsed_output = device.parse(command, output=raw_output)
         return parsed_output
     except Exception as e:
-        print("Faield to parse with genie, error: {}".format(e))
+        print("Failed to parse with genie, error: {}".format(e))
         return raw_output

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -254,7 +254,8 @@ def get_structured_data_genie(raw_output, platform, command):
     except ImportError as e:
         print("Failed to import {}.".format(e))
         print(
-            "pyATS and Genie are required to use 'get_structured_data_genie'. Install these packages with pip: 'pip install pyats genie'"
+            "pyATS and Genie are required to use 'get_structured_data_genie'."
+            "Install these packages with pip: 'pip install pyats genie'"
         )
         return raw_output
     if "cisco" not in platform:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+pyats;python_version>="3.4"
+genie;python_version>="3.4"
 pytest==3.10.0
 pylama==7.6.6
 tox==3.5.3

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-import os
 from os import environ
-from os.path import dirname, join, isdir, relpath
-from uuid import uuid4 as random_uuid
+from os.path import dirname, join, relpath
+import sys
 
 from netmiko import utilities
 from netmiko._textfsm import _clitable as clitable
@@ -175,3 +174,80 @@ def test_get_structured_data_relative_path():
         raw_output, platform="cisco_ios", command="show version"
     )
     assert result == [{"model": "4500"}]
+
+
+def test_get_structured_data_genie():
+    """Convert raw CLI output to structured data using Genie"""
+    if not sys.version_info >= (3, 4):
+        assert True
+        return
+    raw_output = """Cisco IOS Software, C3560CX Software (C3560CX-UNIVERSALK9-M), Version 15.2(4)E7, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2018 by Cisco Systems, Inc.
+Compiled Tue 18-Sep-18 13:20 by prod_rel_team
+
+ROM: Bootstrap program is C3560CX boot loader
+BOOTLDR: C3560CX Boot Loader (C3560CX-HBOOT-M) Version 15.2(4r)E5, RELEASE SOFTWARE (fc4)
+
+3560CX uptime is 5 weeks, 1 day, 2 hours, 30 minutes
+System returned to ROM by power-on
+System restarted at 11:45:26 PDT Tue May 7 2019
+System image file is "flash:c3560cx-universalk9-mz.152-4.E7.bin"
+Last reload reason: power-on
+
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+License Level: ipservices
+License Type: Permanent Right-To-Use
+Next reload license Level: ipservices
+
+cisco WS-C3560CX-8PC-S (APM86XXX) processor (revision A0) with 524288K bytes of memory.
+Processor board ID FOCXXXXXXXX
+Last reset from power-on
+5 Virtual Ethernet interfaces
+12 Gigabit Ethernet interfaces
+The password-recovery mechanism is enabled.
+
+512K bytes of flash-simulated non-volatile configuration memory.
+Base ethernet MAC Address       : 12:34:56:78:9A:BC
+Motherboard assembly number     : 86-75309-01
+Power supply part number        : 867-5309-01
+Motherboard serial number       : FOCXXXXXXXX
+Power supply serial number      : FOCXXXXXXXX
+Model revision number           : A0
+Motherboard revision number     : A0
+Model number                    : WS-C3560CX-8PC-S
+System serial number            : FOCXXXXXXXX
+Top Assembly Part Number        : 86-7530-91
+Top Assembly Revision Number    : A0
+Version ID                      : V01
+CLEI Code Number                : CMM1400DRA
+Hardware Board Revision Number  : 0x02
+
+
+Switch Ports Model                     SW Version            SW Image
+------ ----- -----                     ----------            ----------
+*    1 12    WS-C3560CX-8PC-S          15.2(4)E7             C3560CX-UNIVERSALK9-M
+
+
+Configuration register is 0xF
+"""
+    result = utilities.get_structured_data_genie(
+        raw_output, platform="cisco_xe", command="show version"
+    )
+    assert result["version"]["chassis"] == "WS-C3560CX-8PC-S"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py35,py36,py37
 
 [testenv]
 deps =


### PR DESCRIPTION
first crack at adding pyats/genie support. works well in testing with ios-xe so far, but *should* work with any Cisco device I assume.

modified reqs to add pyats/genie for 3.4+

added basic test of genie

added 3.7 to tox env