### PR TITLE
Disable cmd_verify for operations that occur during session_preparation

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1022,11 +1022,8 @@ class BaseConnection(object):
         log.debug("In disable_paging")
         log.debug(f"Command: {command}")
         self.write_channel(command)
-        # Make sure you read until you detect the command echo (avoid getting out of sync)
-        if self.global_cmd_verify is not False:
-            output = self.read_until_pattern(pattern=re.escape(command.strip()))
-        else:
-            output = self.read_until_prompt()
+        # Do not use command_verify here as still in session_preparation stage.
+        output = self.read_until_prompt()
         log.debug(f"{output}")
         log.debug("Exiting disable_paging")
         return output
@@ -1048,11 +1045,8 @@ class BaseConnection(object):
         delay_factor = self.select_delay_factor(delay_factor)
         command = self.normalize_cmd(command)
         self.write_channel(command)
-        # Make sure you read until you detect the command echo (avoid getting out of sync)
-        if self.global_cmd_verify is not False:
-            output = self.read_until_pattern(pattern=re.escape(command.strip()))
-        else:
-            output = self.read_until_prompt()
+        # Do not use command_verify here as still in session_preparation stage.
+        output = self.read_until_prompt()
         return output
 
     def set_base_prompt(

--- a/netmiko/cloudgenix/cloudgenix_ion.py
+++ b/netmiko/cloudgenix/cloudgenix_ion.py
@@ -12,7 +12,7 @@ class CloudGenixIonSSH(CiscoSSHConnection):
         self.write_channel(self.RETURN)
         self.set_base_prompt(delay_factor=5)
 
-    def disable_paging(self):
+    def disable_paging(self, *args, **kwargs):
         """Cloud Genix ION sets terminal height in establish_connection"""
         return ""
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -38,7 +38,7 @@ class FortinetSSH(CiscoSSHConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def disable_paging(self, delay_factor=1):
+    def disable_paging(self, delay_factor=1, **kwargs):
         """Disable paging is only available with specific roles so it may fail."""
         check_command = "get system status | grep Virtual"
         output = self.send_command_timing(check_command)

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -50,8 +50,8 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         log.debug(f"{output}")
         log.debug("Exiting disable_smart_interaction")
 
-    def disable_paging(self, command="scroll"):
-        return super().disable_paging(command=command)
+    def disable_paging(self, command="scroll", **kwargs):
+        return super().disable_paging(command=command, **kwargs)
 
     def config_mode(self, config_command="config", pattern=""):
         """Enter configuration mode."""


### PR DESCRIPTION
Until things like ANSI escape codes are turned off and terminal width is set, cmd_verify might not work. 

Consequently, don't use cmd_verify during session_preparation.