### PR TITLE
Added sock param support in Netmiko

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -834,6 +834,7 @@ class BaseConnection(object):
             "timeout": self.timeout,
             "auth_timeout": self.auth_timeout,
             "banner_timeout": self.banner_timeout,
+            "sock": self.sock,
         }
 
         # Check if using SSH 'config' file mainly for SSH proxy support

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -75,6 +75,7 @@ class BaseConnection(object):
         session_log_file_mode="write",
         allow_auto_change=False,
         encoding="ascii",
+        sock=None,
     ):
         """
         Initialize attributes for establishing connection to target device.
@@ -191,6 +192,10 @@ class BaseConnection(object):
         :param encoding: Encoding to be used when writing bytes to the output channel.
                 (default: ascii)
         :type encoding: str
+
+        :param sock: An open socket or socket-like object (such as a `.Channel`) to use for
+                communication to the target host (default: None).
+        :type sock: socket
         """
         self.remote_conn = None
 
@@ -232,6 +237,7 @@ class BaseConnection(object):
         self.keepalive = keepalive
         self.allow_auto_change = allow_auto_change
         self.encoding = encoding
+        self.sock = sock
 
         # Netmiko will close the session_log if we open the file
         self.session_log = None

--- a/tests/unit/test_base_connection.py
+++ b/tests/unit/test_base_connection.py
@@ -59,6 +59,7 @@ def test_use_ssh_file():
         auth_timeout=None,
         banner_timeout=10,
         ssh_config_file=join(RESOURCE_FOLDER, "ssh_config"),
+        sock=None,
     )
 
     connect_dict = connection._connect_params_dict()
@@ -102,6 +103,7 @@ def test_use_ssh_file_proxyjump():
         auth_timeout=None,
         banner_timeout=10,
         ssh_config_file=join(RESOURCE_FOLDER, "ssh_config_proxyjump"),
+        sock=None,
     )
 
     connect_dict = connection._connect_params_dict()
@@ -144,6 +146,7 @@ def test_connect_params_dict():
         auth_timeout=None,
         banner_timeout=10,
         ssh_config_file=None,
+        sock=None,
     )
 
     expected = {
@@ -159,6 +162,7 @@ def test_connect_params_dict():
         "passphrase": None,
         "auth_timeout": None,
         "banner_timeout": 10,
+        "sock": None,
     }
     result = connection._connect_params_dict()
     assert result == expected


### PR DESCRIPTION
Added a sock param support in Netmiko since Paramiko already supported.
This should also fix #818 which enables Netmiko to bind address.

Example Usage:
```python
sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.bind(('10.75.58.221', 0)) # The address to bind
sock.connect(('128.9.0.5', 22)) #The server address
net_connect = Netmiko(
    "128.9.0.5",
    username="root",
    password="Test_123",
    device_type="huawei",
    sock=sock
)
```