### PR TITLE
ScreenOS - Fix a problem with finding the base_prompt

### DIFF
--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -2,6 +2,7 @@ import time
 from netmiko.base_connection import BaseConnection
 import re
 
+
 class JuniperScreenOsSSH(BaseConnection):
     """
     Implement methods for interacting with Juniper ScreenOS devices.
@@ -22,8 +23,12 @@ class JuniperScreenOsSSH(BaseConnection):
         self.clear_buffer()
 
     def set_base_prompt(self, *args, **kwargs):
-        """ScreenOS is adding '(VR-NAME)' after the hostname to the prompt when using 'set vr VR-NAME' command"""
-        cur_base_prompt = re.sub(r"\(.*\)-$|-$","",super().set_base_prompt(*args, **kwargs))
+        """
+        ScreenOS is adding '(VR-NAME)' after the hostname to the prompt when
+        using 'set vr VR-NAME' command.
+        The solution is to remove it and trailing '-' from base_prompt
+        """
+        cur_base_prompt = re.sub(r"\(.*\)-$|-$", "", super().set_base_prompt(*args, **kwargs))
         match = re.search(r"(.*)", cur_base_prompt)
         if match:
             self.base_prompt = match.group(1)
@@ -32,18 +37,14 @@ class JuniperScreenOsSSH(BaseConnection):
             print(f"else : {self.base_prompt}")
             return cur_base_prompt
 
-
     def send_command(self, *args, **kwargs):
         """ScreenOS needs special handler here due to the prompt changes."""
-
-
         # Change send_command behavior to use self.base_prompt
         kwargs.setdefault("auto_find_prompt", False)
 
         # refresh self.base_prompt
         self.set_base_prompt()
         return super().send_command(*args, **kwargs)
-
 
     def check_enable_mode(self, *args, **kwargs):
         """No enable mode on Juniper ScreenOS."""

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -28,7 +28,9 @@ class JuniperScreenOsSSH(BaseConnection):
         using 'set vr VR-NAME' command.
         The solution is to remove it and trailing '-' from base_prompt
         """
-        cur_base_prompt = re.sub(r"\(.*\)-$|-$", "", super().set_base_prompt(*args, **kwargs))
+        cur_base_prompt = re.sub(
+            r"\(.*\)-$|-$", "", super().set_base_prompt(*args, **kwargs)
+        )
         match = re.search(r"(.*)", cur_base_prompt)
         if match:
             self.base_prompt = match.group(1)

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -72,5 +72,4 @@ class JuniperScreenOsSSH(BaseConnection):
 
     def save_config(self, cmd="save config", confirm=False, confirm_response=""):
         """Save Config."""
-        print("saving...")
         return self.send_command(command_string=cmd)

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -22,8 +22,8 @@ juniper:
   commit_comment: 'Unit test on commit with comment'
 
 juniper_screenos:
-  base_prompt: "ssg5-serial-"
-  router_prompt: "ssg5-serial->"
+  base_prompt: "ssg5-serial"
+  router_prompt: "ssg5-serial"
   enable_prompt: "ssg5-serial->"
   interface_ip: 100.65.1.1
   multiple_line_output: 'Total Config size'


### PR DESCRIPTION
 Due to some command is changing the base_prompt.

Example :

```
ssg5-serial-> set vrouter test
ssg5-serial(test)->
```

The solution is to remove "(VROUTERNAME)" and trailing "-" from base_prompt so it only looking for the hostname. 

```
Starting tests...good luck:
================== test session starts ===================
platform darwin -- Python 3.7.4, pytest-5.3.1, py-1.8.0, p
luggy-0.13.1 -- /Users/juhchr/venv/netmiko/bin/python
cachedir: .pytest_cache
rootdir: /Users/juhchr/Project/netscreen/netmiko, inifile:
 setup.cfg
plugins: pylama-7.7.1
collected 15 items                                       

test_netmiko_show.py::test_disable_paging PASSED   [  6%]
test_netmiko_show.py::test_ssh_connect PASSED      [ 13%]
test_netmiko_show.py::test_ssh_connect_cm PASSED   [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED [ 26
%]
test_netmiko_show.py::test_send_command PASSED     [ 33%]
test_netmiko_show.py::test_send_command_juniper SKIPPED [ 
40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED [ 46%]
test_netmiko_show.py::test_send_command_genie SKIPPED [ 53%]
test_netmiko_show.py::test_base_prompt PASSED      [ 60%]
test_netmiko_show.py::test_strip_prompt PASSED     [ 66%]
test_netmiko_show.py::test_strip_command PASSED    [ 73%]
test_netmiko_show.py::test_normalize_linefeeds PASSED [ 80%]
test_netmiko_show.py::test_clear_buffer PASSED     [ 86%]
test_netmiko_show.py::test_enable_mode PASSED      [ 93%]
test_netmiko_show.py::test_disconnect PASSED       [100%]

================ short test summary info =================
SKIPPED [1] /Users/juhchr/Project/netscreen/netmiko/tests/test_netmiko_show.py:74: <Skipped instance>
SKIPPED [1] /Users/juhchr/Project/netscreen/netmiko/tests/test_netmiko_show.py:96: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /Users/juhchr/Project/netscreen/netmiko/tests/test_netmiko_show.py:122: Genie not supported on this platform
============= 12 passed, 3 skipped in 39.39s =============
================== test session starts ===================
platform darwin -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/juhchr/venv/netmiko/bin/python
cachedir: .pytest_cache
rootdir: /Users/juhchr/Project/netscreen/netmiko, inifile: setup.cfg
plugins: pylama-7.7.1
collected 7 items                                        

test_netmiko_config.py::test_ssh_connect PASSED    [ 14%]
test_netmiko_config.py::test_enable_mode PASSED    [ 28%]
test_netmiko_config.py::test_config_mode PASSED    [ 42%]
test_netmiko_config.py::test_exit_config_mode PASSED [ 57%]
test_netmiko_config.py::test_command_set PASSED    [ 71%]
test_netmiko_config.py::test_commands_from_file PASSED [ 85%]
test_netmiko_config.py::test_disconnect PASSED     [100%]

=================== 7 passed in 8.37s ====================
```