### PR TITLE
Add UnifiSwitchSSH driver for Ubiquiti UniFi switches

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -74,6 +74,7 @@ from netmiko.ruckus import RuckusFastironTelnet
 from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
+from netmiko.ubiquiti import UnifiSwitchSSH
 from netmiko.vyos import VyOSSSH
 
 
@@ -158,6 +159,7 @@ CLASS_MAPPER_BASE = {
     "ruckus_fastiron": RuckusFastironSSH,
     "ubiquiti_edge": UbiquitiEdgeSSH,
     "ubiquiti_edgeswitch": UbiquitiEdgeSSH,
+    "ubiquiti_unifi": UnifiSwitchSSH,
     "vyatta_vyos": VyOSSSH,
     "vyos": VyOSSSH,
 }

--- a/netmiko/ubiquiti/__init__.py
+++ b/netmiko/ubiquiti/__init__.py
@@ -1,3 +1,4 @@
 from netmiko.ubiquiti.edge_ssh import UbiquitiEdgeSSH
+from netmiko.ubiquiti.unifi_switch_ssh import UnifiSwitchSSH
 
-__all__ = ["UbiquitiEdgeSSH"]
+__all__ = ["UbiquitiEdgeSSH", "UnifiSwitchSSH"]

--- a/netmiko/ubiquiti/unifi_switch_ssh.py
+++ b/netmiko/ubiquiti/unifi_switch_ssh.py
@@ -1,0 +1,27 @@
+import time
+from netmiko.ubiquiti.edge_ssh import UbiquitiEdgeSSH
+
+
+class UnifiSwitchSSH(UbiquitiEdgeSSH):
+    def session_preparation(self):
+        """Prepare the session after the connection has been established.
+        When SSHing to a UniFi switch, the session initially starts at a Linux
+        shell. Nothing interesting can be done in this environment, however,
+        running `telnet localhost` drops the session to a more familiar
+        environment."""
+
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.send_command(
+            command_string="telnet localhost", expect_string=r"\(UBNT\) >"
+        )
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging()
+
+        # Clear read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def disable_paging(self, command="terminal length 0"):
+        super(UbiquitiEdgeSSH, self).disable_paging(command=command)

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -129,6 +129,16 @@ ubiquiti_edge:
     - "logging persistent 4"
   config_verification: "show running-config | include 'logging'"
 
+ubiquiti_unifi:
+  version: "show version"
+  basic: "show network"
+  extended_output: "show running-config"
+  config:
+    - "logging persistent 3"
+    - "no logging persistent"
+    - "logging persistent 4"
+  config_verification: "show running-config | include 'logging'"
+
 dellos10:
   version: "show version"
   basic: "show ip interface brief"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -79,6 +79,16 @@ ubiquiti_edge:
   cmd_response_init: ""
   cmd_response_final: "logging persistent 4"
 
+ubiquiti_unifi:
+  base_prompt: "(UBNT) "
+  router_prompt: "(UBNT) >"
+  enable_prompt: "(UBNT) #"
+  interface_ip: 10.0.132.4
+  version_banner: "Software Version"
+  multiple_line_output: "Current Configuration:"
+  cmd_response_init: ""
+  cmd_response_final: "logging persistent 4"
+
 dellos10:
   base_prompt: OS10
   router_prompt : OS10#

--- a/tests/test_ubiquiti_unifi.sh
+++ b/tests/test_ubiquiti_unifi.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& echo "Ubiquiti UniFi Switch" \
+&& py.test -v test_netmiko_show.py --test_device ubiquiti_unifi \
+&& py.test -v test_netmiko_config.py --test_device ubiquiti_unifi \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
This PR adds a driver for Ubiquiti's UniFi switches.

Ubiquiti's UniFi series of switches have a similar CLI to their EdgeSwitches, but they are not usually meant to be configured using the command line (they talk HTTP to a controller host, which provisions multiple switches). As such, SSHing to them doesn't immediately give a CLI that can be used to get information about the switch, it instead lets you configure the connection to the controller (among a few other things):

```
tris.wilson@pc005-linux ~ % ssh admin@switch04
...snip...
switch04-US.v4.0.14# help
UniFi Command Line Interface - Ubiquiti Networks

   info                      display device information
   set-default               restore to factory default
   set-inform <inform_url>   attempt inform URL (e.g. set-inform http://192.168.0.8:8080/inform)
   upgrade <firmware_url>    upgrade firmware (e.g. upgrade http://192.168.0.8/unifi_fw.bin)
   fwupdate --url <firmware_url|firmware_name> [--dl-only] [--md5sum <sum_of_fw>]
            [--keep-firmware] [--keep-running] [--reboot-sys] 
                                   new firmware update command
   reboot                    reboot the device
```

By typing `telnet localhost` at the prompt, you're dropped to a more familiar switch interface. Thus, this driver extends the EdgeSwitch driver and makes the `telnet localhost` change. While it's not useful to make configuration changes at this interface, since they'll be overwritten by the controller, `show` commands still work as expected and provide the same level as usefulness as they would on an EdgeSwitch.

I also added a test script modeled off of the EdgeSwitch test script; all tests pass when running it against an actual UniFi switch.