### PR TITLE
Add additional venv files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,16 @@ dist
 netmiko.egg-info
 .cache
 bin/.netmiko.cfg
+
+# IDE Related files
 .vscode/*
 .idea/
+
+# Virtual Environment files
 .venv/
+bin/
+lib/
+pyvenv.cfg
 
 # Sphinx documentation
 docs/build/doctrees/


### PR DESCRIPTION
This PR adds some additional Virtual Environment related files and directories to .gitignore:

```
bin/
lib/
pyvenv.cfg
```

And places a comment above the IDE related .gitignore entries.