### PR TITLE
Add support for Adtran OS

### DIFF
--- a/netmiko/adtran/__init__.py
+++ b/netmiko/adtran/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.adtran.adtran import AdtranOSSSH
+
+__all__ = ["AdtranOSSSH"]

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -1,0 +1,40 @@
+import time
+import re
+from netmiko.cisco_base_connection import CiscoBaseConnection
+from netmiko.ssh_exception import NetmikoAuthenticationException
+from netmiko import log
+
+
+class AdtranOSBase(CiscoBaseConnection):
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True 
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging(command="terminal length 0")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def strip_ansi_escape_codes(self, string_buffer):
+        """
+        Huawei does a strange thing where they add a space and then add ESC[1D
+        to move the cursor to the left one.
+
+		Adtran also encounters this same issue like Huawei when executing long commands...
+		This function works as intended with Adtran also (Taken from Huawei)
+
+        The extra space is problematic.
+        """
+        code_cursor_left = chr(27) + r"\[\d+D"
+        output = string_buffer
+        pattern = rf" {code_cursor_left}"
+        output = re.sub(pattern, "", output)
+
+        log.debug("Stripping ANSI escape codes")
+        log.debug(f"new_output = {output}")
+        log.debug(f"repr = {repr(output)}")
+        return super().strip_ansi_escape_codes(output)
+
+class AdtranOSSSH(AdtranOSBase):
+	pass

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -16,12 +16,43 @@ class AdtranOSBase(CiscoBaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def _read_channel_expect(self, *args, **kwargs):
-        output = super()._read_channel_expect()
-        
-        #Strip backspaces for long commands
-        output = self.strip_backspaces(output)
-        return output
+    def strip_ansi_escape_codes(self, string_buffer):
+        """
+            Even with terminal width set to max, some commands such as
+            an EVC map, may start producing \x08 eg:
+            interface muxponder-highspeed 1/1/8 ten-gigabit-et\x08\x08\x08
+
+            Adtran uses the backspace to allow more characters to appear
+        """
+        output = self.strip_backspaces(string_buffer)
+        new_output = output.strip()
+        log.debug("Stripping ANSI escape codes")
+        log.debug(f"new_output = {new_output}")
+        return super().strip_ansi_escape_codes(new_output)
+
+    def check_enable_mode(self, check_string="#"):
+        return super().check_enable_mode(check_string=check_string)
+
+    def enable(self, cmd="enable", pattern="", re_flags=re.IGNORECASE):
+        return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
+
+    def exit_enable_mode(self, exit_command="disable"):
+        return super().exit_enable_mode(exit_command=exit_command)
+
+    def check_config_mode(self, check_string=")#"):
+        return super().check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command="config term", pattern=""):
+        return super().config_mode(config_command=config_command, pattern=pattern)
+
+    def exit_config_mode(self, exit_config="end", pattern="#"):
+        return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
+
+    def set_base_prompt(self, pri_prompt_terminator=">", alt_prompt_terminator="#"):
+        return super().set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+        )
 
 class AdtranOSSSH(AdtranOSBase):
     pass

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -8,7 +8,7 @@ from netmiko import log
 class AdtranOSBase(CiscoBaseConnection):
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
-        self.ansi_escape_codes = True 
+        self.ansi_escape_codes = True
         self._test_channel_read()
         self.set_base_prompt()
         self.disable_paging(command="terminal length 0")
@@ -21,8 +21,8 @@ class AdtranOSBase(CiscoBaseConnection):
         Huawei does a strange thing where they add a space and then add ESC[1D
         to move the cursor to the left one.
 
-		Adtran also encounters this same issue like Huawei when executing long commands...
-		This function works as intended with Adtran also (Taken from Huawei)
+                Adtran also encounters this same issue like Huawei when executing long commands...
+                This function works as intended with Adtran also (Taken from Huawei)
 
         The extra space is problematic.
         """
@@ -36,5 +36,6 @@ class AdtranOSBase(CiscoBaseConnection):
         log.debug(f"repr = {repr(output)}")
         return super().strip_ansi_escape_codes(output)
 
+
 class AdtranOSSSH(AdtranOSBase):
-	pass
+    pass

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -1,5 +1,6 @@
 import time
 import re
+from netmiko.netmiko_globals import MAX_BUFFER, BACKSPACE_CHAR
 from netmiko.cisco_base_connection import CiscoBaseConnection
 from netmiko import log
 
@@ -14,6 +15,13 @@ class AdtranOSBase(CiscoBaseConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
+
+    def _read_channel_expect(self, *args, **kwargs):
+        output = super()._read_channel_expect()
+        
+        #Strip backspaces for long commands
+        output = self.strip_backspaces(output)
+        return output
 
 class AdtranOSSSH(AdtranOSBase):
     pass

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -1,7 +1,6 @@
 import time
 import re
 from netmiko.cisco_base_connection import CiscoBaseConnection
-from netmiko.ssh_exception import NetmikoAuthenticationException
 from netmiko import log
 
 

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -15,26 +15,5 @@ class AdtranOSBase(CiscoBaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def strip_ansi_escape_codes(self, string_buffer):
-        """
-        Huawei does a strange thing where they add a space and then add ESC[1D
-        to move the cursor to the left one.
-
-                Adtran also encounters this same issue like Huawei when executing long commands...
-                This function works as intended with Adtran also (Taken from Huawei)
-
-        The extra space is problematic.
-        """
-        code_cursor_left = chr(27) + r"\[\d+D"
-        output = string_buffer
-        pattern = rf" {code_cursor_left}"
-        output = re.sub(pattern, "", output)
-
-        log.debug("Stripping ANSI escape codes")
-        log.debug(f"new_output = {output}")
-        log.debug(f"repr = {repr(output)}")
-        return super().strip_ansi_escape_codes(output)
-
-
 class AdtranOSSSH(AdtranOSBase):
     pass

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -19,13 +19,10 @@ class AdtranOSBase(CiscoBaseConnection):
     def strip_ansi_escape_codes(self, string_buffer):
         """
             Even with terminal width set to max, some commands such as
-            an EVC map, may start producing \x08 eg:
-            interface muxponder-highspeed 1/1/8 ten-gigabit-et\x08\x08\x08
-
-            Adtran uses the backspace to allow more characters to appear
+            an EVC map, may start producing \x08 so we need to strip it
         """
-        output = self.strip_backspaces(string_buffer)
-        new_output = output.strip()
+        output = string_buffer
+        new_output = self.strip_backspaces(output)
         log.debug("Stripping ANSI escape codes")
         log.debug(f"new_output = {new_output}")
         return super().strip_ansi_escape_codes(new_output)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -1,6 +1,7 @@
 """Controls selection of proper class based on the device type."""
 from netmiko.a10 import A10SSH
 from netmiko.accedian import AccedianSSH
+from netmiko.adtran import AdtranOSSSH
 from netmiko.alcatel import AlcatelAosSSH
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
@@ -84,6 +85,7 @@ from netmiko.watchguard import WatchguardFirewareSSH
 CLASS_MAPPER_BASE = {
     "a10": A10SSH,
     "accedian": AccedianSSH,
+	"adtran_os": AdtranOSSSH,
     "alcatel_aos": AlcatelAosSSH,
     "alcatel_sros": NokiaSrosSSH,
     "apresia_aeos": ApresiaAeosSSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -85,7 +85,7 @@ from netmiko.watchguard import WatchguardFirewareSSH
 CLASS_MAPPER_BASE = {
     "a10": A10SSH,
     "accedian": AccedianSSH,
-	"adtran_os": AdtranOSSSH,
+    "adtran_os": AdtranOSSSH,
     "alcatel_aos": AlcatelAosSSH,
     "alcatel_sros": NokiaSrosSSH,
     "apresia_aeos": ApresiaAeosSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -311,7 +311,7 @@ ruijie_os:
   save_config_confirm: False
   save_config_response: 'OK'
 
-adtran_ta:
+adtran_os:
   version: "show version"
   basic: "show system-management-evc"
   extended_output: "show version"

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -310,3 +310,8 @@ ruijie_os:
   save_config_cmd: 'write'
   save_config_confirm: False
   save_config_response: 'OK'
+
+adtran_ta:
+  version: "show version"
+  basic: "show system-management-evc"
+  extended_output: "show version"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -250,7 +250,7 @@ ruijie_os:
   file_check_cmd: "logging buffered 8880"
   save_config: 'OK'
 
-adtran_ta:
+adtran_os:
   base_prompt: "adtrantest"
   router_prompt: "adtrantest>"
   enable_prompt: "adtrantest#"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -249,3 +249,11 @@ ruijie_os:
   multiple_line_output: ""
   file_check_cmd: "logging buffered 8880"
   save_config: 'OK'
+
+adtran_ta:
+  base_prompt: "adtrantest"
+  router_prompt: "adtrantest>"
+  enable_prompt: "adtrantest#"
+  interface_ip: 192.0.2.1
+  version_banner: "Serial number"
+  multiple_line_output: ""

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -197,8 +197,8 @@ ruijie_os:
   password: ruijie
   secret: ruijie
 
-adtran_ta:
-  device_type: adtran_ta
+adtran_os:
+  device_type: adtran_os
   ip: 192.0.2.1
   username: adtran
   password: adtran

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -196,3 +196,9 @@ ruijie_os:
   username: ruijie
   password: ruijie
   secret: ruijie
+
+adtran_ta:
+  device_type: adtran_ta
+  ip: 192.0.2.1
+  username: adtran
+  password: adtran


### PR DESCRIPTION
Tested against 2 Adtran TA5000 series, Adtran OS is a generic operating system deploy across all of their devices however I have more TA series that I can test on if need be.

```
Adtran TA5006 and TA5000
Version: 10.3.1.1

$ py.test -v tests/test_netmiko_show.py --test_device adtran_os
================================================ test session starts ================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /home/brandon/dev/git/netmiko/venv_netmiko/bin/python3
cachedir: .pytest_cache
rootdir: /home/brandon/dev/git/netmiko/netmiko, inifile: setup.cfg
collected 18 items                                                                                                  

tests/test_netmiko_show.py::test_disable_paging PASSED                                                        [  5%]
tests/test_netmiko_show.py::test_ssh_connect PASSED                                                           [ 11%]
tests/test_netmiko_show.py::test_ssh_connect_cm PASSED                                                        [ 16%]
tests/test_netmiko_show.py::test_send_command_timing PASSED                                                   [ 22%]
tests/test_netmiko_show.py::test_send_command PASSED                                                          [ 27%]
tests/test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                  [ 33%]
tests/test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                        [ 38%]
tests/test_netmiko_show.py::test_send_command_juniper SKIPPED                                                 [ 44%]
tests/test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                 [ 50%]
tests/test_netmiko_show.py::test_send_command_genie SKIPPED                                                   [ 55%]
tests/test_netmiko_show.py::test_base_prompt PASSED                                                           [ 61%]
tests/test_netmiko_show.py::test_strip_prompt PASSED                                                          [ 66%]
tests/test_netmiko_show.py::test_strip_command PASSED                                                         [ 72%]
tests/test_netmiko_show.py::test_normalize_linefeeds PASSED                                                   [ 77%]
tests/test_netmiko_show.py::test_clear_buffer PASSED                                                          [ 83%]
tests/test_netmiko_show.py::test_enable_mode PASSED                                                           [ 88%]
tests/test_netmiko_show.py::test_disconnect PASSED                                                            [ 94%]
tests/test_netmiko_show.py::test_disconnect_no_enable PASSED                                                  [100%]

============================================== short test summary info ==============================================
SKIPPED [1] /home/brandon/dev/git/netmiko/netmiko/tests/test_netmiko_show.py:123: <Skipped instance>
SKIPPED [1] /home/brandon/dev/git/netmiko/netmiko/tests/test_netmiko_show.py:144: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /home/brandon/dev/git/netmiko/netmiko/tests/test_netmiko_show.py:169: Genie not supported on this platform
===================================== 15 passed, 3 skipped in 104.83s (0:01:44) =====================================

```

It's pretty much 100% the same as Cisco CLI so I've reused the CiscoBaseConnection class