### PR TITLE
raise NetmikoAuthenticationException when asa_login fails

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -2,6 +2,7 @@
 import re
 import time
 from netmiko.cisco_base_connection import CiscoSSHConnection, CiscoFileTransfer
+from netmiko.ssh_exception import NetmikoAuthenticationException
 
 
 class CiscoAsaSSH(CiscoSSHConnection):
@@ -88,12 +89,14 @@ class CiscoAsaSSH(CiscoSSHConnection):
 
         twb-dc-fw1> login
         Username: admin
-        Password: ************
+
+        Raises NetmikoAuthenticationException, if we do not reach privilege
+        level 15 after 3 attempts.
         """
         delay_factor = self.select_delay_factor(0)
 
         i = 1
-        max_attempts = 50
+        max_attempts = 3
         self.write_channel("login" + self.RETURN)
         while i <= max_attempts:
             time.sleep(0.5 * delay_factor)
@@ -103,10 +106,13 @@ class CiscoAsaSSH(CiscoSSHConnection):
             elif "ssword" in output:
                 self.write_channel(self.password + self.RETURN)
             elif "#" in output:
-                break
+                return True
             else:
                 self.write_channel("login" + self.RETURN)
             i += 1
+
+        msg = "Unable to get to enable mode!"
+        raise NetmikoAuthenticationException(msg)
 
     def save_config(self, cmd="write mem", confirm=False, confirm_response=""):
         """Saves Config"""


### PR DESCRIPTION
fixes #1578

Took the liberty to change the max_attempts value to 3.
The reason is that 50 seemed to be to excessive for me and takes a long time to fail. Not sure if there was a specific reason to set it to 50?
