### PR TITLE
Corrected failure to capture exception when connection refused

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -22,6 +22,7 @@ from netmiko import log
 from netmiko.netmiko_globals import MAX_BUFFER, BACKSPACE_CHAR
 from netmiko.ssh_exception import (
     NetmikoTimeoutException,
+    NetmikoConnectionException,
     NetmikoAuthenticationException,
 )
 from netmiko.utilities import (
@@ -903,6 +904,16 @@ class BaseConnection(object):
                 )
                 msg += self.RETURN + str(auth_err)
                 raise NetmikoAuthenticationException(msg)
+            except paramiko.ssh_exception.SSHException as fail_err:
+                self.paramiko_cleanup()
+                msg = (
+                    "Connection Failure: The remote host rejected the connection. "
+                    "Potential lock-out {device_type} {ip}:{port}".format(
+                        device_type=self.device_type, ip=self.host, port=self.port
+                    )
+                )
+                msg += self.RETURN + str(fail_err)
+                raise NetmikoConnectionException(msg)
 
             if self.verbose:
                 print(f"SSH connection established to {self.host}:{self.port}")

--- a/netmiko/ssh_exception.py
+++ b/netmiko/ssh_exception.py
@@ -8,6 +8,12 @@ class NetmikoTimeoutException(SSHException):
     pass
 
 
+class NetmikoConnectionException(SSHException):
+    """SSH connection failed. Based on Paramiko ssh_exception on intial connection."""
+
+    pass
+
+
 class NetmikoAuthenticationException(AuthenticationException):
     """SSH authentication exception based on Paramiko AuthenticationException."""
 
@@ -15,4 +21,5 @@ class NetmikoAuthenticationException(AuthenticationException):
 
 
 NetMikoTimeoutException = NetmikoTimeoutException
+NetmikoConnectionException = NetmikoConnectionException
 NetMikoAuthenticationException = NetmikoAuthenticationException


### PR DESCRIPTION
Resolves issue #1623 in which an exception thrown for a refused connection is not captured.

I have introduced a new Netmiko exception as the 2 current exceptions did not make sense for this scenario as although it can be caused by an Authentication issue, on the occasion it happens connection is refused prior to authentication attempting.