### PR TITLE
Added self.enable_scripting_mode(command"set cli scripting-mode on") to

### DIFF
--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -20,6 +20,7 @@ class PaloAltoPanosBase(BaseConnection):
         """
         self._test_channel_read()
         self.set_base_prompt(delay_factor=20)
+        self.enable_scripting_mode(command="set cli scripting-mode on")
         self.disable_paging(command="set cli pager off")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)


### PR DESCRIPTION
panos session_preparation. This fixes/removes ansi \x08 characters from
output. Fixing send_command read_until_pattern issues.