### PR TITLE
Increase default blocking timeout to 20 seconds

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -63,7 +63,7 @@ class BaseConnection(object):
         timeout=100,
         session_timeout=60,
         auth_timeout=None,
-        blocking_timeout=8,
+        blocking_timeout=20,
         banner_timeout=15,
         keepalive=0,
         default_enter=None,


### PR DESCRIPTION
This is for reliability improvements on slow/high-packet loss links