### PR TITLE
Add support for Sophos XG firewalls (SFOS)

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -67,6 +67,7 @@
 - MRV Communications OptiSwitch
 - MRV LX
 - Nokia/Alcatel SR-OS
+- Sophos SFOS
 - QuantaMesh
 - Rad ETX
 - Versa Networks FlexVNF

--- a/netmiko/sophos/__init__.py
+++ b/netmiko/sophos/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.sophos.sophos_sfos_ssh import SophosSfosSSH
+
+__all__ = ["SophosSfosSSH"]

--- a/netmiko/sophos/sophos_sfos_ssh.py
+++ b/netmiko/sophos/sophos_sfos_ssh.py
@@ -1,0 +1,58 @@
+"""SophosXG (SFOS) Firewall support"""
+import time
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+class SophosSfosSSH(CiscoSSHConnection):
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read()
+        """
+        Sophos Firmware Version SFOS 18.0.0 GA-Build339
+
+        Main Menu
+
+            1.  Network  Configuration
+            2.  System   Configuration
+            3.  Route    Configuration
+            4.  Device Console
+            5.  Device Management
+            6.  VPN Management
+            7.  Shutdown/Reboot Device
+            0.  Exit
+
+            Select Menu Number [0-7]:
+        """
+        self.write_channel("4" + self.RETURN)
+        self._test_channel_read(pattern=r"[console>]")
+        self.set_base_prompt()
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on SFOS"""
+        pass
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on SFOS"""
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        """No enable mode on SFOS"""
+        pass
+
+    def check_config_mode(self, *args, **kwargs):
+        """No config mode on SFOS"""
+        pass
+
+    def config_mode(self, *args, **kwargs):
+        """No config mode on SFOS"""
+        return ""
+
+    def exit_config_mode(self, *args, **kwargs):
+        """No config mode on SFOS"""
+        return ""
+
+    def save_config(self, *args, **kwargs):
+        """Not Implemented"""
+        raise NotImplementedError

--- a/netmiko/sophos/sophos_sfos_ssh.py
+++ b/netmiko/sophos/sophos_sfos_ssh.py
@@ -2,6 +2,7 @@
 import time
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
+
 class SophosSfosSSH(CiscoSSHConnection):
     def session_preparation(self):
         """Prepare the session after the connection has been established."""

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -72,6 +72,7 @@ from netmiko.rad import RadETXTelnet
 from netmiko.ruckus import RuckusFastironSSH
 from netmiko.ruckus import RuckusFastironTelnet
 from netmiko.ruijie import RuijieOSSSH, RuijieOSTelnet
+from netmiko.sophos import SophosSfosSSH
 from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
@@ -162,6 +163,7 @@ CLASS_MAPPER_BASE = {
     "rad_etx": RadETXSSH,
     "ruckus_fastiron": RuckusFastironSSH,
     "ruijie_os": RuijieOSSSH,
+    "sophos_sfos": SophosSfosSSH,
     "ubiquiti_edge": UbiquitiEdgeSSH,
     "ubiquiti_edgeswitch": UbiquitiEdgeSSH,
     "vyatta_vyos": VyOSSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -294,3 +294,9 @@ ruijie_os:
   save_config_cmd: 'write'
   save_config_confirm: False
   save_config_response: 'OK'
+
+sophos_sfos:
+  version: "system diagnostics show version-info"
+  basic: "system diagnostics utilities route lookup 172.16.16.16"
+  extended_output: "system diagnostics show version-info"
+

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -233,3 +233,12 @@ ruijie_os:
   multiple_line_output: ""
   file_check_cmd: "logging buffered 8880"
   save_config: 'OK'
+
+sophos_sfos:
+  base_prompt: "console"
+  router_prompt: "console>"
+  enable_prompt: "console>"
+  interface_ip: 172.16.16.16
+  version_banner: "Serial Number"
+  multiple_line_output: ""
+

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -184,3 +184,11 @@ ruijie_os:
   username: ruijie
   password: ruijie
   secret: ruijie
+
+sophos_sfos:
+  device_type: sophos_sfos
+  ip: 172.16.16.16
+  username: admin
+  password: admin
+
+

--- a/tests/test_sophos_sfos.sh
+++ b/tests/test_sophos_sfos.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Sophos SFOS SSH" \
+&& date \
+&& py.test -v test_netmiko_show.py --test_device sophos_sfos \
+&& date \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
Tested against SFOS v17.x and v18.x

```
$ py.test -v test_netmiko_show.py --test_device sophos_sfos
=================================== test session starts ====================================
platform linux -- Python 3.8.2, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/mhauke/tmp/netmiko, inifile: setup.cfg
plugins: expect-1.1.0, cov-2.8.1, aspectlib-1.4.2, asyncio-0.10.0, benchmark-3.2.3
collected 16 items                                                                         

test_netmiko_show.py::test_disable_paging PASSED                                     [  6%]
test_netmiko_show.py::test_ssh_connect PASSED                                        [ 12%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                     [ 18%]
test_netmiko_show.py::test_send_command_timing PASSED                                [ 25%]
test_netmiko_show.py::test_send_command PASSED                                       [ 31%]
test_netmiko_show.py::test_send_command_juniper SKIPPED                              [ 37%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                              [ 43%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                [ 50%]
test_netmiko_show.py::test_base_prompt PASSED                                        [ 56%]
test_netmiko_show.py::test_strip_prompt PASSED                                       [ 62%]
test_netmiko_show.py::test_strip_command PASSED                                      [ 68%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                [ 75%]
test_netmiko_show.py::test_clear_buffer PASSED                                       [ 81%]
test_netmiko_show.py::test_enable_mode PASSED                                        [ 87%]
test_netmiko_show.py::test_disconnect PASSED                                         [ 93%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                               [100%]

================================= short test summary info ==================================
SKIPPED [1] /home/mhauke/tmp/netmiko/tests/test_netmiko_show.py:77: <Skipped instance>
SKIPPED [1] /home/mhauke/tmp/netmiko/tests/test_netmiko_show.py:99: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /home/mhauke/tmp/netmiko/tests/test_netmiko_show.py:125: Genie not supported on this platform
============================== 13 passed, 3 skipped in 51.10s ==============================
```