### PR TITLE
Refactored format strings using shorthand f"" to use "".format()

### DIFF
--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -24,13 +24,13 @@ class AristaBase(CiscoSSHConnection):
 
         Can also be (s2)
         """
-        log.debug(f"pattern: {pattern}")
+        log.debug("pattern: {}".format(pattern))
         self.write_channel(self.RETURN)
         output = self.read_until_pattern(pattern=pattern)
-        log.debug(f"check_config_mode: {repr(output)}")
+        log.debug("check_config_mode: {}".format(repr(output)))
         output = output.replace("(s1)", "")
         output = output.replace("(s2)", "")
-        log.debug(f"check_config_mode: {repr(output)}")
+        log.debug("check_config_mode: {}".format(repr(output)))
         return check_string in output
 
     def _enter_shell(self):
@@ -94,7 +94,7 @@ class AristaFileTransfer(CiscoFileTransfer):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_md5_cmd = f"{base_cmd} file:{self.file_system}/{remote_file}"
+        remote_md5_cmd = "{} file:{}/{}".format(base_cmd, self.file_system, remote_file)
         dest_md5 = self.ssh_ctl_chan.send_command(
             remote_md5_cmd, max_loops=750, delay_factor=4
         )

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -482,7 +482,7 @@ class BaseConnection(object):
                 )
         if self.ansi_escape_codes:
             output = self.strip_ansi_escape_codes(output)
-        log.debug(f"read_channel: {output}")
+        log.debug("read_channel: {}".format(output))
         self._write_session_log(output)
         return output
 
@@ -525,7 +525,7 @@ class BaseConnection(object):
         output = ""
         if not pattern:
             pattern = re.escape(self.base_prompt)
-        log.debug(f"Pattern is: {pattern}")
+        log.debug("Pattern is: {}".format(pattern))
 
         i = 1
         loop_delay = 0.1
@@ -544,7 +544,7 @@ class BaseConnection(object):
                     new_data = new_data.decode("utf-8", "ignore")
                     if self.ansi_escape_codes:
                         new_data = self.strip_ansi_escape_codes(new_data)
-                    log.debug(f"_read_channel_expect read_data: {new_data}")
+                    log.debug("_read_channel_expect read_data: {}".format(new_data))
                     output += new_data
                     self._write_session_log(new_data)
                 except socket.timeout:
@@ -556,12 +556,12 @@ class BaseConnection(object):
             elif self.protocol == "telnet" or "serial":
                 output += self.read_channel()
             if re.search(pattern, output, flags=re_flags):
-                log.debug(f"Pattern found: {pattern} {output}")
+                log.debug("Pattern found: {} {}".format(pattern, output))
                 return output
             time.sleep(loop_delay * self.global_delay_factor)
             i += 1
         raise NetmikoTimeoutException(
-            f"Timed-out reading channel, pattern not found in output: {pattern}"
+            "Timed-out reading channel, pattern not found in output: {}".format(pattern)
         )
 
     def _read_channel_timing(self, delay_factor=1, max_loops=150):
@@ -719,7 +719,7 @@ class BaseConnection(object):
                 i += 1
             except EOFError:
                 self.remote_conn.close()
-                msg = f"Login failed: {self.host}"
+                msg = "Login failed: {}".format(self.host)
                 raise NetmikoAuthenticationException(msg)
 
         # Last try to see if we already logged in
@@ -732,7 +732,7 @@ class BaseConnection(object):
         ):
             return return_msg
 
-        msg = f"Login failed: {self.host}"
+        msg = "Login failed: {}".format(self.host)
         self.remote_conn.close()
         raise NetmikoAuthenticationException(msg)
 
@@ -905,7 +905,7 @@ class BaseConnection(object):
                 raise NetmikoAuthenticationException(msg)
 
             if self.verbose:
-                print(f"SSH connection established to {self.host}:{self.port}")
+                print("SSH connection established to {}:{}".format(self.host, self.port))
 
             # Use invoke_shell to establish an 'interactive session'
             if width and height:
@@ -1016,11 +1016,11 @@ class BaseConnection(object):
         self.clear_buffer()
         command = self.normalize_cmd(command)
         log.debug("In disable_paging")
-        log.debug(f"Command: {command}")
+        log.debug("Command: {}".format(command))
         self.write_channel(command)
         # Make sure you read until you detect the command echo (avoid getting out of sync)
         output = self.read_until_pattern(pattern=re.escape(command.strip()))
-        log.debug(f"{output}")
+        log.debug("{}".format(output))
         log.debug("Exiting disable_paging")
         return output
 
@@ -1069,7 +1069,7 @@ class BaseConnection(object):
         """
         prompt = self.find_prompt(delay_factor=delay_factor)
         if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
-            raise ValueError(f"Router prompt not found: {repr(prompt)}")
+            raise ValueError("Router prompt not found: {}".format(repr(prompt)))
         # Strip off trailing terminator
         self.base_prompt = prompt[:-1]
         return self.base_prompt
@@ -1096,7 +1096,7 @@ class BaseConnection(object):
             prompt = self.read_channel().strip()
             if not prompt:
                 self.write_channel(self.RETURN)
-                # log.debug(f"find_prompt sleep time: {sleep_time}")
+                # log.debug("find_prompt sleep time: {}".format(sleep_time))
                 time.sleep(sleep_time)
                 if sleep_time <= 3:
                     # Double the sleep_time when it is small
@@ -1110,10 +1110,10 @@ class BaseConnection(object):
         prompt = prompt.split(self.RESPONSE_RETURN)[-1]
         prompt = prompt.strip()
         if not prompt:
-            raise ValueError(f"Unable to find prompt: {prompt}")
+            raise ValueError("Unable to find prompt: {}".format(prompt))
         time.sleep(delay_factor * 0.1)
         self.clear_buffer()
-        log.debug(f"[find_prompt()]: prompt is {prompt}")
+        log.debug("[find_prompt()]: prompt is {}".format(prompt))
         return prompt
 
     def clear_buffer(self, backoff=True):
@@ -1206,12 +1206,12 @@ class BaseConnection(object):
                 new_data = new_data.split(cmd)[1:]
                 new_data = self.RESPONSE_RETURN.join(new_data)
                 new_data = new_data.lstrip()
-                output = f"{cmd}{self.RESPONSE_RETURN}{new_data}"
+                output = "{}{}{}".format(cmd, self.RESPONSE_RETURN, new_data)
             else:
                 # cmd is in the actual output (not just echoed)
                 output = new_data
 
-        log.debug(f"send_command_timing current output: {output}")
+        log.debug("send_command_timing current output: {}".format(output))
 
         output += self._read_channel_timing(
             delay_factor=delay_factor, max_loops=max_loops
@@ -1242,7 +1242,7 @@ class BaseConnection(object):
             if not isinstance(structured_output, str):
                 return structured_output
 
-        log.debug(f"send_command_timing final output: {output}")
+        log.debug("send_command_timing final output: {}".format(output))
         return output
 
     def strip_prompt(self, a_string):
@@ -1382,7 +1382,7 @@ class BaseConnection(object):
                 new_data = new_data.split(cmd)[1:]
                 new_data = self.RESPONSE_RETURN.join(new_data)
                 new_data = new_data.lstrip()
-                new_data = f"{cmd}{self.RESPONSE_RETURN}{new_data}"
+                new_data = "{}{}{}".format(cmd, self.RESPONSE_RETURN, new_data)
 
         i = 1
         output = ""
@@ -1632,7 +1632,7 @@ class BaseConnection(object):
                 output += self.read_until_pattern(pattern=pattern)
             if self.check_config_mode():
                 raise ValueError("Failed to exit configuration mode")
-        log.debug(f"exit_config_mode: {output}")
+        log.debug("exit_config_mode: {}".format(output))
         return output
 
     def send_config_from_file(self, config_file=None, **kwargs):
@@ -1740,7 +1740,7 @@ class BaseConnection(object):
                 output += new_output
 
                 # We might capture next prompt in the original read
-                pattern = f"(?:{re.escape(self.base_prompt)}|#)"
+                pattern = "(?:{}|#)".format(re.escape(self.base_prompt))
                 if not re.search(pattern, new_output):
                     # Make sure trailing prompt comes back (after command)
                     # NX-OS has fast-buffering problem where it immediately echoes command
@@ -1751,7 +1751,7 @@ class BaseConnection(object):
         if exit_config_mode:
             output += self.exit_config_mode()
         output = self._sanitize_output(output)
-        log.debug(f"{output}")
+        log.debug("{}".format(output))
         return output
 
     def strip_ansi_escape_codes(self, string_buffer):
@@ -1785,7 +1785,7 @@ class BaseConnection(object):
         :type string_buffer: str
         """  # noqa
         log.debug("In strip_ansi_escape_codes")
-        log.debug(f"repr = {repr(string_buffer)}")
+        log.debug("repr = {}".format(repr(string_buffer)))
 
         code_position_cursor = chr(27) + r"\[\d+;\d+H"
         code_show_cursor = chr(27) + r"\[\?25h"
@@ -1842,8 +1842,8 @@ class BaseConnection(object):
         output = re.sub(code_next_line, self.RETURN, output)
 
         log.debug("Stripping ANSI escape codes")
-        log.debug(f"new_output = {output}")
-        log.debug(f"repr = {repr(output)}")
+        log.debug("new_output = {}".format(output))
+        log.debug("repr = {}".format(repr(output)))
 
         return output
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -905,7 +905,9 @@ class BaseConnection(object):
                 raise NetmikoAuthenticationException(msg)
 
             if self.verbose:
-                print("SSH connection established to {}:{}".format(self.host, self.port))
+                print(
+                    "SSH connection established to {}:{}".format(self.host, self.port)
+                )
 
             # Use invoke_shell to establish an 'interactive session'
             if width and height:

--- a/netmiko/ciena/ciena_saos.py
+++ b/netmiko/ciena/ciena_saos.py
@@ -111,8 +111,8 @@ class CienaSaosFileTransfer(BaseFileTransfer):
         remote_cmd = "file vols -P {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
         remote_output = remote_output.strip()
-        err_msg = (
-            "Parsing error, unexpected output from {}:\n{}".format(remote_cmd, remote_output)
+        err_msg = "Parsing error, unexpected output from {}:\n{}".format(
+            remote_cmd, remote_output
         )
 
         # First line is the header; file_system_line is the output we care about

--- a/netmiko/ciena/ciena_saos.py
+++ b/netmiko/ciena/ciena_saos.py
@@ -89,7 +89,7 @@ class CienaSaosFileTransfer(BaseFileTransfer):
         **kwargs,
     ):
         if file_system == "":
-            file_system = f"/tmp/users/{ssh_conn.username}"
+            file_system = "/tmp/users/{}".format(ssh_conn.username)
         return super().__init__(
             ssh_conn=ssh_conn,
             source_file=source_file,
@@ -108,11 +108,11 @@ class CienaSaosFileTransfer(BaseFileTransfer):
         Filesystem           1K-blocks      Used Available Use% Mounted on
         tmpfs                  1048576       648   1047928   0% /tmp
         """
-        remote_cmd = f"file vols -P {self.file_system}"
+        remote_cmd = "file vols -P {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
         remote_output = remote_output.strip()
         err_msg = (
-            f"Parsing error, unexpected output from {remote_cmd}:\n{remote_output}"
+            "Parsing error, unexpected output from {}:\n{}".format(remote_cmd, remote_output)
         )
 
         # First line is the header; file_system_line is the output we care about
@@ -143,9 +143,9 @@ class CienaSaosFileTransfer(BaseFileTransfer):
         """Check if the dest_file already exists on the file system (return boolean)."""
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = f"file ls {self.file_system}/{self.dest_file}"
+                remote_cmd = "file ls {}/{}".format(self.file_system, self.dest_file)
             remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
-            search_string = re.escape(f"{self.file_system}/{self.dest_file}")
+            search_string = re.escape("{}/{}".format(self.file_system, self.dest_file))
             if "ERROR" in remote_out:
                 return False
             elif re.search(search_string, remote_out):
@@ -163,10 +163,10 @@ class CienaSaosFileTransfer(BaseFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
 
-        remote_file = f"{self.file_system}/{remote_file}"
+        remote_file = "{}/{}".format(self.file_system, remote_file)
 
         if not remote_cmd:
-            remote_cmd = f"file ls -l {remote_file}"
+            remote_cmd = "file ls -l {}".format(remote_file)
 
         remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
 
@@ -199,7 +199,7 @@ class CienaSaosFileTransfer(BaseFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
 
-        remote_md5_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
+        remote_md5_cmd = "{} {}/{}".format(base_cmd,self.file_system, remote_file)
 
         self.ssh_ctl_chan._enter_shell()
         dest_md5 = self.ssh_ctl_chan.send_command(

--- a/netmiko/ciena/ciena_saos.py
+++ b/netmiko/ciena/ciena_saos.py
@@ -199,7 +199,7 @@ class CienaSaosFileTransfer(BaseFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
 
-        remote_md5_cmd = "{} {}/{}".format(base_cmd,self.file_system, remote_file)
+        remote_md5_cmd = "{} {}/{}".format(base_cmd, self.file_system, remote_file)
 
         self.ssh_ctl_chan._enter_shell()
         dest_md5 = self.ssh_ctl_chan.send_command(

--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -138,7 +138,7 @@ class InLineTransfer(CiscoIosFileTransfer):
         )
         for pattern in cmd_failed:
             if pattern in output:
-                raise ValueError(f"Failed to enter tclsh mode on router: {output}")
+                raise ValueError("Failed to enter tclsh mode on router: {}".format(output))
         return output
 
     def _exit_tcl_mode(self):

--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -138,7 +138,9 @@ class InLineTransfer(CiscoIosFileTransfer):
         )
         for pattern in cmd_failed:
             if pattern in output:
-                raise ValueError("Failed to enter tclsh mode on router: {}".format(output))
+                raise ValueError(
+                    "Failed to enter tclsh mode on router: {}".format(output)
+                )
         return output
 
     def _exit_tcl_mode(self):

--- a/netmiko/cisco/cisco_nxos_ssh.py
+++ b/netmiko/cisco/cisco_nxos_ssh.py
@@ -113,7 +113,9 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_md5_cmd = "{} {}{} md5sum".format(base_cmd, self.file_system, remote_file)
+        remote_md5_cmd = "{} {}{} md5sum".format(
+            base_cmd, self.file_system, remote_file
+        )
         return self.ssh_ctl_chan.send_command(remote_md5_cmd, max_loops=1500).strip()
 
     def enable_scp(self, cmd=None):

--- a/netmiko/cisco/cisco_nxos_ssh.py
+++ b/netmiko/cisco/cisco_nxos_ssh.py
@@ -65,7 +65,7 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
         """Check if the dest_file already exists on the file system (return boolean)."""
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = f"dir {self.file_system}{self.dest_file}"
+                remote_cmd = "dir {}{}".format(self.file_system, self.dest_file)
             remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
             search_string = r"{}.*Usage for".format(self.dest_file)
             if "No such file or directory" in remote_out:
@@ -86,7 +86,7 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
                 remote_file = self.source_file
 
         if not remote_cmd:
-            remote_cmd = f"dir {self.file_system}/{remote_file}"
+            remote_cmd = "dir {}/{}".format(self.file_system, remote_file)
 
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
         # Match line containing file name
@@ -113,7 +113,7 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_md5_cmd = f"{base_cmd} {self.file_system}{remote_file} md5sum"
+        remote_md5_cmd = "{} {}{} md5sum".format(base_cmd, self.file_system, remote_file)
         return self.ssh_ctl_chan.send_command(remote_md5_cmd, max_loops=1500).strip()
 
     def enable_scp(self, cmd=None):

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -102,7 +102,7 @@ class CiscoWlcSSH(BaseConnection):
         try:
             self.set_base_prompt()
         except ValueError:
-            msg = f"Authentication failed: {self.host}"
+            msg = "Authentication failed: {}".format(self.host)
             raise NetmikoAuthenticationException(msg)
 
         self.disable_paging(command="config paging disable")

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -77,17 +77,17 @@ class CiscoXrBase(CiscoBaseConnection):
         # Select proper command string based on arguments provided
         if label:
             if comment:
-                command_string = f"commit label {label} comment {comment}"
+                command_string = "commit label {} comment {}".format(label, comment)
             elif confirm:
                 command_string = "commit label {} confirmed {}".format(
                     label, str(confirm_delay)
                 )
             else:
-                command_string = f"commit label {label}"
+                command_string = "commit label {}".format(label)
         elif confirm:
-            command_string = f"commit confirmed {str(confirm_delay)}"
+            command_string = "commit confirmed {}".format(str(confirm_delay))
         elif comment:
-            command_string = f"commit comment {comment}"
+            command_string = "commit comment {}".format(comment)
         else:
             command_string = "commit"
 
@@ -100,13 +100,13 @@ class CiscoXrBase(CiscoBaseConnection):
             delay_factor=delay_factor,
         )
         if error_marker in output:
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
         if alt_error_marker in output:
             # Other commits occurred, don't proceed with commit
             output += self.send_command_timing(
                 "no", strip_prompt=False, strip_command=False, delay_factor=delay_factor
             )
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
 
         return output
 
@@ -170,7 +170,7 @@ class CiscoXrFileTransfer(CiscoFileTransfer):
         if match:
             return match.group(1)
         else:
-            raise ValueError(f"Invalid output from MD5 command: {md5_output}")
+            raise ValueError("Invalid output from MD5 command: {}".format(md5_output))
 
     def remote_md5(self, base_cmd="show md5 file", remote_file=None):
         """
@@ -184,7 +184,7 @@ class CiscoXrFileTransfer(CiscoFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
         # IOS-XR requires both the leading slash and the slash between file-system and file here
-        remote_md5_cmd = f"{base_cmd} /{self.file_system}/{remote_file}"
+        remote_md5_cmd = "{} /{}/{}".format(base_cmd, self.file_system, remote_file)
         dest_md5 = self.ssh_ctl_chan.send_command(remote_md5_cmd, max_loops=1500)
         dest_md5 = self.process_md5(dest_md5)
         return dest_md5

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -100,13 +100,17 @@ class CiscoXrBase(CiscoBaseConnection):
             delay_factor=delay_factor,
         )
         if error_marker in output:
-            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with the following errors:\n\n{}".format(output)
+            )
         if alt_error_marker in output:
             # Other commits occurred, don't proceed with commit
             output += self.send_command_timing(
                 "no", strip_prompt=False, strip_command=False, delay_factor=delay_factor
             )
-            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with the following errors:\n\n{}".format(output)
+            )
 
         return output
 

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -140,7 +140,7 @@ class CiscoBaseConnection(BaseConnection):
                 i += 1
             except EOFError:
                 self.remote_conn.close()
-                msg = f"Login failed: {self.host}"
+                msg = "Login failed: {}".format(self.host)
                 raise NetmikoAuthenticationException(msg)
 
         # Last try to see if we already logged in
@@ -154,7 +154,7 @@ class CiscoBaseConnection(BaseConnection):
             return return_msg
 
         self.remote_conn.close()
-        msg = f"Login failed: {self.host}"
+        msg = "Login failed: {}".format(self.host)
         raise NetmikoAuthenticationException(msg)
 
     def cleanup(self, command="exit"):
@@ -178,7 +178,7 @@ class CiscoBaseConnection(BaseConnection):
         if match:
             file_system = match.group(1)
             # Test file_system
-            cmd = f"dir {file_system}"
+            cmd = "dir {}".format(file_system)
             output = self.send_command_expect(cmd)
             if "% Invalid" in output or "%Error:" in output:
                 raise ValueError(

--- a/netmiko/citrix/netscaler_ssh.py
+++ b/netmiko/citrix/netscaler_ssh.py
@@ -12,7 +12,7 @@ class NetscalerSSH(BaseConnection):
         delay_factor = self.select_delay_factor(delay_factor=0)
         self._test_channel_read()
         self.set_base_prompt()
-        cmd = f"{self.RETURN}set cli mode -page OFF{self.RETURN}"
+        cmd = "{}set cli mode -page OFF{}".format(self.RETURN, self.RETURN)
         self.disable_paging(command=cmd)
         time.sleep(1 * delay_factor)
         self.set_base_prompt()
@@ -28,7 +28,7 @@ class NetscalerSSH(BaseConnection):
         """
         prompt = self.find_prompt(delay_factor=delay_factor)
         if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
-            raise ValueError(f"Router prompt not found: {repr(prompt)}")
+            raise ValueError("Router prompt not found: {}".format(repr(prompt)))
 
         prompt = prompt.strip()
         if len(prompt) == 1:

--- a/netmiko/dell/dell_isilon_ssh.py
+++ b/netmiko/dell/dell_isilon_ssh.py
@@ -41,7 +41,7 @@ class DellIsilonSSH(BaseConnection):
         self.clear_buffer()
 
     def set_prompt(self, prompt_terminator="$"):
-        prompt = f"PROMPT='%m{prompt_terminator}'"
+        prompt = "PROMPT='%m{}'".format(prompt_terminator)
         command = self.RETURN + prompt + self.RETURN
         self.write_channel(command)
 

--- a/netmiko/dell/dell_os10_ssh.py
+++ b/netmiko/dell/dell_os10_ssh.py
@@ -100,13 +100,13 @@ class DellOS10FileTransfer(BaseFileTransfer):
 
     def put_file(self):
         """SCP copy the file from the local system to the remote device."""
-        destination = f"{self.dest_file}"
+        destination = "{}".format(self.dest_file)
         self.scp_conn.scp_transfer_file(self.source_file, destination)
         # Must close the SCP connection to get the file written (flush)
         self.scp_conn.close()
 
     def get_file(self):
         """SCP copy the file from the remote device to local system."""
-        source_file = f"{self.source_file}"
+        source_file = "{}".format(self.source_file)
         self.scp_conn.scp_get_file(source_file, self.dest_file)
         self.scp_conn.close()

--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -20,7 +20,7 @@ class F5TmshSSH(BaseConnection):
         """tmsh command is equivalent to config command on F5."""
         delay_factor = self.select_delay_factor(delay_factor)
         self.clear_buffer()
-        command = f"{self.RETURN}tmsh{self.RETURN}"
+        command = "{}tmsh{}".format(self.RETURN, self.RETURN)
         self.write_channel(command)
         time.sleep(1 * delay_factor)
         self.clear_buffer()

--- a/netmiko/flexvnf/flexvnf_ssh.py
+++ b/netmiko/flexvnf/flexvnf_ssh.py
@@ -162,7 +162,9 @@ class FlexvnfSSH(BaseConnection):
             )
 
         if commit_marker not in output:
-            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with the following errors:\n\n{}".format(output)
+            )
 
         return output
 

--- a/netmiko/flexvnf/flexvnf_ssh.py
+++ b/netmiko/flexvnf/flexvnf_ssh.py
@@ -162,7 +162,7 @@ class FlexvnfSSH(BaseConnection):
             )
 
         if commit_marker not in output:
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
 
         return output
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -89,7 +89,7 @@ class FortinetSSH(CiscoSSHConnection):
         """Re-enable paging globally."""
         if self.allow_disable_global:
             # Return paging state
-            output_mode_cmd = f"set output {self._output_mode}"
+            output_mode_cmd = "set output {}".format(self._output_mode)
             enable_paging_commands = ["config system console", output_mode_cmd, "end"]
             if self.vdoms:
                 enable_paging_commands.insert(0, "config global")

--- a/netmiko/hp/hp_procurve.py
+++ b/netmiko/hp/hp_procurve.py
@@ -65,7 +65,7 @@ class HPProcurveBase(CiscoSSHConnection):
             output += new_output
             i += 1
 
-        log.debug(f"{output}")
+        log.debug("{}".format(output))
         self.clear_buffer()
         msg = (
             "Failed to enter enable mode. Please ensure you pass "

--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -67,7 +67,7 @@ class HuaweiBase(CiscoBaseConnection):
 
         # Check that ends with a valid terminator character
         if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
-            raise ValueError(f"Router prompt not found: {prompt}")
+            raise ValueError("Router prompt not found: {}".format(prompt))
 
         # Strip off any leading HRP_. characters for USGv5 HA
         prompt = re.sub(r"^HRP_.", "", prompt, flags=re.M)
@@ -76,7 +76,7 @@ class HuaweiBase(CiscoBaseConnection):
         prompt = prompt[1:-1]
         prompt = prompt.strip()
         self.base_prompt = prompt
-        log.debug(f"prompt: {self.base_prompt}")
+        log.debug("prompt: {}".format(self.base_prompt))
 
         return self.base_prompt
 
@@ -160,7 +160,7 @@ class HuaweiTelnet(HuaweiBase):
 
             except EOFError:
                 self.remote_conn.close()
-                msg = f"Login failed: {self.host}"
+                msg = "Login failed: {}".format(self.host)
                 raise NetmikoAuthenticationException(msg)
 
         # Last try to see if we already logged in
@@ -174,7 +174,7 @@ class HuaweiTelnet(HuaweiBase):
             return return_msg
 
         self.remote_conn.close()
-        msg = f"Login failed: {self.host}"
+        msg = "Login failed: {}".format(self.host)
         raise NetmikoAuthenticationException(msg)
 
 
@@ -210,7 +210,7 @@ class HuaweiVrpv8SSH(HuaweiSSH):
         output += self.exit_config_mode()
 
         if error_marker in output:
-            raise ValueError(f"Commit failed with following errors:\n\n{output}")
+            raise ValueError("Commit failed with following errors:\n\n{}".format(output))
         return output
 
     def save_config(self, *args, **kwargs):

--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -210,7 +210,9 @@ class HuaweiVrpv8SSH(HuaweiSSH):
         output += self.exit_config_mode()
 
         if error_marker in output:
-            raise ValueError("Commit failed with following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with following errors:\n\n{}".format(output)
+            )
         return output
 
     def save_config(self, *args, **kwargs):

--- a/netmiko/juniper/juniper.py
+++ b/netmiko/juniper/juniper.py
@@ -191,7 +191,9 @@ class JuniperBase(BaseConnection):
             )
 
         if commit_marker not in output:
-            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with the following errors:\n\n{}".format(output)
+            )
 
         return output
 

--- a/netmiko/juniper/juniper.py
+++ b/netmiko/juniper/juniper.py
@@ -191,7 +191,7 @@ class JuniperBase(BaseConnection):
             )
 
         if commit_marker not in output:
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
 
         return output
 

--- a/netmiko/keymile/keymile_nos_ssh.py
+++ b/netmiko/keymile/keymile_nos_ssh.py
@@ -22,7 +22,7 @@ class KeymileNOSSSH(CiscoIosBase):
         if re.search(pattern, output):
             self.paramiko_cleanup()
             msg = "Authentication failure: unable to connect"
-            msg += f"{self.device_type} {self.host}:{self.port}"
+            msg += "{} {}:{}".format(self.device_type, self.host, self.port)
             msg += self.RESPONSE_RETURN + "Login incorrect"
             raise NetmikoAuthenticationException(msg)
         else:

--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -156,7 +156,7 @@ class LinuxFileTransfer(CiscoFileTransfer):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_md5_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
+        remote_md5_cmd = "{} {}/{}".format(base_cmd, self.file_system, remote_file)
         dest_md5 = self.ssh_ctl_chan.send_command(
             remote_md5_cmd, max_loops=750, delay_factor=2
         )

--- a/netmiko/mellanox/mellanox_mlnxos_ssh.py
+++ b/netmiko/mellanox/mellanox_mlnxos_ssh.py
@@ -47,7 +47,7 @@ class MellanoxMlnxosSSH(CiscoSSHConnection):
         if self.check_config_mode():
             raise ValueError("Failed to exit configuration mode")
 
-        log.debug(f"exit_config_mode: {output}")
+        log.debug("exit_config_mode: {}".format(output))
         return output
 
     def save_config(

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -92,7 +92,7 @@ class PaloAltoPanosBase(BaseConnection):
         if partial:
             command_string += " partial"
             if vsys:
-                command_string += f" {vsys}"
+                command_string += " {}".format(vsys)
             if device_and_network:
                 command_string += " device-and-network"
             if policy_and_objects:
@@ -112,7 +112,7 @@ class PaloAltoPanosBase(BaseConnection):
         )
 
         if commit_marker not in output.lower():
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
         return output
 
     def strip_command(self, command_string, output):

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -112,7 +112,9 @@ class PaloAltoPanosBase(BaseConnection):
         )
 
         if commit_marker not in output.lower():
-            raise ValueError("Commit failed with the following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with the following errors:\n\n{}".format(output)
+            )
         return output
 
     def strip_command(self, command_string, output):

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -113,7 +113,7 @@ class BaseFileTransfer(object):
 
     def remote_space_available(self, search_pattern=r"(\d+) \w+ free"):
         """Return space available on remote device."""
-        remote_cmd = f"dir {self.file_system}"
+        remote_cmd = "dir {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command_expect(remote_cmd)
         match = re.search(search_pattern, remote_output)
         if "kbytes" in match.group(0) or "Kbytes" in match.group(0):
@@ -123,7 +123,7 @@ class BaseFileTransfer(object):
     def _remote_space_available_unix(self, search_pattern=""):
         """Return space available on *nix system (BSD/Linux)."""
         self.ssh_ctl_chan._enter_shell()
-        remote_cmd = f"/bin/df -k {self.file_system}"
+        remote_cmd = "/bin/df -k {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command(
             remote_cmd, expect_string=r"[\$#]"
         )
@@ -183,7 +183,7 @@ class BaseFileTransfer(object):
         """Check if the dest_file already exists on the file system (return boolean)."""
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = f"dir {self.file_system}/{self.dest_file}"
+                remote_cmd = "dir {}/{}".format(self.file_system, self.dest_file)
             remote_out = self.ssh_ctl_chan.send_command_expect(remote_cmd)
             search_string = r"Directory of .*{0}".format(self.dest_file)
             if (
@@ -203,7 +203,7 @@ class BaseFileTransfer(object):
         """Check if the dest_file already exists on the file system (return boolean)."""
         if self.direction == "put":
             self.ssh_ctl_chan._enter_shell()
-            remote_cmd = f"ls {self.file_system}"
+            remote_cmd = "ls {}".format(self.file_system)
             remote_out = self.ssh_ctl_chan.send_command(
                 remote_cmd, expect_string=r"[\$#]"
             )
@@ -220,7 +220,7 @@ class BaseFileTransfer(object):
             elif self.direction == "get":
                 remote_file = self.source_file
         if not remote_cmd:
-            remote_cmd = f"dir {self.file_system}/{remote_file}"
+            remote_cmd = "dir {}/{}".format(self.file_system, remote_file)
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
         # Strip out "Directory of flash:/filename line
         remote_out = re.split(r"Directory of .*", remote_out)
@@ -245,9 +245,9 @@ class BaseFileTransfer(object):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_file = f"{self.file_system}/{remote_file}"
+        remote_file = "{}/{}".format(self.file_system, remote_file)
         if not remote_cmd:
-            remote_cmd = f"ls -l {remote_file}"
+            remote_cmd = "ls -l {}".format(remote_file)
 
         self.ssh_ctl_chan._enter_shell()
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd, expect_string=r"[\$#]")
@@ -304,7 +304,7 @@ class BaseFileTransfer(object):
         if match:
             return match.group(1)
         else:
-            raise ValueError(f"Invalid output from MD5 command: {md5_output}")
+            raise ValueError("Invalid output from MD5 command: {}".format(md5_output))
 
     def compare_md5(self):
         """Compare md5 of file on network device to md5 of local file."""
@@ -325,7 +325,7 @@ class BaseFileTransfer(object):
                 remote_file = self.dest_file
             elif self.direction == "get":
                 remote_file = self.source_file
-        remote_md5_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
+        remote_md5_cmd = "{} {}/{}".format(base_cmd, self.file_system, remote_file)
         dest_md5 = self.ssh_ctl_chan.send_command(remote_md5_cmd, max_loops=1500)
         dest_md5 = self.process_md5(dest_md5)
         return dest_md5
@@ -339,13 +339,13 @@ class BaseFileTransfer(object):
 
     def get_file(self):
         """SCP copy the file from the remote device to local system."""
-        source_file = f"{self.file_system}/{self.source_file}"
+        source_file = "{}/{}".format(self.file_system, self.source_file)
         self.scp_conn.scp_get_file(source_file, self.dest_file)
         self.scp_conn.close()
 
     def put_file(self):
         """SCP copy the file from the local system to the remote device."""
-        destination = f"{self.file_system}/{self.dest_file}"
+        destination = "{}/{}".format(self.file_system, self.dest_file)
         self.scp_conn.scp_transfer_file(self.source_file, destination)
         # Must close the SCP connection to get the file written (flush)
         self.scp_conn.close()

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -68,7 +68,7 @@ def load_yaml_file(yaml_file):
         with io.open(yaml_file, "rt", encoding="utf-8") as fname:
             return yaml.safe_load(fname)
     except IOError:
-        sys.exit(f"Unable to open YAML file: {yaml_file}")
+        sys.exit("Unable to open YAML file: {}".format(yaml_file))
 
 
 def load_devices(file_name=None):
@@ -96,7 +96,7 @@ def find_cfg_file(file_name=None):
     # Filter optional_path if null
     search_paths = [path for path in search_paths if path]
     for path in search_paths:
-        files = glob(f"{path}/.netmiko.yml") + glob(f"{path}/netmiko.yml")
+        files = glob("{}/.netmiko.yml".format(path)) + glob("{}/netmiko.yml".format(path))
         if files:
             return files[0]
     raise IOError(
@@ -120,8 +120,8 @@ def display_inventory(my_devices):
     print("\nDevices:")
     print("-" * 40)
     for a_device, device_type in inventory_devices:
-        device_type = f"  ({device_type})"
-        print(f"{a_device:<25}{device_type:>15}")
+        device_type = "  ({})".format(device_type)
+        print("{:<25}{:>15}".format(a_device, device_type))
     print("\n\nGroups:")
     print("-" * 40)
     for a_group in inventory_groups:
@@ -142,7 +142,7 @@ def obtain_all_devices(my_devices):
 def obtain_netmiko_filename(device_name):
     """Create file name based on device_name."""
     _, netmiko_full_dir = find_netmiko_dir()
-    return f"{netmiko_full_dir}/{device_name}.txt"
+    return "{}/{}.txt".format(netmiko_full_dir, device_name)
 
 
 def write_tmp_file(device_name, output):
@@ -161,7 +161,7 @@ def ensure_dir_exists(verify_dir):
         # Exists
         if not os.path.isdir(verify_dir):
             # Not a dir, raise an exception
-            raise ValueError(f"{verify_dir} is not a directory")
+            raise ValueError("{} is not a directory".format(verify_dir))
 
 
 def find_netmiko_dir():
@@ -173,7 +173,7 @@ def find_netmiko_dir():
     netmiko_base_dir = os.path.expanduser(netmiko_base_dir)
     if netmiko_base_dir == "/":
         raise ValueError("/ cannot be netmiko_base_dir")
-    netmiko_full_dir = f"{netmiko_base_dir}/tmp"
+    netmiko_full_dir = "{}/tmp".format(netmiko_base_dir)
     return (netmiko_base_dir, netmiko_full_dir)
 
 
@@ -199,11 +199,11 @@ def check_serial_port(name):
         cdc = next(serial.tools.list_ports.grep(name))
         return cdc[0]
     except StopIteration:
-        msg = f"device {name} not found. "
+        msg = "device {} not found. ".format(name)
         msg += "available devices are: "
         ports = list(serial.tools.list_ports.comports())
         for p in ports:
-            msg += f"{str(p)},"
+            msg += "{},".format(str(p))
         raise ValueError(msg)
 
 

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -96,7 +96,9 @@ def find_cfg_file(file_name=None):
     # Filter optional_path if null
     search_paths = [path for path in search_paths if path]
     for path in search_paths:
-        files = glob("{}/.netmiko.yml".format(path)) + glob("{}/netmiko.yml".format(path))
+        files = glob("{}/.netmiko.yml".format(path)) + glob(
+            "{}/netmiko.yml".format(path)
+        )
         if files:
             return files[0]
     raise IOError(

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -78,7 +78,9 @@ class VyOSSSH(CiscoSSHConnection):
         )
 
         if any(x in output for x in error_marker):
-            raise ValueError("Commit failed with following errors:\n\n{}".format(output))
+            raise ValueError(
+                "Commit failed with following errors:\n\n{}".format(output)
+            )
         return output
 
     def set_base_prompt(

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -78,7 +78,7 @@ class VyOSSSH(CiscoSSHConnection):
         )
 
         if any(x in output for x in error_marker):
-            raise ValueError(f"Commit failed with following errors:\n\n{output}")
+            raise ValueError("Commit failed with following errors:\n\n{}".format(output))
         return output
 
     def set_base_prompt(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,9 +158,9 @@ def delete_file_ios(ssh_conn, dest_file_system, dest_file):
     if not dest_file:
         raise ValueError("Invalid dest file specified")
 
-    full_file_name = f"{dest_file_system}/{dest_file}"
+    full_file_name = "{}/{}".format(dest_file_system, dest_file)
 
-    cmd = f"delete {full_file_name}"
+    cmd = "delete {}".format(full_file_name)
     output = ssh_conn.send_command_timing(cmd, delay_factor=2)
     if "Delete" in output and dest_file in output:
         output += ssh_conn.send_command_timing("\n", delay_factor=2)
@@ -233,7 +233,7 @@ def scp_fixture(request):
     platform = device["device_type"]
     dest_file_system = platform_args[platform]["file_system"]
     if "ciena_saos" in platform and ssh_conn.username:
-        dest_file_system = f"/tmp/users/{ssh_conn.username}"
+        dest_file_system = "/tmp/users/{}".format(ssh_conn.username)
 
     source_file = "test9.txt"
     dest_file = "test9.txt"

--- a/tests/test_netmiko_config_acl.py
+++ b/tests/test_netmiko_config_acl.py
@@ -46,9 +46,9 @@ def test_large_acl(net_connect, acl_entries=100):
     # Generate sequence of ACL entries
     for i in range(1, acl_entries + 1):
         if "cisco_xr" in net_connect.device_type:
-            cmd = "permit ipv4 host {} any".format(ip_address('192.168.0.0') + i)
+            cmd = "permit ipv4 host {} any".format(ip_address("192.168.0.0") + i)
         else:
-            cmd = "permit ip host {} any".format(ip_address('192.168.0.0') + i)
+            cmd = "permit ip host {} any".format(ip_address("192.168.0.0") + i)
         cfg_lines.append(cmd)
 
     result = net_connect.send_config_set(cfg_lines)

--- a/tests/test_netmiko_config_acl.py
+++ b/tests/test_netmiko_config_acl.py
@@ -37,7 +37,7 @@ def test_large_acl(net_connect, acl_entries=100):
     cmd = platforms[net_connect.device_type]["base_cmd"]
     verify_cmd = platforms[net_connect.device_type]["verify_cmd"]
     offset = platforms[net_connect.device_type]["offset"]
-    net_connect.send_config_set(f"no {cmd}")
+    net_connect.send_config_set("no {}".format(cmd))
     if "cisco_xr" in net_connect.device_type:
         net_connect.commit()
         net_connect.exit_config_mode()
@@ -46,9 +46,9 @@ def test_large_acl(net_connect, acl_entries=100):
     # Generate sequence of ACL entries
     for i in range(1, acl_entries + 1):
         if "cisco_xr" in net_connect.device_type:
-            cmd = f"permit ipv4 host {ip_address('192.168.0.0') + i} any"
+            cmd = "permit ipv4 host {} any".format(ip_address('192.168.0.0') + i)
         else:
-            cmd = f"permit ip host {ip_address('192.168.0.0') + i} any"
+            cmd = "permit ip host {} any".format(ip_address('192.168.0.0') + i)
         cfg_lines.append(cmd)
 
     result = net_connect.send_config_set(cfg_lines)
@@ -68,7 +68,7 @@ def test_large_acl(net_connect, acl_entries=100):
     if "UTC" in verify_list[0]:
         verify_list.pop(0)
     assert len(verify_list) == len(cfg_lines)
-    net_connect.send_config_set(f"no {cmd}")
+    net_connect.send_config_set("no {}".format(cmd))
     if "cisco_xr" in net_connect.device_type:
         net_connect.commit()
         net_connect.exit_config_mode()

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -219,7 +219,8 @@ def test_textfsm_direct_template():
 
     # Should also work with no-platform or command
     result = utilities.get_structured_data(
-        raw_output, template="{}/cisco_ios_show_version.template".format(RESOURCE_FOLDER)
+        raw_output,
+        template="{}/cisco_ios_show_version.template".format(RESOURCE_FOLDER),
     )
     assert result == [{"model": "4500"}]
 

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -213,13 +213,13 @@ def test_textfsm_direct_template():
         raw_output,
         platform="cisco_ios",
         command="show version",
-        template=f"{RESOURCE_FOLDER}/cisco_ios_show_version.template",
+        template="{}/cisco_ios_show_version.template".format(RESOURCE_FOLDER),
     )
     assert result == [{"model": "4500"}]
 
     # Should also work with no-platform or command
     result = utilities.get_structured_data(
-        raw_output, template=f"{RESOURCE_FOLDER}/cisco_ios_show_version.template"
+        raw_output, template="{}/cisco_ios_show_version.template".format(RESOURCE_FOLDER)
     )
     assert result == [{"model": "4500"}]
 
@@ -231,7 +231,7 @@ def test_textfsm_failed_parsing():
         raw_output,
         platform="cisco_ios",
         command="show version",
-        template=f"{RESOURCE_FOLDER}/nothinghere",
+        template="{}/nothinghere".format(RESOURCE_FOLDER),
     )
     assert result == raw_output
 
@@ -243,7 +243,7 @@ def test_textfsm_missing_template():
         raw_output,
         platform="cisco_ios",
         command="show version",
-        template=f"{RESOURCE_FOLDER}/nothinghere",
+        template="{}/nothinghere".format(RESOURCE_FOLDER),
     )
     assert result == raw_output
 


### PR DESCRIPTION
Hello,

this pull request changes all format strings which use the shorthand syntax

`f"{var}"`

which was introduced in python3.6 back to the regular format string syntax 

`"{}".format(var)`

to keep compatibility with older python versions like for example python3.5 which is the default in ubuntu 16.04 .