### PR TITLE
file_md5 modified to read file in chunks to compute md5 hash

### DIFF
--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -259,12 +259,23 @@ class BaseFileTransfer(object):
             "Search pattern not found for remote file size during SCP transfer."
         )
 
+    # def file_md5(self, file_name):
+    #     """Compute MD5 hash of file."""
+    #     with open(file_name, "rb") as f:
+    #         file_contents = f.read()
+    #         file_hash = hashlib.md5(file_contents).hexdigest()
+    #     return file_hash
+
     def file_md5(self, file_name):
         """Compute MD5 hash of file."""
+        file_hash = hashlib.md5()
         with open(file_name, "rb") as f:
-            file_contents = f.read()
-            file_hash = hashlib.md5(file_contents).hexdigest()
-        return file_hash
+            while True:
+                file_contents = f.read(512)
+                if not file_contents:
+                    break
+                file_hash.update(file_contents)
+        return file_hash.hexdigest()
 
     @staticmethod
     def process_md5(md5_output, pattern=r"=\s+(\S+)"):


### PR DESCRIPTION
md5 hash computation fails for large files on RHEL OS. I tested computing md5 hash of file by reading the file in chunks and it worked. Therefore modified file_md5 function to read the file in chunks and generate md5.