### PR TITLE
Add SR-OS SCP support; Convert file_transfer to more generic verification

### DIFF
--- a/netmiko/nokia/__init__.py
+++ b/netmiko/nokia/__init__.py
@@ -1,3 +1,3 @@
-from netmiko.nokia.nokia_sros_ssh import NokiaSrosSSH
+from netmiko.nokia.nokia_sros_ssh import NokiaSrosSSH, NokiaSrosFileTransfer
 
-__all__ = ["NokiaSrosSSH"]
+__all__ = ["NokiaSrosSSH", "NokiaSrosFileTransfer"]

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -189,8 +189,15 @@ class NokiaSrosSSH(BaseConnection):
 
 
 class NokiaSrosFileTransfer(BaseFileTransfer):
-    def __init__(self, hash_supported=False, **kwargs):
-        super().__init__(self, hash_supported=hash_supported, **kwargs)
+    def __init__(
+        self, ssh_conn, source_file, dest_file, hash_supported=False, **kwargs
+    ):
+        import ipdb
+
+        ipdb.set_trace()
+        super().__init__(
+            ssh_conn, source_file, dest_file, hash_supported=hash_supported, **kwargs
+        )
 
     def _file_cmd_prefix(self):
         """

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -41,11 +41,11 @@ class NokiaSrosSSH(BaseConnection):
         # "@" indicates model-driven CLI (vs Classical CLI)
         if "@" in self.base_prompt:
             self.disable_paging(command="environment more false")
+            # To perform file operations we need to disable paging in classical-CLI also
             self.disable_paging(command="//environment no more")
             self.set_terminal_width(command="environment console width 512")
         else:
             self.disable_paging(command="environment no more")
-            self.disable_paging(command="//environment more false")
 
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
@@ -189,10 +189,11 @@ class NokiaSrosSSH(BaseConnection):
 
 
 class NokiaSrosFileTransfer(BaseFileTransfer):
-    def _get_cmd_prefix(self):
+    def _file_cmd_prefix(self):
         """
-        Returns "//" if the current prompt is MD-CLI
-        empty string otherwise
+        Allow MD-CLI to execute file operations by using classical CLI.
+
+        Returns "//" if the current prompt is MD-CLI (empty string otherwise).
         """
         return "//" if "@" in self.ssh_ctl_chan.base_prompt else ""
 
@@ -201,7 +202,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
 
         # Sample text for search_pattern.
         # "               3 Dir(s)               961531904 bytes free."
-        remote_cmd = self._get_cmd_prefix() + "file dir {}".format(self.file_system)
+        remote_cmd = self._file_cmd_prefix() + "file dir {}".format(self.file_system)
         remote_output = self.ssh_ctl_chan.send_command(remote_cmd)
         match = re.search(search_pattern, remote_output)
         return int(match.group(1))
@@ -211,7 +212,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
 
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = self._get_cmd_prefix() + "file dir {}/{}".format(
+                remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
                     self.file_system, self.dest_file
                 )
             remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
@@ -233,7 +234,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
         if not remote_cmd:
-            remote_cmd = self._get_cmd_prefix() + "file dir {}/{}".format(
+            remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
                 self.file_system, remote_file
             )
         remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
@@ -255,7 +256,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
 
     def process_md5(self, md5_output, pattern=r"=\s+(\S+)"):
         """ Nokia SROS does not support a md5sum calculation."""
-        pass
+        raise ValueError("SR-OS does not support an MD5-hash operation.")
 
     def verify_file(self):
         """Verify the file has been transferred correctly based on filesize."""
@@ -270,6 +271,5 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
             )
 
     def compare_md5(self):
-        """ Nokia SROS does not support a md5sum calculation.
-         File verification is patched with verify_file which is based on file size."""
-        return self.verify_file()
+        """ Nokia SROS does not support a md5sum calculation."""
+        raise ValueError("SR-OS does not support an MD5-hash operation.")

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -192,9 +192,6 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
     def __init__(
         self, ssh_conn, source_file, dest_file, hash_supported=False, **kwargs
     ):
-        import ipdb
-
-        ipdb.set_trace()
         super().__init__(
             ssh_conn, source_file, dest_file, hash_supported=hash_supported, **kwargs
         )

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -189,6 +189,9 @@ class NokiaSrosSSH(BaseConnection):
 
 
 class NokiaSrosFileTransfer(BaseFileTransfer):
+    def __init__(self, hash_supported=False, **kwargs):
+        super().__init__(self, hash_supported=hash_supported, **kwargs)
+
     def _file_cmd_prefix(self):
         """
         Allow MD-CLI to execute file operations by using classical CLI.
@@ -254,10 +257,6 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
         file_size = int(match.group(1))
         return file_size
 
-    def process_md5(self, md5_output, pattern=r"=\s+(\S+)"):
-        """ Nokia SROS does not support a md5sum calculation."""
-        raise ValueError("SR-OS does not support an MD5-hash operation.")
-
     def verify_file(self):
         """Verify the file has been transferred correctly based on filesize."""
         if self.direction == "put":
@@ -270,6 +269,14 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
                 == os.stat(self.dest_file).st_size
             )
 
-    def compare_md5(self):
-        """ Nokia SROS does not support a md5sum calculation."""
-        raise ValueError("SR-OS does not support an MD5-hash operation.")
+    def file_md5(self, **kwargs):
+        raise AttributeError("SR-OS does not support an MD5-hash operation.")
+
+    def process_md5(self, **kwargs):
+        raise AttributeError("SR-OS does not support an MD5-hash operation.")
+
+    def compare_md5(self, **kwargs):
+        raise AttributeError("SR-OS does not support an MD5-hash operation.")
+
+    def remote_md5(self, **kwargs):
+        raise AttributeError("SR-OS does not support an MD5-hash operation.")

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -64,6 +64,7 @@ class BaseFileTransfer(object):
         file_system=None,
         direction="put",
         socket_timeout=10.0,
+        hash_supported=True,
     ):
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file
@@ -85,10 +86,12 @@ class BaseFileTransfer(object):
             self.file_system = file_system
 
         if direction == "put":
-            self.source_md5 = self.file_md5(source_file)
+            self.source_md5 = self.file_md5(source_file) if hash_supported else None
             self.file_size = os.stat(source_file).st_size
         elif direction == "get":
-            self.source_md5 = self.remote_md5(remote_file=source_file)
+            self.source_md5 = (
+                self.remote_md5(remote_file=source_file) if hash_supported else None
+            )
             self.file_size = self.remote_file_size(remote_file=source_file)
         else:
             raise ValueError("Invalid direction specified")

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -62,7 +62,7 @@ from netmiko.mellanox import MellanoxMlnxosSSH
 from netmiko.mrv import MrvLxSSH
 from netmiko.mrv import MrvOptiswitchSSH
 from netmiko.netapp import NetAppcDotSSH
-from netmiko.nokia import NokiaSrosSSH
+from netmiko.nokia import NokiaSrosSSH, NokiaSrosFileTransfer
 from netmiko.oneaccess import OneaccessOneOSTelnet, OneaccessOneOSSSH
 from netmiko.ovs import OvsLinuxSSH
 from netmiko.paloalto import PaloAltoPanosSSH
@@ -189,6 +189,7 @@ FILE_TRANSFER_MAP = {
     "dell_os10": DellOS10FileTransfer,
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,
+    "nokia_sros": NokiaSrosFileTransfer,
 }
 
 # Also support keys that end in _ssh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,20 @@ def delete_file_ciena_saos(ssh_conn, dest_file_system, dest_file):
     return output
 
 
+def delete_file_nokia_sros(ssh_conn, dest_file_system, dest_file):
+    """Delete a remote file for a Nokia SR OS device."""
+    full_file_name = "{}/{}".format(dest_file_system, dest_file)
+    cmd = "file delete {} force".format(full_file_name)
+    cmd_prefix = ""
+    if "@" in ssh_conn.base_prompt:
+        cmd_prefix = "//"
+    ssh_conn.send_command(cmd_prefix + "environment no more")
+    output = ssh_conn.send_command_timing(
+        cmd_prefix + cmd, strip_command=False, strip_prompt=False
+    )
+    return output
+
+
 @pytest.fixture(scope="module")
 def scp_fixture(request):
     """
@@ -473,5 +487,10 @@ def get_platform_args():
             "file_system": "/tmp/users/ciena",
             "enable_scp": False,
             "delete_file": delete_file_ciena_saos,
+        },
+        "nokia_sros": {
+            "file_system": "cf3:",
+            "enable_scp": False,
+            "delete_file": delete_file_nokia_sros,
         },
     }

--- a/tests/test_netmiko_scp.py
+++ b/tests/test_netmiko_scp.py
@@ -2,17 +2,6 @@
 import pytest
 from netmiko import file_transfer
 
-# def test_enable_scp(scp_fixture):
-#    ssh_conn, scp_transfer = scp_fixture
-#
-#    scp_transfer.disable_scp()
-#    output = ssh_conn.send_command_expect("show run | inc scp")
-#    assert 'ip scp server enable' not in output
-#
-#    scp_transfer.enable_scp()
-#    output = ssh_conn.send_command_expect("show run | inc scp")
-#    assert 'ip scp server enable' in output
-
 
 def test_scp_put(scp_fixture):
     ssh_conn, scp_transfer = scp_fixture
@@ -53,6 +42,8 @@ def test_remote_file_size(scp_fixture):
 
 def test_md5_methods(scp_fixture):
     ssh_conn, scp_transfer = scp_fixture
+    if "nokia_sros" in ssh_conn.device_type:
+        pytest.skip("MD5 not supported on this platform")
     md5_value = "d8df36973ff832b564ad84642d07a261"
 
     remote_md5 = scp_transfer.remote_md5()
@@ -90,6 +81,8 @@ def test_scp_get(scp_fixture_get):
 
 def test_md5_methods_get(scp_fixture_get):
     ssh_conn, scp_transfer = scp_fixture_get
+    if "nokia_sros" in ssh_conn.device_type:
+        pytest.skip("MD5 not supported on this platform")
     md5_value = "d8df36973ff832b564ad84642d07a261"
     local_md5 = scp_transfer.file_md5("test9.txt")
     assert local_md5 == md5_value


### PR DESCRIPTION
Current file_transfer function was directly bound to MD5 which is a bad idea:
* Some platforms don't support MD5 and might do other verifications (file size, checksum)
* Other hashing algorithms might be used

Also add Nokia SR-OS SCP support.