### PR TITLE
added vscode's .devcontainer to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/.netmiko.cfg
 .vscode/*
 .idea/
 .venv/
+.devcontainer
 
 # Sphinx documentation
 docs/build/doctrees/


### PR DESCRIPTION
added .devcontainer to ignore list to allow contributors to use [vscode remote container feature](https://code.visualstudio.com/docs/remote/containers) for development process.

in addition to #1695