### PR TITLE
Provide access to device output received before a timeout.

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -543,7 +543,7 @@ class BaseConnection(object):
                     self._write_session_log(new_data)
                 except socket.timeout:
                     raise NetmikoTimeoutException(
-                        "Timed-out reading channel, data not available."
+                        "Timed-out reading channel, data not available.", output
                     )
                 finally:
                     self._unlock_netmiko_session()
@@ -555,7 +555,7 @@ class BaseConnection(object):
             time.sleep(loop_delay * self.global_delay_factor)
             i += 1
         raise NetmikoTimeoutException(
-            f"Timed-out reading channel, pattern not found in output: {pattern}"
+            f"Timed-out reading channel, pattern not found in output: {pattern}", output
         )
 
     def _read_channel_timing(self, delay_factor=1, max_loops=150):
@@ -1395,10 +1395,11 @@ class BaseConnection(object):
             i += 1
             new_data = self.read_channel()
         else:  # nobreak
-            raise IOError(
+            raise NetmikoTimeoutException(
                 "Search pattern never detected in send_command_expect: {}".format(
                     search_pattern
-                )
+                ),
+                output,
             )
 
         output = self._sanitize_output(

--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -92,7 +92,7 @@ class LinuxSSH(CiscoSSHConnection):
                 self.set_base_prompt()
             except socket.timeout:
                 raise NetmikoTimeoutException(
-                    "Timed-out reading channel, data not available."
+                    "Timed-out reading channel, data not available.", output
                 )
             if not self.check_enable_mode():
                 msg = (

--- a/netmiko/ssh_exception.py
+++ b/netmiko/ssh_exception.py
@@ -5,7 +5,10 @@ from paramiko.ssh_exception import AuthenticationException
 class NetmikoTimeoutException(SSHException):
     """SSH session timed trying to connect to the device."""
 
-    pass
+    def __init__(self, *args):
+        super().__init__(args[0])
+        if len(args) > 1:
+            self.output = args[1]
 
 
 class NetmikoAuthenticationException(AuthenticationException):


### PR DESCRIPTION
- Seeing the actual output is very helpful when debugging device interaction.
- A new "output" attribute has been added to NetmikoTimeoutException that
  contains all output received prior to the timeout.  The output text is not
  sanitized in any way so the caller has access to exact device output.
- For backward compatibility, the stringified exception remains as just the
  string error, i.e. it does not include any device output.
- An IOError that arguably should have been a timeout was converted to a
  NetmikoTimeoutError to allow for returning output.