### PR TITLE
testing textfsm installed as module

### DIFF
--- a/netmiko/_textfsm/_clitable.py
+++ b/netmiko/_textfsm/_clitable.py
@@ -31,9 +31,12 @@ import copy
 import os
 import re
 import threading
+
 try:
+    # TextFSM >= 1.0 (new package structure)
     from textfsm import copyable_regex_object
 except ImportError:
+    # TextFSM <= 0.4.1
     import copyable_regex_object
 import textfsm
 from netmiko._textfsm import _texttable as texttable

--- a/netmiko/_textfsm/_clitable.py
+++ b/netmiko/_textfsm/_clitable.py
@@ -31,7 +31,10 @@ import copy
 import os
 import re
 import threading
-import copyable_regex_object
+try:
+    from textfsm import copyable_regex_object
+except ImportError:
+    import copyable_regex_object
 import textfsm
 from netmiko._textfsm import _texttable as texttable
 

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -8,13 +8,8 @@ import io
 import os
 import serial.tools.list_ports
 from netmiko.py23_compat import text_type
-
-try:
-    from textfsm import clitable
-    from textfsm.clitable import CliTableError
-except ImportError:
-    from netmiko._textfsm import _clitable as clitable
-    from netmiko._textfsm._clitable import CliTableError
+from netmiko._textfsm import _clitable as clitable
+from netmiko._textfsm._clitable import CliTableError
 
 try:
     from genie.conf.base import Device

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -7,9 +7,14 @@ import sys
 import io
 import os
 import serial.tools.list_ports
-from netmiko._textfsm import _clitable as clitable
-from netmiko._textfsm._clitable import CliTableError
 from netmiko.py23_compat import text_type
+
+try:
+    from textfsm import clitable
+    from textfsm.clitable import CliTableError
+except ImportError:
+    from netmiko._textfsm import _clitable as clitable
+    from netmiko._textfsm._clitable import CliTableError
 
 try:
     from genie.conf.base import Device


### PR DESCRIPTION
fresh venv w/ this commit installed:
```(venv) $ pip list | grep textfsm
textfsm      0.4.1
You are using pip version 18.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(venv) $ python netmiko_test.py
[{'protocol': 'O', 'type': 'E2', 'network': '0.0.0.0', 'mask': '0', 'distance': '110', 'metric': '1', 'nexthop_ip': '172.31.255.254', 'nexthop_if': 'Vlan3967', 'uptime': '5w2d'}, {'protocol': 'C', 'type': '', 'network': '172.31.254.0', 'mask': '24', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan254', 'uptime': ''}, {'protocol': 'L', 'type': '', 'network': '172.31.254.2', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan254', 'uptime': ''}, {'protocol': 'C', 'type': '', 'network': '172.31.255.5', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Loopback0', 'uptime': ''}, {'protocol': 'C', 'type': '', 'network': '172.31.255.254', 'mask': '31', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan3967', 'uptime': ''}, {'protocol': 'L', 'type': '', 'network': '172.31.255.255', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan3967', 'uptime': ''}]
```

^ netmiko + TextFSM (the bits inside netmiko + textfsm 0.4.1) working as expected

```(venv) $ pip uninstall textfsm
Uninstalling textfsm-0.4.1:
  Would remove:
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/clitable.py
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/copyable_regex_object.py
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/terminal.py
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/textfsm-0.4.1.dist-info/*
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/textfsm.py
    /Users/carl/Desktop/netmiko-dev/venv/lib/python3.7/site-packages/texttable.py
Proceed (y/n)? y
  Successfully uninstalled textfsm-0.4.1
(venv) $ pip install -e git+https://github.com/google/textfsm@84e43d8#egg=textfsm
Obtaining textfsm from git+https://github.com/google/textfsm@84e43d8#egg=textfsm
  Cloning https://github.com/google/textfsm (to revision 84e43d8) to ./netmiko-dev/venv/src/textfsm
  Did not find branch or tag '84e43d8', assuming revision or ref.
Installing collected packages: textfsm
  Running setup.py develop for textfsm
Successfully installed textfsm
You are using pip version 18.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(venv) $ pip list | grep textfsm
textfsm      1.1.0   /Users/carl/Desktop/netmiko-dev/venv/src/textfsm
You are using pip version 18.1, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

^ textfsm 0.4.1 removed and 1.1.0 installed on latest commit

```(venv) $ python netmiko_test.py
[{'protocol': 'O', 'type': 'E2', 'network': '0.0.0.0', 'mask': '0', 'distance': '110', 'metric': '1', 'nexthop_ip': '172.31.255.254', 'nexthop_if': 'Vlan3967', 'uptime': '5w2d'}, {'protocol': 'C', 'type': '', 'network': '172.31.254.0', 'mask': '24', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan254', 'uptime': ''}, {'protocol': 'L', 'type': '', 'network': '172.31.254.2', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan254', 'uptime': ''}, {'protocol': 'C', 'type': '', 'network': '172.31.255.5', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Loopback0', 'uptime': ''}, {'protocol': 'C', 'type': '', 'network': '172.31.255.254', 'mask': '31', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan3967', 'uptime': ''}, {'protocol': 'L', 'type': '', 'network': '172.31.255.255', 'mask': '32', 'distance': '', 'metric': '', 'nexthop_ip': '', 'nexthop_if': 'Vlan3967', 'uptime': ''}]```

^ structured data still happy :D 