### PR TITLE
increase file size for scp_get

### DIFF
--- a/tests/test_netmiko_scp.py
+++ b/tests/test_netmiko_scp.py
@@ -70,7 +70,7 @@ def test_verify_space_available_get(scp_fixture_get):
     ssh_conn, scp_transfer = scp_fixture_get
     assert scp_transfer.verify_space_available() is True
     # intentional make there not be enough space available
-    scp_transfer.file_size = 100000000000000
+    scp_transfer.file_size = 100000000000000000
     assert scp_transfer.verify_space_available() is False
 
 


### PR DESCRIPTION
to accommodate large disk sizes. On my 1TB disk the test failed because I had more space reported free than was expected by the test

```
local free:        205280714424320
configured_fsize:  100000000000000 
```