### PR TITLE
update links in readme to point to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Multi-vendor library to simplify Paramiko SSH connections to network devices
 
 ## Quick Links
 
-- [Supported Platforms](#SupportedPlatforms)
-- [Installation](#Installation)
-- [Tutorials/Examples/Getting Started](#TutorialsExamplesGetting-Started)
-- [Common Issues/FAQ](#Common-IssuesFAQ)
-- [API-Documentation](#API-Documentation)
-- [TextFSM Integration](#TextFSM-Integration)
-- [Contributing](#Contributing)
-- [Questions/Discussion](#QuestionsDiscussion)
+- [Supported Platforms](https://ktbyers.github.io/netmiko/#supported-platforms)
+- [Installation](https://ktbyers.github.io/netmiko/#installation)
+- [Tutorials/Examples/Getting Started](https://ktbyers.github.io/netmiko/#tutorialsexamplesgetting-started)
+- [Common Issues/FAQ](https://ktbyers.github.io/netmiko/#common-issuesfaq)
+- [API-Documentation](https://ktbyers.github.io/netmiko/#api-documentation)
+- [TextFSM Integration](https://ktbyers.github.io/netmiko/#textfsm-integration)
+- [Contributing](https://ktbyers.github.io/netmiko/#contributing)
+- [Questions/Discussion](https://ktbyers.github.io/netmiko/#questionsdiscussion)
 
 
 ## Supported Platforms


### PR DESCRIPTION
this changes the links from the relative markdown links to full url links to the GitHub pages site. the markdown links are nice in the readme (non Github Pages bits), but dont work on Github Pages. Downside is this will always link everyone to the GitHub pages but that seems better than links not doing anything if you're viewing in pages view. 