### PR TITLE
Fix ansi escape code in output of paloalto_panos device type

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -765,6 +765,7 @@ class BaseConnection(object):
         """
         self._test_channel_read()
         self.set_base_prompt()
+        self.enable_scripting_mode()
         self.disable_paging()
         self.set_terminal_width()
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -765,7 +765,6 @@ class BaseConnection(object):
         """
         self._test_channel_read()
         self.set_base_prompt()
-        self.enable_scripting_mode()
         self.disable_paging()
         self.set_terminal_width()
 

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -25,14 +25,14 @@ class PaloAltoPanosBase(BaseConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-    
+
     def special_login_handler(self, delay_factor=1):
         """Enable scripting mode to remove ANSI escape codes from output
 
         :param delay_factor: See __init__: global_delay_factor
         :type delay_factor: int
         """
-        
+
         command = "set cli scripting-mode on"
 
         delay_factor = self.select_delay_factor(delay_factor)

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -20,6 +20,7 @@ class PaloAltoPanosBase(BaseConnection):
         """
         self._test_channel_read()
         self.set_base_prompt(delay_factor=20)
+        self.enable_scripting_mode(command="set cli scripting-mode on")
         self.disable_paging(command="set cli pager off")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)


### PR DESCRIPTION
Added special_login_handler function to paloalto_panos.py
Sends command set cli scripting-mode on
This disables interactive cli access, and eliminates the ansi escape codes in the output.