### PR TITLE
Extreme NetIron\MLX platform improvements

### DIFF
--- a/netmiko/extreme/extreme_netiron.py
+++ b/netmiko/extreme/extreme_netiron.py
@@ -1,3 +1,4 @@
+import time
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
@@ -18,6 +19,7 @@ class ExtremeNetironBase(CiscoSSHConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
+
 
 class ExtremeNetironSSH(ExtremeNetironBase):
     pass

--- a/netmiko/extreme/extreme_netiron.py
+++ b/netmiko/extreme/extreme_netiron.py
@@ -8,6 +8,16 @@ class ExtremeNetironBase(CiscoSSHConnection):
             cmd=cmd, confirm=confirm, confirm_response=confirm_response
         )
 
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging(command="skip-page-display")
+        self.set_terminal_width()
+
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
 
 class ExtremeNetironSSH(ExtremeNetironBase):
     pass

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -151,7 +151,13 @@ SSH_MAPPER_BASE = {
     },
     "brocade_netiron": {
         "cmd": "show version",
-        "search_patterns": [r"NetIron"],
+        "search_patterns": [r"NetIron|MLX"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "extreme_netiron": {
+        "cmd": "show version",
+        "search_patterns": [r"NetIron|MLX"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Some changes for Extreme (Brocade) NetIron\MLX devices:

- add autodetect token `MLX` for `brocade_netiron` platform
<details>
  <summary>show vesion for Brocade MLX-8e router:</summary>
 
```
System Mode: MLX
Chassis: MLXe 8-slot (Serial #: BGB2500000,  Part #: 40-1000362-03)
NI-X-HSF Switch Fabric Module 1 (Serial #: BEU04010000,  Part #: 60-1001588-14)
FE 1: Type fe600,  Version 1
FE 3: Type fe600,  Version 1
Switch Fabric Module 1 Up Time is 0 days 11 hours 34 minutes 25 seconds
NI-X-HSF Switch Fabric Module 2 (Serial #: BEU04270000,  Part #: 60-1001588-14)
FE 1: Type fe600,  Version 1
FE 3: Type fe600,  Version 1
Switch Fabric Module 2 Up Time is 0 days 11 hours 34 minutes 25 seconds
==========================================================================
SL M1: BR-MLX-MR2-M Management Module Active (Serial #: BVP04290000, Part #: 60-1002374-06):
Boot     : Version 5.8.0T165 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:10 labeled as xmprm05800
 (521590 bytes) from boot flash
Monitor  : Version 5.8.0T165 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:01:40 labeled as xmb05800
 (539721 bytes) from code flash
IronWare : Version 5.8.0hT163 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:23:50 labeled as xmr05800h
 (9986752 bytes) from Primary
Board ID : 00 MBRIDGE Revision : 37
1666 MHz Power PC processor 7448 (version 8004/0202) 166 MHz bus
512 KB Boot Flash (MX29LV040C), 128 MB Code Flash (MT28F256J3)
4096 MB DRAM INSTALLED
4096 MB DRAM ADDRESSABLE
Active Management uptime is 0 days 11 hours 34 minutes 25 seconds
==========================================================================
SL 1: NI-MLX-10Gx8-M 8-port 10GbE (M) Module (Serial #: BEQ04A30000, Part #: 60-1001587-16)
(LID: dgsFJcIiFOt)
Boot     : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:24 labeled as xmlprm05800
 (449481 bytes) from boot flash
Monitor  : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:40 labeled as xmlb05800
 (568745 bytes) from code flash
IronWare : Version 5.8.0hT177 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:50:00 labeled as xmlp05800h
 (9309018 bytes) from Primary
FPGA versions:
Valid PBIF Version = 2.24, Build Time = 4/7/2016 14:16:00

Valid XPP Version = 0.08, Build Time = 6/27/2016 10:36:00

MACXPP40G 0
MACXPP40G 1
1333 MHz MPC MPC8548 (version 8021/0022) 533 MHz bus
512 KB Boot Flash (MX29LV040C), 64 MB Code Flash (MT28F256J3)
1024 MB DRAM, 8 KB SRAM
LP Slot 1 uptime is 0 days 11 hours 33 minutes 25 seconds
==========================================================================
SL 2: NI-MLX-10Gx8-M 8-port 10GbE (M) Module (Serial #: BEQ04F20000, Part #: 60-1001587-16)
(LID: dgsFJhHhFJt)
Boot     : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:24 labeled as xmlprm05800
 (449481 bytes) from boot flash
Monitor  : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:40 labeled as xmlb05800
 (568745 bytes) from code flash
IronWare : Version 5.8.0hT177 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:50:00 labeled as xmlp05800h
 (9309018 bytes) from Primary
FPGA versions:
Valid PBIF Version = 2.24, Build Time = 4/7/2016 14:16:00

Valid XPP Version = 0.08, Build Time = 6/27/2016 10:36:00

MACXPP40G 0
MACXPP40G 1
1333 MHz MPC MPC8548 (version 8021/0022) 533 MHz bus
512 KB Boot Flash (MX29LV040C), 64 MB Code Flash (MT28F256J3)
1024 MB DRAM, 8 KB SRAM
LP Slot 2 uptime is 0 days 11 hours 33 minutes 25 seconds
==========================================================================
SL 3: NI-MLX-10Gx8-M 8-port 10GbE (M) Module (Serial #: BEQ04A30000, Part #: 60-1001587-16)
(LID: dgsFJcIiFOz)
Boot     : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:24 labeled as xmlprm05800
 (449481 bytes) from boot flash
Monitor  : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:40 labeled as xmlb05800
 (568745 bytes) from code flash
IronWare : Version 5.8.0hT177 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:50:00 labeled as xmlp05800h
 (9309018 bytes) from Primary
FPGA versions:
Valid PBIF Version = 2.24, Build Time = 4/7/2016 14:16:00

Valid XPP Version = 0.08, Build Time = 6/27/2016 10:36:00

MACXPP40G 0
MACXPP40G 1
1333 MHz MPC MPC8548 (version 8021/0022) 533 MHz bus
512 KB Boot Flash (MX29LV040C), 64 MB Code Flash (MT28F256J3)
1024 MB DRAM, 8 KB SRAM
LP Slot 3 uptime is 0 days 11 hours 33 minutes 25 seconds
==========================================================================
SL 4: NI-MLX-10Gx8-M 8-port 10GbE (M) Module (Serial #: BEQ04A10000, Part #: 60-1001587-16)
(LID: dgsFJcGiFFp)
Boot     : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:24 labeled as xmlprm05800
 (449481 bytes) from boot flash
Monitor  : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:40 labeled as xmlb05800
 (568745 bytes) from code flash
IronWare : Version 5.8.0hT177 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:50:00 labeled as xmlp05800h
 (9309018 bytes) from Primary
FPGA versions:
Valid PBIF Version = 2.24, Build Time = 4/7/2016 14:16:00

Valid XPP Version = 0.08, Build Time = 6/27/2016 10:36:00

MACXPP40G 0
MACXPP40G 1
1333 MHz MPC MPC8548 (version 8021/0022) 533 MHz bus
512 KB Boot Flash (MX29LV040C), 64 MB Code Flash (MT28F256J3)
1024 MB DRAM, 8 KB SRAM
LP Slot 4 uptime is 0 days 11 hours 33 minutes 25 seconds
==========================================================================
SL 5: BR-MLX-1GFx24-X 24-port 1GbE SFP Module (Serial #: BND04250000, Part #: 60-1001892-11)
License:  (LID: dpfFJHKjFGO)
Boot     : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:24 labeled as xmlprm05800
 (449481 bytes) from boot flash
Monitor  : Version 5.8.0T175 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on May 18 2015 at 13:02:40 labeled as xmlb05800
 (568745 bytes) from code flash
IronWare : Version 5.8.0hT177 Copyright (c) 1996-2014 Brocade Communications Systems, Inc.
Compiled on Nov  7 2017 at 04:50:00 labeled as xmlp05800h
 (9309018 bytes) from Primary
FPGA versions:
Valid PBIF Version = 4.04, Build Time = 11/10/2014 22:10:00

Valid XPP Version = 1.03, Build Time = 6/30/2016 10:37:00

Valid STATS Version = 0.09, Build Time = 11/21/2010 14:52:00

BCM56512GMAC 0
BCM56512GMAC 1
666 MHz MPC MPC8541E (version 8020/0020) 333 MHz bus
512 KB Boot Flash (MX29LV040C), 16 MB Code Flash (MT28F128J3)
1024 MB DRAM, 8 KB SRAM
LP Slot 5 uptime is 0 days 11 hours 33 minutes 25 seconds
==========================================================================
All show version done
```
</details>

- add autodetect platform `extreme_netiron`
- disable terminal output paging by invoking command `skip-page-display` while session preparation