### PR TITLE
Support Yamaha routers and firewalls

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -167,6 +167,12 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "yamaha": {
+        "cmd": "show environment",
+        "search_patterns": [r"RTX", r"NVR", r"FWX"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
 }
 
 

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -75,6 +75,8 @@ from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.vyos import VyOSSSH
+from netmiko.yamaha import YamahaSSH
+from netmiko.yamaha import YamahaTelnet
 
 
 # The keys of this dictionary are the supported device_types
@@ -161,6 +163,7 @@ CLASS_MAPPER_BASE = {
     "ubiquiti_edgeswitch": UbiquitiEdgeSSH,
     "vyatta_vyos": VyOSSSH,
     "vyos": VyOSSSH,
+    "yamaha": YamahaSSH,
 }
 
 FILE_TRANSFER_MAP = {
@@ -213,6 +216,7 @@ CLASS_MAPPER["paloalto_panos_telnet"] = PaloAltoPanosTelnet
 CLASS_MAPPER["oneaccess_oneos_telnet"] = OneaccessOneOSTelnet
 CLASS_MAPPER["rad_etx_telnet"] = RadETXTelnet
 CLASS_MAPPER["ruckus_fastiron_telnet"] = RuckusFastironTelnet
+CLASS_MAPPER["yamaha_telnet"] = YamahaTelnet
 
 # Add serial drivers
 CLASS_MAPPER["cisco_ios_serial"] = CiscoIosSerial

--- a/netmiko/yamaha/__init__.py
+++ b/netmiko/yamaha/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+from netmiko.yamaha.yamaha import YamahaSSH, YamahaTelnet
+#from netmiko.yamaha.yamaha_ssh import YamahaSSH
+
+__all__ = ["YamahaSSH", "YamahaTelnet"]

--- a/netmiko/yamaha/__init__.py
+++ b/netmiko/yamaha/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
 from netmiko.yamaha.yamaha import YamahaSSH, YamahaTelnet
-#from netmiko.yamaha.yamaha_ssh import YamahaSSH
 
 __all__ = ["YamahaSSH", "YamahaTelnet"]

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -2,7 +2,6 @@ from netmiko.base_connection import BaseConnection
 from netmiko.ssh_exception import NetmikoTimeoutException
 from netmiko import log
 import time
-import re
 
 
 class YamahaBase(BaseConnection):

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -1,4 +1,5 @@
 from netmiko.base_connection import BaseConnection
+from netmiko.ssh_exception import NetmikoTimeoutException
 from netmiko import log
 import time
 import re
@@ -34,6 +35,10 @@ class YamahaBase(BaseConnection):
     def config_mode(self, config_command="administrator", pattern="ssword"):
         """Enter into administrator mode and configure device."""
         output = ""
+        msg = (
+            "Failed to enter administrator mode. Please ensure you pass "
+            "the 'secret' argument to ConnectHandler."
+        )
         if not self.check_config_mode():
             self.write_channel(self.normalize_cmd(config_command))
             try:
@@ -42,10 +47,10 @@ class YamahaBase(BaseConnection):
                 )
                 self.write_channel(self.normalize_cmd(self.secret))
                 output += self.read_until_prompt()
-            except NetMikoTimeoutException:
+            except NetmikoTimeoutException:
                 raise ValueError(msg)
             if not self.check_config_mode():
-                raise ValueError("Failed to enter administrator mode.")
+                raise ValueError(msg)
         return output
 
     def exit_config_mode(self, exit_config="exit", pattern=">"):
@@ -95,5 +100,3 @@ class YamahaSSH(YamahaBase):
 class YamahaTelnet(YamahaBase):
     """Yamaha Telnet driver."""
     pass
-
-

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -1,0 +1,100 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from netmiko.base_connection import BaseConnection
+from netmiko import log
+import time
+import re
+
+
+class YamahaBase(BaseConnection):
+    def session_preparation(self):
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.disable_paging(command="console lines infinity")
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on Yamaha."""
+        pass
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on Yamaha."""
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        """No enable mode on Yamaha."""
+        pass
+
+    def check_config_mode(self, check_string="#", pattern=""):
+        """Checks if the device is in administrator mode or not."""
+        return super(YamahaBase, self).check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
+
+    def config_mode(self, config_command="administrator", pattern="ssword"):
+        """Enter into administrator mode and configure device."""
+        output = ""
+        if not self.check_config_mode():
+            self.write_channel(self.normalize_cmd(config_command))
+            try:
+                output += self.read_until_prompt_or_pattern(
+                    pattern=pattern
+                )
+                self.write_channel(self.normalize_cmd(self.secret))
+                output += self.read_until_prompt()
+            except NetMikoTimeoutException:
+                raise ValueError(msg)
+            if not self.check_config_mode():
+                raise ValueError("Failed to enter administrator mode.")
+        return output
+
+    def exit_config_mode(self, exit_config="exit", pattern=">"):
+        """Exit from administrator mode.
+        """
+        output = ""
+        if self.check_config_mode():
+            self.write_channel(self.normalize_cmd(exit_config))
+            self.write_channel('\n')
+            time.sleep(1)
+            self.write_channel('\n')
+            time.sleep(1)
+            output = self.read_channel()
+            if '(Y/N)' in output:
+                self.write_channel('N')
+            self.write_channel('\n')
+            time.sleep(1)
+            self.write_channel('\n')
+            time.sleep(1)
+            output += self.read_until_pattern(pattern=pattern)
+            if self.check_config_mode():
+                raise ValueError("Failed to exit configuration mode")
+        log.debug("exit_config_mode: {}".format(output))
+        return output
+
+    def save_config(self, cmd="save", confirm=False, confirm_response=""):
+        """Saves Config."""
+        self.config_mode()
+        if confirm:
+            output = self.send_command_timing(command_string=cmd)
+            if confirm_response:
+                output += self.send_command_timing(confirm_response)
+            else:
+                # Send enter by default
+                output += self.send_command_timing(self.RETURN)
+        else:
+            # Some devices are slow so match on trailing-prompt if you can
+            output = self.send_command(command_string=cmd)
+        return output
+
+
+class YamahaSSH(YamahaBase):
+    """Yamaha SSH driver."""
+    pass
+
+
+class YamahaTelnet(YamahaBase):
+    """Yamaha Telnet driver."""
+    pass
+
+

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 from netmiko.base_connection import BaseConnection
 from netmiko import log
 import time
@@ -8,6 +6,7 @@ import re
 
 class YamahaBase(BaseConnection):
     def session_preparation(self):
+        """Prepare the session after the connection has been established."""
         self._test_channel_read(pattern=r"[>#]")
         self.set_base_prompt()
         self.disable_paging(command="console lines infinity")

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -41,9 +41,7 @@ class YamahaBase(BaseConnection):
         if not self.check_config_mode():
             self.write_channel(self.normalize_cmd(config_command))
             try:
-                output += self.read_until_prompt_or_pattern(
-                    pattern=pattern
-                )
+                output += self.read_until_prompt_or_pattern(pattern=pattern)
                 self.write_channel(self.normalize_cmd(self.secret))
                 output += self.read_until_prompt()
             except NetmikoTimeoutException:
@@ -58,16 +56,16 @@ class YamahaBase(BaseConnection):
         output = ""
         if self.check_config_mode():
             self.write_channel(self.normalize_cmd(exit_config))
-            self.write_channel('\n')
+            self.write_channel("\n")
             time.sleep(1)
-            self.write_channel('\n')
+            self.write_channel("\n")
             time.sleep(1)
             output = self.read_channel()
-            if '(Y/N)' in output:
-                self.write_channel('N')
-            self.write_channel('\n')
+            if "(Y/N)" in output:
+                self.write_channel("N")
+            self.write_channel("\n")
             time.sleep(1)
-            self.write_channel('\n')
+            self.write_channel("\n")
             time.sleep(1)
             output += self.read_until_pattern(pattern=pattern)
             if self.check_config_mode():
@@ -93,9 +91,11 @@ class YamahaBase(BaseConnection):
 
 class YamahaSSH(YamahaBase):
     """Yamaha SSH driver."""
+
     pass
 
 
 class YamahaTelnet(YamahaBase):
     """Yamaha Telnet driver."""
+
     pass

--- a/tests/test_yamaha.sh
+++ b/tests/test_yamaha.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device yamaha \
+&& py.test -v test_netmiko_config.py --test_device yamaha \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
Added support for Yamaha routers (RTX) and firewalls (FWX).
https://www.yamaha.com/products/en/network/

Test Results

```
(venv_an2.8.4) [centos@localhost tests]$ ./test_yamaha.sh
Starting tests...good luck:
======================================================== test session starts ========================================================
platform linux -- Python 3.6.8, pytest-5.2.0, py-1.8.0, pluggy-0.13.0 -- /home/centos/venv_an2.8.4/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/centos/venv_an2.8.4/netmiko, inifile: setup.cfg
plugins: f5-sdk-3.0.21
collected 14 items                                                                                                                  

test_netmiko_show.py::test_disable_paging PASSED                                                                              [  7%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                 [ 14%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                              [ 21%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                         [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                [ 35%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                       [ 42%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                         [ 50%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                 [ 57%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                [ 64%]
test_netmiko_show.py::test_strip_command PASSED                                                                               [ 71%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                         [ 78%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                [ 85%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                 [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                  [100%]

========================================================= warnings summary ==========================================================
/home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127
  /home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: cache could not write path /home/centos/venv_an2.8.4/netmiko/.pytest_cache/v/cache/stepwise
    self.warn("cache could not write path {path}", path=path)

/home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127
  /home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: cache could not write path /home/centos/venv_an2.8.4/netmiko/.pytest_cache/v/cache/nodeids
    self.warn("cache could not write path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================================== short test summary info ======================================================
SKIPPED [1] /home/centos/venv_an2.8.4/netmiko/tests/test_netmiko_show.py:83: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /home/centos/venv_an2.8.4/netmiko/tests/test_netmiko_show.py:109: TextFSM/ntc-templates not supported on this platform
============================================ 12 passed, 2 skipped, 2 warnings in 31.96s =============================================
======================================================== test session starts ========================================================
platform linux -- Python 3.6.8, pytest-5.2.0, py-1.8.0, pluggy-0.13.0 -- /home/centos/venv_an2.8.4/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/centos/venv_an2.8.4/netmiko, inifile: setup.cfg
plugins: f5-sdk-3.0.21
collected 7 items                                                                                                                   

test_netmiko_config.py::test_ssh_connect PASSED                                                                               [ 14%]
test_netmiko_config.py::test_enable_mode PASSED                                                                               [ 28%]
test_netmiko_config.py::test_config_mode PASSED                                                                               [ 42%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                          [ 57%]
test_netmiko_config.py::test_command_set PASSED                                                                               [ 71%]
test_netmiko_config.py::test_commands_from_file PASSED                                                                        [ 85%]
test_netmiko_config.py::test_disconnect PASSED                                                                                [100%]

========================================================= warnings summary ==========================================================
/home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127
  /home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: cache could not write path /home/centos/venv_an2.8.4/netmiko/.pytest_cache/v/cache/stepwise
    self.warn("cache could not write path {path}", path=path)

/home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127
  /home/centos/venv_an2.8.4/lib64/python3.6/site-packages/_pytest/cacheprovider.py:127: PytestCacheWarning: cache could not write path /home/centos/venv_an2.8.4/netmiko/.pytest_cache/v/cache/nodeids
    self.warn("cache could not write path {path}", path=path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================= 7 passed, 2 warnings in 72.19s (0:01:12) ==============================================
```

Sample Code (Japanese)
https://qiita.com/tech_kitara/items/b2496f74c5a4e0aab174