### PR TITLE
Juniper ScreenOS support

### DIFF
--- a/netmiko/juniper/__init__.py
+++ b/netmiko/juniper/__init__.py
@@ -1,3 +1,4 @@
 from netmiko.juniper.juniper import JuniperSSH, JuniperTelnet, JuniperFileTransfer
+from netmiko.juniper.juniper_screenos import JuniperScreenOsSSH
 
-__all__ = ["JuniperSSH", "JuniperTelnet", "JuniperFileTransfer"]
+__all__ = ["JuniperSSH", "JuniperTelnet", "JuniperFileTransfer","JuniperScreenOsSSH"]

--- a/netmiko/juniper/__init__.py
+++ b/netmiko/juniper/__init__.py
@@ -1,4 +1,4 @@
 from netmiko.juniper.juniper import JuniperSSH, JuniperTelnet, JuniperFileTransfer
 from netmiko.juniper.juniper_screenos import JuniperScreenOsSSH
 
-__all__ = ["JuniperSSH", "JuniperTelnet", "JuniperFileTransfer","JuniperScreenOsSSH"]
+__all__ = ["JuniperSSH", "JuniperTelnet", "JuniperFileTransfer", "JuniperScreenOsSSH"]

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -1,0 +1,56 @@
+import re
+import time
+
+from netmiko.base_connection import BaseConnection
+from netmiko.scp_handler import BaseFileTransfer
+
+
+class JuniperScreenOsBase(BaseConnection):
+    """
+    Implement methods for interacting with Juniper ScreenOS devices.
+    """
+
+    def session_preparation(self):
+        """
+        Prepare the session after the connection has been established.
+
+        Disable paging (the '--more--' prompts).
+        Set the base prompt for interaction ('>').
+        """
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging(command="set console page 0")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on Juniper ScreenOS."""
+        pass
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on Juniper ScreenOS."""
+        pass
+
+    def check_config_mode(self, check_string=""):
+        """Checks whether in configuration mode. Returns a boolean."""
+        return self._in_config_mode
+
+    def save_config(self, cmd="save config", confirm=False, confirm_response=""):
+        """Saves Config Using Save Config"""
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+    def config_mode(self):
+        """No configuration mode on Juniper ScreenOS."""
+        self._in_config_mode = True
+        return ""
+
+    def exit_config_mode(self, exit_config="-"):
+        """No configuration mode on Juniper ScreenOS."""
+        self._in_config_mode = False
+        return ""
+
+class JuniperScreenOsSSH(JuniperScreenOsBase):
+    pass

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -37,10 +37,8 @@ class JuniperScreenOsBase(BaseConnection):
         return self._in_config_mode
 
     def save_config(self, cmd="save config", confirm=False, confirm_response=""):
-        """Saves Config Using Save Config"""
-        return super().save_config(
-            cmd=cmd, confirm=confirm, confirm_response=confirm_response
-        )
+        """Save Config."""
+        return self.send_command(command_string=cmd)
 
     def config_mode(self):
         """No configuration mode on Juniper ScreenOS."""

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -1,8 +1,5 @@
-import re
 import time
-
 from netmiko.base_connection import BaseConnection
-from netmiko.scp_handler import BaseFileTransfer
 
 
 class JuniperScreenOsBase(BaseConnection):
@@ -49,6 +46,7 @@ class JuniperScreenOsBase(BaseConnection):
         """No configuration mode on Juniper ScreenOS."""
         self._in_config_mode = False
         return ""
+
 
 class JuniperScreenOsSSH(JuniperScreenOsBase):
     pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -51,7 +51,7 @@ from netmiko.fortinet import FortinetSSH
 from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH, HuaweiTelnet
 from netmiko.ipinfusion import IpInfusionOcNOSSSH, IpInfusionOcNOSTelnet
-from netmiko.juniper import JuniperSSH, JuniperTelnet,JuniperScreenOsSSH
+from netmiko.juniper import JuniperSSH, JuniperTelnet, JuniperScreenOsSSH
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.keymile import KeymileSSH, KeymileNOSSSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -51,7 +51,7 @@ from netmiko.fortinet import FortinetSSH
 from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH, HuaweiTelnet
 from netmiko.ipinfusion import IpInfusionOcNOSSSH, IpInfusionOcNOSTelnet
-from netmiko.juniper import JuniperSSH, JuniperTelnet
+from netmiko.juniper import JuniperSSH, JuniperTelnet,JuniperScreenOsSSH
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.keymile import KeymileSSH, KeymileNOSSSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
@@ -139,6 +139,7 @@ CLASS_MAPPER_BASE = {
     "ipinfusion_ocnos": IpInfusionOcNOSSSH,
     "juniper": JuniperSSH,
     "juniper_junos": JuniperSSH,
+    "juniper_screenos": JuniperScreenOsSSH,
     "keymile": KeymileSSH,
     "keymile_nos": KeymileNOSSSH,
     "linux": LinuxSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -58,6 +58,14 @@ juniper:
   rollback: 'rollback 0'
   commit_verification: "run show system commit"
 
+juniper_screenos:
+  version: "get system version"
+  basic: "get route"
+  extended_output: "get config" # requires paging to be disabled
+  config:
+    - 'set alias test "test"'
+  config_verification: "get config | inc alias"
+
 fortinet:
   version: "get system status"
   basic: "get system interface physical"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -21,6 +21,16 @@ juniper:
   cmd_response_final: 'archive size 120k files 3'
   commit_comment: 'Unit test on commit with comment'
 
+juniper_screenos:
+  base_prompt: "ssg5-serial-"
+  router_prompt: "ssg5-serial->"
+  enable_prompt: "ssg5-serial->"
+  interface_ip: 100.65.1.1
+  multiple_line_output: 'Total Config size'
+  version_banner: 'Version: 6.3.0.1.0.0.0.0'
+  cmd_response_init: ""
+  cmd_response_final: 'set alias test'
+
 paloalto_panos:
   base_prompt: ntc@pa1
   router_prompt: ntc@pa1>

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -38,6 +38,12 @@ juniper:
   username: admin
   password: juniper123
 
+juniper_screenos:
+  device_type: juniper_screenos
+  ip: 100.65.1.1
+  username: netscreen
+  password: netscreen
+
 paloalto_panos:
   device_type: paloalto_panos
   ip: 10.10.10.15

--- a/tests/test_juniper_screenos.sh
+++ b/tests/test_juniper_screenos.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device juniper_screenos \
+&& py.test -v test_netmiko_config.py --test_device juniper_screenos \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
Tested on  a Juniper SSG 5 

```
ssg5-serial-> get system
Product Name: SSG5-Serial
Serial Number: xxxxxxxxxxxxxxx, Control Number: 00000000
Hardware Version: 0710(0)-(00), FPGA checksum: 00000000, VLAN1 IP (0.0.0.0)
Flash Type: Samsung
Software Version: 6.3.0r14b.0, Type: Firewall+VPN
Feature: AV-K
BOOT Loader Version: 1.3.2
Compiled by build_master at: Mon Dec 14 08:58:02 PST 2015
Base Mac: 2c6b.f50d.3200
File Name: ssg5ssg20.6.3.0r14b.0, Checksum: b405cc36
, Total Memory: 128MB
```

```
(netmiko) ➜  tests git:(ScreenOS) ✗ sh test_juniper_screenos.sh
Starting tests...good luck:
======================================================== test session starts =========================================================
platform darwin -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/nebi/venv/netmiko/bin/python
cachedir: .pytest_cache
rootdir: /Users/nebi/Project/netscreen/netmiko, inifile: setup.cfg
collected 14 items                                                                                                                   

test_netmiko_show.py::test_disable_paging PASSED                                                                               [  7%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                  [ 14%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                               [ 21%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                          [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                 [ 35%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                        [ 42%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                          [ 50%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                  [ 57%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                 [ 64%]
test_netmiko_show.py::test_strip_command PASSED                                                                                [ 71%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                          [ 78%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                 [ 85%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                  [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                   [100%]

====================================================== short test summary info =======================================================
SKIPPED [1] /Users/nebi/Project/netscreen/netmiko/tests/test_netmiko_show.py:82: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /Users/nebi/Project/netscreen/netmiko/tests/test_netmiko_show.py:108: Genie not supported on this platform
=================================================== 12 passed, 2 skipped in 32.79s ===================================================
======================================================== test session starts =========================================================
platform darwin -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/nebi/venv/netmiko/bin/python
cachedir: .pytest_cache
rootdir: /Users/nebi/Project/netscreen/netmiko, inifile: setup.cfg
collected 7 items                                                                                                                    

test_netmiko_config.py::test_ssh_connect PASSED                                                                                [ 14%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                [ 28%]
test_netmiko_config.py::test_config_mode PASSED                                                                                [ 42%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                           [ 57%]
test_netmiko_config.py::test_command_set PASSED                                                                                [ 71%]
test_netmiko_config.py::test_commands_from_file PASSED                                                                         [ 85%]
test_netmiko_config.py::test_disconnect PASSED                                                                                 [100%]

========================================================= 7 passed in 8.27s ==========================================================
```