### PR TITLE
Allow custom socket_timeout in scp file_transfer

### DIFF
--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -63,6 +63,7 @@ class AristaFileTransfer(CiscoFileTransfer):
         dest_file,
         file_system="/mnt/flash",
         direction="put",
+        socket_timeout=5,
     ):
         return super().__init__(
             ssh_conn=ssh_conn,
@@ -70,6 +71,7 @@ class AristaFileTransfer(CiscoFileTransfer):
             dest_file=dest_file,
             file_system=file_system,
             direction=direction,
+            socket_timeout=socket_timeout,
         )
 
     def remote_space_available(self, search_pattern=""):

--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -63,7 +63,7 @@ class AristaFileTransfer(CiscoFileTransfer):
         dest_file,
         file_system="/mnt/flash",
         direction="put",
-        socket_timeout=5,
+        socket_timeout=10.0,
     ):
         return super().__init__(
             ssh_conn=ssh_conn,

--- a/netmiko/scp_functions.py
+++ b/netmiko/scp_functions.py
@@ -26,6 +26,7 @@ def file_transfer(
     disable_md5=False,
     inline_transfer=False,
     overwrite_file=False,
+    socket_timeout=5,
 ):
     """Use Secure Copy or Inline (IOS-only) to transfer files to/from network devices.
 
@@ -65,6 +66,7 @@ def file_transfer(
         "source_file": source_file,
         "dest_file": dest_file,
         "direction": direction,
+        "socket_timeout": socket_timeout,
     }
     if file_system is not None:
         scp_args["file_system"] = file_system

--- a/netmiko/scp_functions.py
+++ b/netmiko/scp_functions.py
@@ -26,7 +26,7 @@ def file_transfer(
     disable_md5=False,
     inline_transfer=False,
     overwrite_file=False,
-    socket_timeout=5,
+    socket_timeout=10.0,
 ):
     """Use Secure Copy or Inline (IOS-only) to transfer files to/from network devices.
 

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -21,7 +21,7 @@ class SCPConn(object):
     Must close the SCP connection to get the file to write to the remote filesystem
     """
 
-    def __init__(self, ssh_conn, socket_timeout=5):
+    def __init__(self, ssh_conn, socket_timeout=10.0):
         self.ssh_ctl_chan = ssh_conn
         self.socket_timeout = socket_timeout
         self.establish_scp_conn()
@@ -62,7 +62,7 @@ class BaseFileTransfer(object):
         dest_file,
         file_system=None,
         direction="put",
-        socket_timeout=5,
+        socket_timeout=10.0,
     ):
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -21,8 +21,9 @@ class SCPConn(object):
     Must close the SCP connection to get the file to write to the remote filesystem
     """
 
-    def __init__(self, ssh_conn):
+    def __init__(self, ssh_conn, socket_timeout=5):
         self.ssh_ctl_chan = ssh_conn
+        self.socket_timeout = socket_timeout
         self.establish_scp_conn()
 
     def establish_scp_conn(self):
@@ -30,7 +31,9 @@ class SCPConn(object):
         ssh_connect_params = self.ssh_ctl_chan._connect_params_dict()
         self.scp_conn = self.ssh_ctl_chan._build_ssh_client()
         self.scp_conn.connect(**ssh_connect_params)
-        self.scp_client = scp.SCPClient(self.scp_conn.get_transport())
+        self.scp_client = scp.SCPClient(
+            self.scp_conn.get_transport(), socket_timeout=self.socket_timeout
+        )
 
     def scp_transfer_file(self, source_file, dest_file):
         """Put file using SCP (for backwards compatibility)."""
@@ -53,12 +56,19 @@ class BaseFileTransfer(object):
     """Class to manage SCP file transfer and associated SSH control channel."""
 
     def __init__(
-        self, ssh_conn, source_file, dest_file, file_system=None, direction="put"
+        self,
+        ssh_conn,
+        source_file,
+        dest_file,
+        file_system=None,
+        direction="put",
+        socket_timeout=5,
     ):
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file
         self.dest_file = dest_file
         self.direction = direction
+        self.socket_timeout = socket_timeout
 
         auto_flag = (
             "cisco_ios" in ssh_conn.device_type
@@ -93,7 +103,7 @@ class BaseFileTransfer(object):
 
     def establish_scp_conn(self):
         """Establish SCP connection."""
-        self.scp_conn = SCPConn(self.ssh_ctl_chan)
+        self.scp_conn = SCPConn(self.ssh_ctl_chan, socket_timeout=self.socket_timeout)
 
     def close_scp_chan(self):
         """Close the SCP connection to the remote network device."""


### PR DESCRIPTION
This addresses the bug affecting EOS devices in https://github.com/ktbyers/netmiko/issues/1254. You can now pass a socket_timeout keyword argument to file_transfer to override the default socket_timeout in SCPConn.