### PR TITLE
escape spec. chars in re

### DIFF
--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -68,7 +68,7 @@ class NokiaSrosSSH(BaseConnection):
         """Nokia SR OS does not support enable-mode"""
         return ""
 
-    def config_mode(self, config_command="edit-config exclusive", pattern=r"(ex)["):
+    def config_mode(self, config_command="edit-config exclusive", pattern=r"\(ex\)\["):
         """Enable config edit-mode for Nokia SR OS"""
         output = ""
         # Only model-driven CLI supports config-mode


### PR DESCRIPTION
without escaping (even though the string was raw) the tests were failing:
```
========================================================================================================================================== FAILURES ===========================================================================================================================================
______________________________________________________________________________________________________________________________________ test_config_mode _______________________________________________________________________________________________________________________________________

net_connect = <netmiko.nokia.nokia_sros_ssh.NokiaSrosSSH object at 0x7f5067198310>
commands = {'basic': 'show router interface ipv4', 'config': ['configure router ecmp 2', 'configure system location Russia', 'con...cmp 4'], 'config_verification': 'admin show configuration | match ecmp', 'extended_output': 'show chassis detail', ...}
expected_responses = {'base_prompt': 'A:admin@R1', 'cmd_response_final': 'ecmp 4', 'cmd_response_init': 'ecmp 2', 'enable_prompt': 'A:admin@R1#', ...}

    def test_config_mode(net_connect, commands, expected_responses):
        """
        Test enter config mode
        """
>       net_connect.config_mode()

test_netmiko_config.py:28:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../netmiko/nokia/nokia_sros_ssh.py:77: in config_mode
    config_command=config_command, pattern=pattern
../netmiko/base_connection.py:1585: in config_mode
    if not re.search(pattern, output, flags=re.M):
/usr/local/lib/python3.7/re.py:183: in search
    return _compile(pattern, flags).search(string)
/usr/local/lib/python3.7/re.py:286: in _compile
    p = sre_compile.compile(pattern, flags)
/usr/local/lib/python3.7/sre_compile.py:764: in compile
    p = sre_parse.parse(p, flags)
/usr/local/lib/python3.7/sre_parse.py:924: in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
/usr/local/lib/python3.7/sre_parse.py:420: in _parse_sub
    not nested and not items))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = <sre_parse.Tokenizer object at 0x7f5066e9d150>, state = <sre_parse.Pattern object at 0x7f5066e9d1d0>, verbose = 0, nested = 1, first = True

    def _parse(source, state, verbose, nested, first=False):
        # parse a simple pattern
        subpattern = SubPattern(state)

        # precompute constants into local variables
        subpatternappend = subpattern.append
        sourceget = source.get
        sourcematch = source.match
        _len = len
        _ord = ord

        while True:

            this = source.next
            if this is None:
                break # end of pattern
            if this in "|)":
                break # end of subpattern
            sourceget()

            if verbose:
                # skip whitespace and comments
                if this in WHITESPACE:
                    continue
                if this == "#":
                    while True:
                        this = sourceget()
                        if this is None or this == "\n":
                            break
                    continue

            if this[0] == "\\":
                code = _escape(source, this, state)
                subpatternappend(code)

            elif this not in SPECIAL_CHARS:
                subpatternappend((LITERAL, _ord(this)))

            elif this == "[":
                here = source.tell() - 1
                # character set
                set = []
                setappend = set.append
    ##          if sourcematch(":"):
    ##              pass # handle character classes
                if source.next == '[':
                    import warnings
                    warnings.warn(
                        'Possible nested set at position %d' % source.tell(),
                        FutureWarning, stacklevel=nested + 6
                    )
                negate = sourcematch("^")
                # check remaining characters
                while True:
                    this = sourceget()
                    if this is None:
                        raise source.error("unterminated character set",
>                                          source.tell() - here)
E                       re.error: unterminated character set at position 4
```