### PR TITLE
Ensure file_size gets created regardless of match.

### DIFF
--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -219,7 +219,7 @@ class BaseFileTransfer(object):
         escape_file_name = re.escape(remote_file)
         pattern = r".*({}).*".format(escape_file_name)
         match = re.search(pattern, remote_out)
-        filesize = sys.maxsize
+        file_size = sys.maxsize
         if match:
             line = match.group(0)
             # Format will be 26  -rw-   6738  Jul 30 2016 19:49:50 -07:00  filename

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -10,7 +10,7 @@ Currently only supports Cisco IOS and Cisco ASA.
 import re
 import os
 import hashlib
-
+import sys
 import scp
 
 
@@ -219,6 +219,7 @@ class BaseFileTransfer(object):
         escape_file_name = re.escape(remote_file)
         pattern = r".*({}).*".format(escape_file_name)
         match = re.search(pattern, remote_out)
+        filesize = sys.maxsize
         if match:
             line = match.group(0)
             # Format will be 26  -rw-   6738  Jul 30 2016 19:49:50 -07:00  filename


### PR DESCRIPTION
I noticed when we accidentally passed in the full path to a file as the source_file of the file_transfer function.  This gets passed along to the remote_file_size function which utilizes regex to search for the filename in the output of a "dir" command.  If there is no match then the variable file_size never gets created.  However, since there was also no error, the remote_file_size function attempts to convert the file_size to an int before returning.  This causes a crash since file_size does not exist.  By forcing it to be the max size before the check for a match, at worst, the file will not be transferred and the program will not crash.  