### PR TITLE
Add `special_login_handler()` to ignore password change request.

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -90,7 +90,15 @@ class HuaweiBase(CiscoBaseConnection):
 class HuaweiSSH(HuaweiBase):
     """Huawei SSH driver."""
 
-    pass
+    def special_login_handler(self):
+        """Handle password change request by ignoring it"""
+
+        password_change_prompt = r"(Change now|Please choose 'YES' or 'NO').+"
+        output = self.read_until_prompt_or_pattern(password_change_prompt)
+        if re.search(password_change_prompt, output):
+            self.write_channel("N\n")
+            self._read_channel_expect(pattern="N\n")
+        return output
 
 
 class HuaweiTelnet(HuaweiBase):


### PR DESCRIPTION
In Huawei devices that have password configured for the first time
(no AAA is used), the devices will always ask for password change.
The `special_login_handler()` ignores by answering "N" when such
prompt appears (leaving the prompt unanswered for 15 seconds will
do - but it is too long)