### PR TITLE
Specifying pyats and genie version with Python 3.8 environment

### DIFF
--- a/requirements-genie.txt
+++ b/requirements-genie.txt
@@ -1,3 +1,5 @@
 # pyats and genie are not available for Python 3.8 yet
-pyats>=19.7; python_version<"3.8"
-genie>=19.7; python_version<"3.8"
+pyats>=19.7,<20.2; python_version<"3.8"
+genie>=19.7,<20.2; python_version<"3.8"
+pyats>=20.2; python_version>="3.8"
+genie>=20.2; python_version>="3.8"

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -3,6 +3,7 @@
 import os
 from os.path import dirname, join, relpath
 import sys
+import pkg_resources
 
 import pytest
 
@@ -178,7 +179,8 @@ def test_clitable_to_dict():
     """Converts TextFSM cli_table object to list of dictionaries"""
     table = clitable.CliTable(template_dir=RESOURCE_FOLDER)
     text_filename = join(RESOURCE_FOLDER, "textfsm.txt")
-    template_filename = join(RESOURCE_FOLDER, "cisco_ios_show_version.template")
+    template_filename = join(
+        RESOURCE_FOLDER, "cisco_ios_show_version.template")
     with open(text_filename) as data_file:
         text = data_file.read()
 
@@ -252,8 +254,10 @@ def test_textfsm_missing_template():
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 8),
-    reason="The genie package is not available for Python 3.8 yet",
+    sys.version_info >= (3, 8) and float(
+        pkg_resources.get_distribution("genie").version) < 20.0,
+    # reason="The genie package is not available for Python 3.8 yet",
+    reason="The genie package is available in Python 3.8 after 20.2 version",
 )
 def test_get_structured_data_genie():
     """Convert raw CLI output to structured data using Genie"""

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -179,8 +179,7 @@ def test_clitable_to_dict():
     """Converts TextFSM cli_table object to list of dictionaries"""
     table = clitable.CliTable(template_dir=RESOURCE_FOLDER)
     text_filename = join(RESOURCE_FOLDER, "textfsm.txt")
-    template_filename = join(
-        RESOURCE_FOLDER, "cisco_ios_show_version.template")
+    template_filename = join(RESOURCE_FOLDER, "cisco_ios_show_version.template")
     with open(text_filename) as data_file:
         text = data_file.read()
 
@@ -254,8 +253,8 @@ def test_textfsm_missing_template():
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 8) and float(
-        pkg_resources.get_distribution("genie").version) < 20.0,
+    sys.version_info >= (3, 8)
+    and float(pkg_resources.get_distribution("genie").version) < 20.0,
     # reason="The genie package is not available for Python 3.8 yet",
     reason="The genie package is available in Python 3.8 after 20.2 version",
 )


### PR DESCRIPTION
Hello!

This PR is just an amendment to `requirements-genie.txt` to install `pyats` and `genie` modules with version 20.2 (or above) if the environment is running on python 3.8.

Here are some snippets of the install on different python versions.

python 3.6:
```shell
$ python --version
Python 3.6.10
 pip install -r requirements-genie.txt
Ignoring pyats: markers 'python_version >= "3.8"' don't match your environment
Ignoring genie: markers 'python_version >= "3.8"' don't match your environment
Collecting pyats<20.2,>=19.7
  Downloading pyats-20.1-cp36-cp36m-macosx_10_10_x86_64.whl (533 kB)
     |████████████████████████████████| 533 kB 592 kB/s
Collecting genie<20.2,>=19.7
  Downloading genie-20.1-cp36-cp36m-macosx_10_10_x86_64.whl (5.2 MB)
     |████████████████████████████████| 5.2 MB 107 kB/s
...
<omitted output>
```

python 3.8:
```shell
$ python --version
Python 3.8.1
$ pip install -r requirements-genie.txt
Ignoring pyats: markers 'python_version < "3.8"' don't match your environment
Ignoring genie: markers 'python_version < "3.8"' don't match your environment
Collecting pyats>=20.2
  Downloading pyats-20.2-cp38-cp38-macosx_10_10_x86_64.whl (530 kB)
     |████████████████████████████████| 530 kB 238 kB/s
Collecting genie>=20.2
  Downloading genie-20.2-cp38-cp38-macosx_10_10_x86_64.whl (5.2 MB)
     |████████████████████████████████| 5.2 MB 253 kB/s
...
<omitted output>
```

Although the `tox` tests passed, I double checked on the test `tests/unit/test_utilities.py::test_get_structured_data_genie` on each environment.

python3.6:
```shell
pytest tests/unit/test_utilities.py
========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.6.10, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/netpanda/repos/netmiko, inifile: setup.cfg
collected 19 items

tests/unit/test_utilities.py ...................                                                                                                                  [100%]

========================================================================== 19 passed in 0.47s ===========================================================================
```

python 3.8:
```shell
pytest tests/unit/test_utilities.py
========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.8.1, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/netpanda/repos/netmiko, inifile: setup.cfg
plugins: pylama-7.7.1
collected 19 items

tests/unit/test_utilities.py ...................                                                                                                                  [100%]

========================================================================== 19 passed in 0.49s ===========================================================================
```