### PR TITLE
cisco_ios.py: InLineTransfer.config_md5 restore correct check

### DIFF
--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -169,7 +169,10 @@ class InLineTransfer(CiscoIosFileTransfer):
         return hashlib.md5(file_contents).hexdigest()
 
     def config_md5(self, source_config):
-        return super().file_md5(source_config, add_newline=True)
+        """Compute MD5 hash of text."""
+        file_contents = source_config + "\n"  # Cisco IOS automatically adds this
+        file_contents = file_contents.encode("UTF-8")
+        return hashlib.md5(file_contents).hexdigest()
 
     def put_file(self):
         curlybrace = r"{"


### PR DESCRIPTION
After #1408 `config_md5` just calls `file_md5`

`file_md5` computes hash of file contents from filename, `config_md5` should compute hash of a string