### PR TITLE
Add support for vendor/os: broadcom_icos.

### DIFF
--- a/netmiko/broadcom/__init__.py
+++ b/netmiko/broadcom/__init__.py
@@ -1,0 +1,4 @@
+from netmiko.broadcom.broadcom_icos_ssh import BroadcomIcosSSH
+
+
+__all__ = ["BroadcomIcosSSH"]

--- a/netmiko/broadcom/broadcom_icos_ssh.py
+++ b/netmiko/broadcom/broadcom_icos_ssh.py
@@ -1,0 +1,43 @@
+import time
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class BroadcomIcosSSH(CiscoSSHConnection):
+    """
+    Implements support for Broadcom Icos devices.
+    Syntax its almost identical to Cisco IOS in most cases
+    """
+
+    def session_preparation(self):
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.enable()
+        self.set_base_prompt()
+        self.disable_paging()
+        self.set_terminal_width()
+
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_config_mode(self, check_string=")#"):
+        """Checks if the device is in configuration mode or not."""
+        return super().check_config_mode(check_string=check_string)
+
+    def config_mode(self, config_command="configure"):
+        """Enter configuration mode."""
+        return super().config_mode(config_command=config_command)
+
+    def exit_config_mode(self, exit_config="exit"):
+        """Exit configuration mode."""
+        return super().exit_config_mode(exit_config=exit_config)
+
+    def exit_enable_mode(self, exit_command="exit"):
+        """Exit enable mode."""
+        return super().exit_enable_mode(exit_command=exit_command)
+
+    def save_config(self, cmd="write memory", confirm=False, confirm_response=""):
+        """Saves configuration."""
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -6,6 +6,7 @@ from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
+from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
 from netmiko.centec import CentecOSSSH, CentecOSTelnet
 from netmiko.checkpoint import CheckPointGaiaSSH
@@ -96,6 +97,7 @@ CLASS_MAPPER_BASE = {
     "aruba_os": ArubaSSH,
     "avaya_ers": ExtremeErsSSH,
     "avaya_vsp": ExtremeVspSSH,
+    "broadcom_icos": BroadcomIcosSSH,
     "brocade_fastiron": RuckusFastironSSH,
     "brocade_netiron": ExtremeNetironSSH,
     "brocade_nos": ExtremeNosSSH,

--- a/tests/test_broadcom_icos.sh
+++ b/tests/test_broadcom_icos.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& echo "Broadcom Icos" \
+&& py.test -v test_netmiko_show.py --test_device broadcom_icos \
+&& py.test -v test_netmiko_config.py --test_device broadcom_icos \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
Add support for vendor/os: broadcom_icos.

Some example hardware models that i have access to and use the OS above:  

```
Accton AS4610-54P 
Accton AS5610-52X
Quanta LY2R
Quanta LB9
DNI AG3448P-R
```

- Ran tests and black against added code:

[broadcom_icos_test_results.txt](https://github.com/ktbyers/netmiko/files/4724899/broadcom_icos_test_results.txt)