### PR TITLE
SCP nokia_sros: Fix to check_file_exists() to support sub-directories

### DIFF
--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -222,7 +222,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
                 remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
                     self.file_system, self.dest_file
                 )
-            dest_file_name = self.dest_file.replace('\\', '/').split('/')[-1]
+            dest_file_name = self.dest_file.replace("\\", "/").split("/")[-1]
             remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
             if "File Not Found" in remote_out:
                 return False

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -222,10 +222,11 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
                 remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
                     self.file_system, self.dest_file
                 )
+            dest_file_name = self.dest_file.replace('\\', '/').split('/')[-1]
             remote_out = self.ssh_ctl_chan.send_command(remote_cmd)
             if "File Not Found" in remote_out:
                 return False
-            elif self.dest_file in remote_out:
+            elif dest_file_name in remote_out:
                 return True
             else:
                 raise ValueError("Unexpected output from check_file_exists")


### PR DESCRIPTION
This is a minor fix to support file operations in sub-directories.

nokia_sros output of:
```
A:vSIM# file dir <directory>\<file_name>

Volume in drive cf3 on slot A is SROS VM.

Volume in drive cf3 on slot A is formatted as FAT32

Directory of cf3:\<directory>

05/31/2018  06:02p             2198912 <file_name>
               1 File(s)                2198912 bytes.
               0 Dir(s)               961523712 bytes free.
```
Only a file name is shown in the command output, so if attribute self.dest_file contains full directory it will never be found in the output, so file name needs to be isolated for this check.

This PR is to fix the above.
