### PR TITLE
Update read after commit for fast commits #1663

### DIFF
--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -124,7 +124,7 @@ class NokiaSrosSSH(BaseConnection):
             log.info("Apply uncommitted changes!")
             cmd = "commit"
             self.write_channel(self.normalize_cmd(cmd))
-            output += self.read_until_pattern(r"[^\*]\(ex\)\[]"))
+            output += self.read_until_pattern(r"[^\*]\(ex\)\[]")
         return output
 
     def _exit_all(self):

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -124,8 +124,7 @@ class NokiaSrosSSH(BaseConnection):
             log.info("Apply uncommitted changes!")
             cmd = "commit"
             self.write_channel(self.normalize_cmd(cmd))
-            output += self.read_until_pattern(pattern=re.escape(cmd))
-            output += self.read_until_pattern(r"@")
+            output += self.read_until_pattern(pattern="^(ex)[]$")
         return output
 
     def _exit_all(self):

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -124,7 +124,7 @@ class NokiaSrosSSH(BaseConnection):
             log.info("Apply uncommitted changes!")
             cmd = "commit"
             self.write_channel(self.normalize_cmd(cmd))
-            output += self.read_until_pattern(pattern="^(ex)[]$")
+            output += self.read_until_pattern(r"[^\*]\(ex\)\[]"))
         return output
 
     def _exit_all(self):


### PR DESCRIPTION
PR for issue #1663  It appears that for MD-CLI devices, when committing configuration changes,  if the prompt returns quickly, the second read_until_pattern() call was not getting anything from the buffer.  The first one matches the commit command on the prompt, and can read past that line to the return prompt if the commit is completed quickly.  

This change updates to only one read operation after sending the commit command to search for "^(ex)[]" as opposed to "^*(ex)[]" - the * indicating uncommitted changes.

This does have the limit of requiring of being in config mode via "edit-config exclusive" in order to match the (ex) line, which is the default for the driver.  Reference:

```
def config_mode(self, config_command="edit-config exclusive", pattern=r"\(ex\)\["):
    """Enable config edit-mode for Nokia SR OS"""
```

Tested against TiMOS-C-16.0.R7-1 cpm/x86_64 Nokia 7750 SR in model-driven configuration mode.