### PR TITLE
add index.rst to have rdt redirect to github pages for docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,8 @@
+Netmiko Documentation has Moved!
+================================
+
+.. contents::
+
+Netmiko documentation has moved to GitHub Pages!
+
+You can find the README for Netmiko `here <https://github.com/ktbyers/netmiko/blob/develop/README.md>`__, and the API documentation `here <https://ktbyers.github.io/netmiko/docs/netmiko/index.html>`__.


### PR DESCRIPTION
*hopefully* this will get rtd updated to display this and link folks to the GitHub pages readme/docs. not sure how to test this other than just merging to develop and then seeing if rtd updates though.