### PR TITLE
Change Linux enable-sudo behavior for broader support

### DIFF
--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -55,7 +55,7 @@ class LinuxSSH(CiscoSSHConnection):
         """Verify root"""
         return self.check_enable_mode(check_string=check_string)
 
-    def config_mode(self, config_command="sudo su"):
+    def config_mode(self, config_command="sudo -s"):
         """Attempt to become root."""
         return self.enable(cmd=config_command)
 
@@ -78,7 +78,7 @@ class LinuxSSH(CiscoSSHConnection):
                 raise ValueError("Failed to exit enable mode.")
         return output
 
-    def enable(self, cmd="sudo su", pattern="ssword", re_flags=re.IGNORECASE):
+    def enable(self, cmd="sudo -s", pattern="ssword", re_flags=re.IGNORECASE):
         """Attempt to become root."""
         delay_factor = self.select_delay_factor(delay_factor=0)
         output = ""


### PR DESCRIPTION
OpenGear has a very lean install. Using inbuilt `sudo` "run shell" should suffice.

```
$ sudo su
sudo: su: command not found
$ sudo
usage: sudo -h | -K | -k | -L | -V
usage: sudo -v [-AknS] [-g groupname|#gid] [-p prompt] [-u user name|#uid]
usage: sudo -l[l] [-AknS] [-g groupname|#gid] [-p prompt] [-U user name] [-u user name|#uid] [-g groupname|#gid] [command]
usage: sudo [-AbEHknPS] [-C fd] [-g groupname|#gid] [-p prompt] [-u user name|#uid] [-g groupname|#gid] [VAR=value] [-i|-s] [<command>]
usage: sudo -e [-AknS] [-C fd] [-g groupname|#gid] [-p prompt] [-u user name|#uid] file ...
$ sudo -s
# exit
$
```