### PR TITLE
Enable testing for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,25 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8-dev"
+  - "nightly"
+stages:
+  - lint
+  - test
 matrix:
   include:
-  - python: 3.6
-    env: TOXENV=black
-  - python: 3.6
-    env: TOXENV=pylama
-install: 
-  - pip install tox==3.13.2 tox-travis==0.12
-script: 
+    - stage: lint
+      name: Black
+      python: 3.6
+      env: TOXENV=black
+    - stage: lint
+      name: Pylama
+      python: 3.6
+      env: TOXENV=pylama
+  allow_failures:
+    - python: 3.8-dev
+    - python: nightly
+install:
+  - pip install tox-travis
+script:
   - tox

--- a/requirements-genie.txt
+++ b/requirements-genie.txt
@@ -1,2 +1,3 @@
-pyats>=19.7; python_version>="3.4"
-genie>=19.7; python_version>="3.4"
+# pyats and genie are not available for Python 3.8 yet
+pyats>=19.7; python_version<"3.8"
+genie>=19.7; python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ skip = tests/*,build/*,.tox/*,netmiko/_textfsm/*,examples/use_cases/*
 
 [pylama:pep8]
 max_line_length = 100
+
+[tool:pytest]
+addopts = -rs

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -4,6 +4,8 @@ import os
 from os.path import dirname, join, relpath
 import sys
 
+import pytest
+
 from netmiko import utilities
 from netmiko._textfsm import _clitable as clitable
 
@@ -207,11 +209,13 @@ def test_get_structured_data_relative_path():
     assert result == [{"model": "4500"}]
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 8),
+    reason="The genie package is not available for Python 3.8 yet",
+)
 def test_get_structured_data_genie():
     """Convert raw CLI output to structured data using Genie"""
-    if not sys.version_info >= (3, 4):
-        assert True
-        return
+
     raw_output = """Cisco IOS Software, C3560CX Software (C3560CX-UNIVERSALK9-M), Version 15.2(4)E7, RELEASE SOFTWARE (fc2)
 Technical Support: http://www.cisco.com/techsupport
 Copyright (c) 1986-2018 by Cisco Systems, Inc.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,15 @@
 [tox]
-envlist = py36,py37
+envlist = py3{6,7,8},black,pylama
+skip_missing_interpreters = true
+
+[travis]
+python =
+    3.6: py36,black,pylama
+
+[travis:env]
+TRAVIS_BUILD_STAGE_NAME =
+    Lint: black,pylama
+    Test: py3{6,7,8}
 
 [testenv]
 deps =


### PR DESCRIPTION
Hello @ktbyers,

I believe it would be nice to have tests for the upcoming [Python 3.8](https://www.python.org/dev/peps/pep-0569/).

These changes also:
 - split testing into the `Lint` and `Test` stages

Best regards!