### PR TITLE
Updates for Nokia SR OS (former: Alcatel-Lucent, Alcatel, Timetra)

### DIFF
--- a/netmiko/alcatel/__init__.py
+++ b/netmiko/alcatel/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from netmiko.alcatel.alcatel_sros_ssh import AlcatelSrosSSH, FileTransferSROS
 from netmiko.alcatel.alcatel_aos_ssh import AlcatelAosSSH
 

--- a/netmiko/alcatel/__init__.py
+++ b/netmiko/alcatel/__init__.py
@@ -1,4 +1,5 @@
-from netmiko.alcatel.alcatel_sros_ssh import AlcatelSrosSSH
+from __future__ import unicode_literals
+from netmiko.alcatel.alcatel_sros_ssh import AlcatelSrosSSH, FileTransferSROS
 from netmiko.alcatel.alcatel_aos_ssh import AlcatelAosSSH
 
-__all__ = ["AlcatelSrosSSH", "AlcatelAosSSH"]
+__all__ = ["AlcatelSrosSSH", "AlcatelAosSSH", "FileTransferSROS"]

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -50,7 +50,6 @@ class AlcatelSrosSSH(BaseConnection):
             self.base_prompt = match.group(1)
             return self.base_prompt
 
-
     def enable(self, *args, **kwargs):
         """Nokia SR OS does not support enable-mode"""
         pass
@@ -63,31 +62,34 @@ class AlcatelSrosSSH(BaseConnection):
         """Nokia SR OS does not support enable-mode"""
         pass
 
-
     def config_mode(self, config_command="edit-config private", pattern="#"):
         """Enable configuration edit-mode for Nokia SR OS"""
         if '@' not in self.base_prompt:
             return ""
-        return super(AlcatelSrosSSH, self).config_mode(config_command=config_command, pattern=pattern)
+        return super(AlcatelSrosSSH, self).config_mode(
+            config_command=config_command, pattern=pattern
+        )
 
     def exit_config_mode(self, exit_config="quit-config", pattern="#"):
         """Disable configuration edit-mode for Nokia SR OS"""
         if '@' not in self.base_prompt:
             return ""
-        return super(AlcatelSrosSSH, self).exit_config_mode(exit_config=exit_config, pattern=pattern)
+        return super(AlcatelSrosSSH, self).exit_config_mode(
+            exit_config=exit_config, pattern=pattern
+        )
 
     def check_config_mode(self, check_string="(pr)", pattern="#"):
         """Check configuration edit-mode for Nokia SR OS"""
         if '@' not in self.base_prompt:
             return True
-        return super(AlcatelSrosSSH, self).check_config_mode(check_string=check_string, pattern=pattern)
-
+        return super(AlcatelSrosSSH, self).check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
 
     def save_config(self, *args, **kwargs):
         """Persist configuration to cflash for Nokia SR OS"""
         output = self.send_command(command_string="/admin save")
         return output
-
 
     def commit(self, *args, **kwargs):
         """Activate changes from private candidate for Nokia SR OS"""
@@ -129,14 +131,12 @@ class FileTransferSROS(BaseFileTransfer):
         else:
             raise ValueError("Invalid direction specified")
 
-
     def remote_space_available(self, search_pattern=r"(\d+) \w+ free"):
         """Return space available on remote device."""
         remote_cmd = "file dir {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
         match = re.search(search_pattern, remote_output)
         return int(match.group(1))
-
 
     def check_file_exists(self, remote_cmd=""):
         """Check if the dest_file already exists on the file system (return boolean)."""
@@ -151,7 +151,6 @@ class FileTransferSROS(BaseFileTransfer):
                 raise ValueError("Unexpected output from check_file_exists")
         elif self.direction == "get":
             return os.path.exists(self.dest_file)
-
 
     def remote_file_size(self, remote_cmd=None, remote_file=None):
         """Get the file size of the remote file."""
@@ -179,16 +178,13 @@ class FileTransferSROS(BaseFileTransfer):
         file_size = int(match.group(3))
         return file_size
 
-
     def remote_md5(self, base_cmd=None, remote_file=None):
         # Nokia SR OS does not expose a md5sum method
         raise NotImplementedError
 
-
     def compare_md5(self):
         # Nokia SR OS does not expose a md5sum method
         raise NotImplementedError
-
 
     def verify_file(self):
         """Verify the file has been transferred correctly based on filesize."""

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2019 - NOKIA Inc. All Rights Reserved.
-# Please read the associated COPYRIGHTS file for more details.
+# Copyright (c) 2019 NOKIA Inc.
+# MIT License 
+# See License file at https://github.com/ktbyers/netmiko/blob/develop/LICENSE
 
 import re
 import os

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -1,70 +1,198 @@
-"""Alcatel-Lucent SROS support."""
+# Copyright (c) 2019 - NOKIA Inc. All Rights Reserved.
+# Please read the associated COPYRIGHTS file for more details.
+
 import re
+import os
 import time
-from netmiko.cisco_base_connection import CiscoSSHConnection
+
+from netmiko.base_connection import BaseConnection
+from netmiko.scp_handler import BaseFileTransfer
 
 
-class AlcatelSrosSSH(CiscoSSHConnection):
-    """Alcatel-Lucent SROS support."""
+class AlcatelSrosSSH(BaseConnection):
+    """
+    Implement methods for interacting with Nokia SR OS devices.
+
+    Not applicable in Nokia SR OS (disabled):
+        - enable()
+        - exit_enable_mode()
+        - check_enable_mode()
+
+    Overriden methods to adapt Nokia SR OS behavior (changed):
+        - session_preparation()
+        - set_base_prompt()
+        - config_mode()
+        - exit_config_mode()
+        - check_config_mode()
+        - save_config()
+        - commit()
+        - strip_prompt()
+    """
 
     def session_preparation(self):
         self._test_channel_read()
         self.set_base_prompt()
-        self.disable_paging(command="environment no more")
+        if '@' in self.base_prompt:
+            self.disable_paging(command="environment more false")
+            self.set_terminal_width(command="environment console width 512")
+        else:
+            self.disable_paging(command="environment no more")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
     def set_base_prompt(self, *args, **kwargs):
         """Remove the > when navigating into the different config level."""
-        cur_base_prompt = super().set_base_prompt(*args, **kwargs)
-        match = re.search(r"(.*)(>.*)*#", cur_base_prompt)
+        cur_base_prompt = super(AlcatelSrosSSH, self).set_base_prompt(*args, **kwargs)
+        match = re.search(r"\*?(.*)(>.*)*#", cur_base_prompt)
         if match:
             # strip off >... from base_prompt
             self.base_prompt = match.group(1)
             return self.base_prompt
 
-    def enable(self, cmd="enable-admin", pattern="ssword", re_flags=re.IGNORECASE):
-        """Enter enable mode."""
-        return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
 
-    def check_enable_mode(self, check_string="CLI Already in admin mode"):
-        """Check whether we are in enable-admin mode.
-         SROS requires us to do this:
-        *A:HOSTNAME# enable-admin
-        MINOR: CLI Already in admin mode.
-        *A:HOSTNAME#
-        *A:HOSTNAME# enable-admin
-        Password:
-        MINOR: CLI Invalid password.
-        *A:HOSTNAME#
-        """
-        output = self.send_command_timing("enable-admin")
-        if re.search(r"ssword", output):
-            # Just hit enter as we don't actually want to enter enable here
-            self.write_channel(self.normalize_cmd(self.RETURN))
-            self.read_until_prompt()
-            return False
-        elif check_string in output:
-            return True
-        raise ValueError("Unexpected response in check_enable_mode() method")
-
-    def exit_enable_mode(self, exit_command=""):
-        """No corresponding exit of enable mode on SROS."""
+    def enable(self, *args, **kwargs):
+        """Nokia SR OS does not support enable-mode"""
         pass
 
-    def config_mode(self, config_command="configure", pattern="#"):
-        """ Enter into configuration mode on SROS device."""
-        return super().config_mode(config_command=config_command, pattern=pattern)
+    def check_enable_mode(self, *args, **kwargs):
+        """Nokia SR OS does not support enable-mode"""
+        pass
 
-    def exit_config_mode(self, exit_config="exit all", pattern="#"):
-        """ Exit from configuration mode."""
-        return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
+    def exit_enable_mode(self, *args, **kwargs):
+        """Nokia SR OS does not support enable-mode"""
+        pass
 
-    def check_config_mode(self, check_string="config", pattern="#"):
-        """ Checks if the device is in configuration mode or not. """
-        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def config_mode(self, config_command="edit-config private", pattern="#"):
+        """Enable configuration edit-mode for Nokia SR OS"""
+        if '@' not in self.base_prompt:
+            return ""
+        return super(AlcatelSrosSSH, self).config_mode(config_command=config_command, pattern=pattern)
+
+    def exit_config_mode(self, exit_config="quit-config", pattern="#"):
+        """Disable configuration edit-mode for Nokia SR OS"""
+        if '@' not in self.base_prompt:
+            return ""
+        return super(AlcatelSrosSSH, self).exit_config_mode(exit_config=exit_config, pattern=pattern)
+
+    def check_config_mode(self, check_string="(pr)", pattern="#"):
+        """Check configuration edit-mode for Nokia SR OS"""
+        if '@' not in self.base_prompt:
+            return True
+        return super(AlcatelSrosSSH, self).check_config_mode(check_string=check_string, pattern=pattern)
+
 
     def save_config(self, *args, **kwargs):
-        """Not Implemented"""
+        """Persist configuration to cflash for Nokia SR OS"""
+        output = self.send_command(command_string="/admin save")
+        return output
+
+
+    def commit(self, *args, **kwargs):
+        """Activate changes from private candidate for Nokia SR OS"""
+        if '@' not in self.base_prompt:
+            raise AttributeError("'commit' command is only supported in MD-CLI")
+
+        output = self.send_command(command_string="/commit")
+        return output
+
+    def strip_prompt(self, *args, **kwargs):
+        """Strip prompt from the output."""
+        output = super(AlcatelSrosSSH, self).strip_prompt(*args, **kwargs)
+        if '@' in self.base_prompt:
+            # Remove context prompt too
+            strips = r"[\r\n]*\!?\*?(\((ex|gl|pr|ro)\))?\[\S*\][\r\n]*"
+            return re.sub(strips, "", output)
+        else:
+            return output
+
+
+class FileTransferSROS(BaseFileTransfer):
+    def __init__(
+        self, ssh_conn, source_file, dest_file, file_system, direction="put"
+    ):
+        self.ssh_ctl_chan = ssh_conn
+        self.source_file = source_file
+        self.dest_file = dest_file
+        self.direction = direction
+
+        if not file_system:
+            self.file_system = "cf3:"
+        else:
+            self.file_system = file_system
+
+        if direction == "put":
+            self.file_size = os.stat(source_file).st_size
+        elif direction == "get":
+            self.file_size = self.remote_file_size(remote_file=source_file)
+        else:
+            raise ValueError("Invalid direction specified")
+
+
+    def remote_space_available(self, search_pattern=r"(\d+) \w+ free"):
+        """Return space available on remote device."""
+        remote_cmd = "file dir {}".format(self.file_system)
+        remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
+        match = re.search(search_pattern, remote_output)
+        return int(match.group(1))
+
+
+    def check_file_exists(self, remote_cmd=""):
+        """Check if the dest_file already exists on the file system (return boolean)."""
+        if self.direction == "put":
+            remote_cmd = "file dir {}/{}".format(self.file_system, self.dest_file)
+            remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
+            if "File Not Found" in remote_out:
+                return False
+            elif self.dest_file in remote_out:
+                return True
+            else:
+                raise ValueError("Unexpected output from check_file_exists")
+        elif self.direction == "get":
+            return os.path.exists(self.dest_file)
+
+
+    def remote_file_size(self, remote_cmd=None, remote_file=None):
+        """Get the file size of the remote file."""
+        if remote_file is None:
+            if self.direction == "put":
+                remote_file = self.dest_file
+            elif self.direction == "get":
+                remote_file = self.source_file
+        if not remote_cmd:
+            remote_cmd = "file dir {}/{}".format(self.file_system, remote_file)
+        remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
+
+        if "File Not Found" in remote_out:
+            raise IOError("Unable to find file on remote system")
+
+        # Parse dir output for filename. Output format is:
+        # "10/16/2019  10:00p                6738 {filename}"
+
+        pattern = r"(\S+)[ \t]+(\S+)[ \t]+(\d+)[ \t]+{}".format(re.escape(remote_file))
+        match = re.search(pattern, remote_out)
+
+        if not match:
+            raise ValueError("Filename entry not found in dir output")
+
+        file_size = int(match.group(3))
+        return file_size
+
+
+    def remote_md5(self, base_cmd=None, remote_file=None):
+        # Nokia SR OS does not expose a md5sum method
         raise NotImplementedError
+
+
+    def compare_md5(self):
+        # Nokia SR OS does not expose a md5sum method
+        raise NotImplementedError
+
+
+    def verify_file(self):
+        """Verify the file has been transferred correctly based on filesize."""
+        if self.direction == "put":
+            return self.file_size == self.remote_file_size(remote_file=self.source_file)
+        elif self.direction == "get":
+            return self.file_size == os.stat(self.source_file).st_size

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019 NOKIA Inc.
-# MIT License 
-# See License file at https://github.com/ktbyers/netmiko/blob/develop/LICENSE
+# MIT License - See License file at:
+#   https://github.com/ktbyers/netmiko/blob/develop/LICENSE
 
 import re
 import os

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2019 - NOKIA Inc. All Rights Reserved.
 # Please read the associated COPYRIGHTS file for more details.
 
@@ -10,6 +12,7 @@ from netmiko.scp_handler import BaseFileTransfer
 
 
 class AlcatelSrosSSH(BaseConnection):
+
     """
     Implement methods for interacting with Nokia SR OS devices.
 
@@ -33,162 +36,194 @@ class AlcatelSrosSSH(BaseConnection):
         self._test_channel_read()
         self.set_base_prompt()
         if '@' in self.base_prompt:
-            self.disable_paging(command="environment more false")
-            self.set_terminal_width(command="environment console width 512")
+            self.disable_paging(command='environment more false')
+            self.set_terminal_width(command='environment console width 512'
+                                    )
         else:
-            self.disable_paging(command="environment no more")
+            self.disable_paging(command='environment no more')
+
         # Clear the read buffer
+
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
     def set_base_prompt(self, *args, **kwargs):
         """Remove the > when navigating into the different config level."""
-        cur_base_prompt = super(AlcatelSrosSSH, self).set_base_prompt(*args, **kwargs)
+
+        cur_base_prompt = super(AlcatelSrosSSH,
+                                self).set_base_prompt(*args, **kwargs)
         match = re.search(r"\*?(.*)(>.*)*#", cur_base_prompt)
         if match:
+
             # strip off >... from base_prompt
+
             self.base_prompt = match.group(1)
             return self.base_prompt
 
     def enable(self, *args, **kwargs):
         """Nokia SR OS does not support enable-mode"""
+
         pass
 
     def check_enable_mode(self, *args, **kwargs):
         """Nokia SR OS does not support enable-mode"""
+
         pass
 
     def exit_enable_mode(self, *args, **kwargs):
         """Nokia SR OS does not support enable-mode"""
+
         pass
 
-    def config_mode(self, config_command="edit-config private", pattern="#"):
+    def config_mode(self, config_command='edit-config private',
+                    pattern='#'):
         """Enable configuration edit-mode for Nokia SR OS"""
+
         if '@' not in self.base_prompt:
-            return ""
+            return ''
         return super(AlcatelSrosSSH, self).config_mode(
-            config_command=config_command, pattern=pattern
-        )
+            config_command=config_command, pattern=pattern)
 
-    def exit_config_mode(self, exit_config="quit-config", pattern="#"):
+    def exit_config_mode(self, exit_config='quit-config', pattern='#'):
         """Disable configuration edit-mode for Nokia SR OS"""
-        if '@' not in self.base_prompt:
-            return ""
-        return super(AlcatelSrosSSH, self).exit_config_mode(
-            exit_config=exit_config, pattern=pattern
-        )
 
-    def check_config_mode(self, check_string="(pr)", pattern="#"):
+        if '@' not in self.base_prompt:
+            return ''
+        return super(AlcatelSrosSSH, self).exit_config_mode(
+            exit_config=exit_config, pattern=pattern)
+
+    def check_config_mode(self, check_string='(pr)', pattern='#'):
         """Check configuration edit-mode for Nokia SR OS"""
+
         if '@' not in self.base_prompt:
             return True
         return super(AlcatelSrosSSH, self).check_config_mode(
-            check_string=check_string, pattern=pattern
-        )
+            check_string=check_string, pattern=pattern)
 
     def save_config(self, *args, **kwargs):
         """Persist configuration to cflash for Nokia SR OS"""
-        output = self.send_command(command_string="/admin save")
+
+        output = self.send_command(command_string='/admin save')
         return output
 
     def commit(self, *args, **kwargs):
         """Activate changes from private candidate for Nokia SR OS"""
-        if '@' not in self.base_prompt:
-            raise AttributeError("'commit' command is only supported in MD-CLI")
 
-        output = self.send_command(command_string="/commit")
+        if '@' not in self.base_prompt:
+            raise AttributeError('commit is only supported in MD-CLI')
+
+        output = self.send_command(command_string='/commit')
         return output
 
     def strip_prompt(self, *args, **kwargs):
         """Strip prompt from the output."""
+
         output = super(AlcatelSrosSSH, self).strip_prompt(*args, **kwargs)
+
         if '@' in self.base_prompt:
             # Remove context prompt too
             strips = r"[\r\n]*\!?\*?(\((ex|gl|pr|ro)\))?\[\S*\][\r\n]*"
-            return re.sub(strips, "", output)
+            return re.sub(strips, '', output)
         else:
             return output
 
 
 class FileTransferSROS(BaseFileTransfer):
+
     def __init__(
-        self, ssh_conn, source_file, dest_file, file_system, direction="put"
+        self, ssh_conn, source_file, dest_file, file_system, direction='put'
     ):
+
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file
         self.dest_file = dest_file
         self.direction = direction
 
         if not file_system:
-            self.file_system = "cf3:"
+            self.file_system = 'cf3:'
         else:
             self.file_system = file_system
 
-        if direction == "put":
+        if direction == 'put':
             self.file_size = os.stat(source_file).st_size
-        elif direction == "get":
-            self.file_size = self.remote_file_size(remote_file=source_file)
+        elif direction == 'get':
+            self.file_size = \
+                self.remote_file_size(remote_file=source_file)
         else:
-            raise ValueError("Invalid direction specified")
+            raise ValueError('Invalid direction specified')
 
     def remote_space_available(self, search_pattern=r"(\d+) \w+ free"):
         """Return space available on remote device."""
-        remote_cmd = "file dir {}".format(self.file_system)
-        remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
+
+        remote_cmd = 'file dir {}'.format(self.file_system)
+        remote_output = \
+            self.ssh_ctl_chan.send_command_expect(remote_cmd)
         match = re.search(search_pattern, remote_output)
         return int(match.group(1))
 
-    def check_file_exists(self, remote_cmd=""):
-        """Check if the dest_file already exists on the file system (return boolean)."""
-        if self.direction == "put":
-            remote_cmd = "file dir {}/{}".format(self.file_system, self.dest_file)
+    def check_file_exists(self, remote_cmd=''):
+        """Check if destination file exists (returns boolean)."""
+
+        if self.direction == 'put':
+            remote_cmd = 'file dir {}/{}'.format(
+                self.file_system, self.dest_file)
             remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
-            if "File Not Found" in remote_out:
+            if 'File Not Found' in remote_out:
                 return False
             elif self.dest_file in remote_out:
                 return True
             else:
-                raise ValueError("Unexpected output from check_file_exists")
-        elif self.direction == "get":
+                raise ValueError('Unexpected output from check_file_exists'
+                                 )
+        elif self.direction == 'get':
             return os.path.exists(self.dest_file)
 
     def remote_file_size(self, remote_cmd=None, remote_file=None):
         """Get the file size of the remote file."""
+
         if remote_file is None:
-            if self.direction == "put":
+            if self.direction == 'put':
                 remote_file = self.dest_file
-            elif self.direction == "get":
+            elif self.direction == 'get':
                 remote_file = self.source_file
         if not remote_cmd:
-            remote_cmd = "file dir {}/{}".format(self.file_system, remote_file)
+            remote_cmd = 'file dir {}/{}'.format(self.file_system, remote_file)
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
 
-        if "File Not Found" in remote_out:
-            raise IOError("Unable to find file on remote system")
+        if 'File Not Found' in remote_out:
+            raise IOError('Unable to find file on remote system')
 
         # Parse dir output for filename. Output format is:
         # "10/16/2019  10:00p                6738 {filename}"
 
-        pattern = r"(\S+)[ \t]+(\S+)[ \t]+(\d+)[ \t]+{}".format(re.escape(remote_file))
+        pattern = r"(\S+)[ \t]+(\S+)[ \t]+(\d+)[ \t]+{}".format(
+            re.escape(remote_file))
         match = re.search(pattern, remote_out)
 
         if not match:
-            raise ValueError("Filename entry not found in dir output")
+            raise ValueError('Filename entry not found in dir output')
 
         file_size = int(match.group(3))
         return file_size
 
     def remote_md5(self, base_cmd=None, remote_file=None):
+
         # Nokia SR OS does not expose a md5sum method
+
         raise NotImplementedError
 
     def compare_md5(self):
+
         # Nokia SR OS does not expose a md5sum method
+
         raise NotImplementedError
 
     def verify_file(self):
         """Verify the file has been transferred correctly based on filesize."""
-        if self.direction == "put":
-            return self.file_size == self.remote_file_size(remote_file=self.source_file)
-        elif self.direction == "get":
+
+        if self.direction == 'put':
+            return self.file_size \
+                == self.remote_file_size(remote_file=self.source_file)
+        elif self.direction == 'get':
             return self.file_size == os.stat(self.source_file).st_size
+

--- a/netmiko/alcatel/alcatel_sros_ssh.py
+++ b/netmiko/alcatel/alcatel_sros_ssh.py
@@ -217,4 +217,3 @@ class FileTransferSROS(BaseFileTransfer):
             return self.file_size == self.remote_file_size(remote_file=self.source_file)
         elif self.direction == "get":
             return self.file_size == os.stat(self.source_file).st_size
-

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -20,8 +20,6 @@ SNMPDetect class defaults to SNMPv3
 Note, pysnmp is a required dependency for SNMPDetect and is intentionally not included in
 netmiko requirements. So installation of pysnmp might be required.
 """
-from __future__ import unicode_literals
-
 import re
 
 try:
@@ -30,7 +28,6 @@ except ImportError:
     raise ImportError("pysnmp not installed; please install it: 'pip install pysnmp'")
 
 from netmiko.ssh_dispatcher import CLASS_MAPPER
-from netmiko.py23_compat import text_type
 
 
 # Higher priority indicates a better match.
@@ -267,7 +264,7 @@ class SNMPDetect(object):
         )
 
         if not error_detected and snmp_data[0][1]:
-            return text_type(snmp_data[0][1])
+            return str(snmp_data[0][1])
         return ""
 
     def _get_snmpv2c(self, oid):
@@ -296,7 +293,7 @@ class SNMPDetect(object):
         )
 
         if not error_detected and snmp_data[0][1]:
-            return text_type(snmp_data[0][1])
+            return str(snmp_data[0][1])
         return ""
 
     def _get_snmp(self, oid):

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -20,6 +20,8 @@ SNMPDetect class defaults to SNMPv3
 Note, pysnmp is a required dependency for SNMPDetect and is intentionally not included in
 netmiko requirements. So installation of pysnmp might be required.
 """
+from __future__ import unicode_literals
+
 import re
 
 try:
@@ -28,6 +30,7 @@ except ImportError:
     raise ImportError("pysnmp not installed; please install it: 'pip install pysnmp'")
 
 from netmiko.ssh_dispatcher import CLASS_MAPPER
+from netmiko.py23_compat import text_type
 
 
 # Higher priority indicates a better match.
@@ -100,6 +103,11 @@ SNMP_MAPPER_BASE = {
     "juniper_junos": {
         "oid": ".1.3.6.1.2.1.1.1.0",
         "expr": re.compile(r".*Juniper.*"),
+        "priority": 99,
+    },
+    "alcatel_sros": {
+        "oid": ".1.3.6.1.2.1.1.1.0",
+        "expr": re.compile(r".*TiMOS.*"),
         "priority": 99,
     },
 }
@@ -259,7 +267,7 @@ class SNMPDetect(object):
         )
 
         if not error_detected and snmp_data[0][1]:
-            return str(snmp_data[0][1])
+            return text_type(snmp_data[0][1])
         return ""
 
     def _get_snmpv2c(self, oid):
@@ -288,7 +296,7 @@ class SNMPDetect(object):
         )
 
         if not error_detected and snmp_data[0][1]:
-            return str(snmp_data[0][1])
+            return text_type(snmp_data[0][1])
         return ""
 
     def _get_snmp(self, oid):

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -1,15 +1,18 @@
 """Controls selection of proper class based on the device type."""
+from __future__ import unicode_literals
+
 from netmiko.a10 import A10SSH
 from netmiko.accedian import AccedianSSH
 from netmiko.alcatel import AlcatelAosSSH
 from netmiko.alcatel import AlcatelSrosSSH
+from netmiko.alcatel import FileTransferSROS
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
 from netmiko.checkpoint import CheckPointGaiaSSH
-from netmiko.ciena import CienaSaosSSH, CienaSaosTelnet, CienaSaosFileTransfer
+from netmiko.ciena import CienaSaosSSH
 from netmiko.cisco import CiscoAsaSSH, CiscoAsaFileTransfer
 from netmiko.cisco import (
     CiscoIosSSH,
@@ -32,7 +35,7 @@ from netmiko.dell import DellOS10SSH, DellOS10FileTransfer
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
 from netmiko.dell import DellIsilonSSH
-from netmiko.eltex import EltexSSH, EltexEsrSSH
+from netmiko.eltex import EltexSSH
 from netmiko.endace import EndaceSSH
 from netmiko.enterasys import EnterasysSSH
 from netmiko.extreme import ExtremeErsSSH
@@ -115,7 +118,6 @@ CLASS_MAPPER_BASE = {
     "dell_isilon": DellIsilonSSH,
     "endace": EndaceSSH,
     "eltex": EltexSSH,
-    "eltex_esr": EltexEsrSSH,
     "enterasys": EnterasysSSH,
     "extreme": ExtremeExosSSH,
     "extreme_ers": ExtremeErsSSH,
@@ -165,15 +167,15 @@ CLASS_MAPPER_BASE = {
 
 FILE_TRANSFER_MAP = {
     "arista_eos": AristaFileTransfer,
-    "ciena_saos": CienaSaosFileTransfer,
     "cisco_asa": CiscoAsaFileTransfer,
     "cisco_ios": CiscoIosFileTransfer,
+    "dell_os10": DellOS10FileTransfer,
     "cisco_nxos": CiscoNxosFileTransfer,
     "cisco_xe": CiscoIosFileTransfer,
     "cisco_xr": CiscoXrFileTransfer,
-    "dell_os10": DellOS10FileTransfer,
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,
+    "alcatel_sros": FileTransferSROS,
 }
 
 # Also support keys that end in _ssh
@@ -197,7 +199,6 @@ CLASS_MAPPER["arista_eos_telnet"] = AristaTelnet
 CLASS_MAPPER["brocade_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["brocade_netiron_telnet"] = ExtremeNetironTelnet
 CLASS_MAPPER["calix_b6_telnet"] = CalixB6Telnet
-CLASS_MAPPER["ciena_saos_telnet"] = CienaSaosTelnet
 CLASS_MAPPER["cisco_ios_telnet"] = CiscoIosTelnet
 CLASS_MAPPER["cisco_xr_telnet"] = CiscoXrTelnet
 CLASS_MAPPER["dell_dnos6_telnet"] = DellDNOS6Telnet

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -1,6 +1,4 @@
 """Controls selection of proper class based on the device type."""
-from __future__ import unicode_literals
-
 from netmiko.a10 import A10SSH
 from netmiko.accedian import AccedianSSH
 from netmiko.alcatel import AlcatelAosSSH
@@ -12,7 +10,7 @@ from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
 from netmiko.checkpoint import CheckPointGaiaSSH
-from netmiko.ciena import CienaSaosSSH
+from netmiko.ciena import CienaSaosSSH, CienaSaosTelnet, CienaSaosFileTransfer
 from netmiko.cisco import CiscoAsaSSH, CiscoAsaFileTransfer
 from netmiko.cisco import (
     CiscoIosSSH,
@@ -35,7 +33,7 @@ from netmiko.dell import DellOS10SSH, DellOS10FileTransfer
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
 from netmiko.dell import DellIsilonSSH
-from netmiko.eltex import EltexSSH
+from netmiko.eltex import EltexSSH, EltexEsrSSH
 from netmiko.endace import EndaceSSH
 from netmiko.enterasys import EnterasysSSH
 from netmiko.extreme import ExtremeErsSSH
@@ -118,6 +116,7 @@ CLASS_MAPPER_BASE = {
     "dell_isilon": DellIsilonSSH,
     "endace": EndaceSSH,
     "eltex": EltexSSH,
+    "eltex_esr": EltexEsrSSH,
     "enterasys": EnterasysSSH,
     "extreme": ExtremeExosSSH,
     "extreme_ers": ExtremeErsSSH,
@@ -167,12 +166,13 @@ CLASS_MAPPER_BASE = {
 
 FILE_TRANSFER_MAP = {
     "arista_eos": AristaFileTransfer,
+    "ciena_saos": CienaSaosFileTransfer,
     "cisco_asa": CiscoAsaFileTransfer,
     "cisco_ios": CiscoIosFileTransfer,
-    "dell_os10": DellOS10FileTransfer,
     "cisco_nxos": CiscoNxosFileTransfer,
     "cisco_xe": CiscoIosFileTransfer,
     "cisco_xr": CiscoXrFileTransfer,
+    "dell_os10": DellOS10FileTransfer,
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,
     "alcatel_sros": FileTransferSROS,
@@ -199,6 +199,7 @@ CLASS_MAPPER["arista_eos_telnet"] = AristaTelnet
 CLASS_MAPPER["brocade_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["brocade_netiron_telnet"] = ExtremeNetironTelnet
 CLASS_MAPPER["calix_b6_telnet"] = CalixB6Telnet
+CLASS_MAPPER["ciena_saos_telnet"] = CienaSaosTelnet
 CLASS_MAPPER["cisco_ios_telnet"] = CiscoIosTelnet
 CLASS_MAPPER["cisco_xr_telnet"] = CiscoXrTelnet
 CLASS_MAPPER["dell_dnos6_telnet"] = DellDNOS6Telnet


### PR DESCRIPTION
Support for Nokia SR OS devices using Netmiko. The updated module supports both classic CLI and model-driven CLI.

Integration notes:
- When running against MD-CLI the option `exit_config_mode=False` must be used. Use the commit operation to apply changes from candidate to running.
- If trying to exit the configuration mode (quit-config) without commit (or discard) CLI would raise a warning dialogue aka `Discard uncommitted changes? [y,n]`. Therefore we automatically discard changes before `quit-config` to avoid those exceptions.
- `enable-admin` has been removed. It did not really add value. In theory this allows a regular user to get admin privileges. However, if there is a need for admin rights, typically providers would assign the requires access-rights to the user account that is used by Netmiko.
- Classic CLI writes changes directly to the running configuration. No commit/discard exists.
- File operations (SCP) have been integrated. Corresponding CLI commands are "file ..." which is supported in classic CLI and from SR OS 19.10 onwards also in MD-CLI.
- There is no file operation to calculate/print MD5 hashes. Therefore it is not possible to validate copied files using checksums. Therefore option disable_md5 must be set to True. The `verify_file()` method is just comparing file sizes.