### PR TITLE
Strip ansi codes on Aruba devices and add BaseConnection constructor parameter

### DIFF
--- a/netmiko/aruba/aruba_ssh.py
+++ b/netmiko/aruba/aruba_ssh.py
@@ -13,6 +13,10 @@ class ArubaSSH(CiscoSSHConnection):
         # Aruba has an auto-complete on space behavior that is problematic
         if kwargs.get("global_cmd_verify") is None:
             kwargs["global_cmd_verify"] = False
+        # Some Aruba switches output ANSI escape codes
+        if kwargs.get("ansi_escape_codes") is None:
+            kwargs["ansi_escape_codes"] = True
+
         return super().__init__(**kwargs)
 
     def session_preparation(self):

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -49,6 +49,7 @@ class BaseConnection(object):
         secret="",
         port=None,
         device_type="",
+        ansi_escape_codes=False,
         verbose=False,
         global_delay_factor=1,
         global_cmd_verify=None,
@@ -108,6 +109,10 @@ class BaseConnection(object):
 
         :param device_type: Class selection based on device type.
         :type device_type: str
+
+        :param ansi_escape_codes: Whether the device outputs ANSI escape codes that
+                need to be stripped.
+        :type ansi_escape_codes: bool
 
         :param verbose: Enable additional messages to standard output.
         :type verbose: bool
@@ -239,7 +244,7 @@ class BaseConnection(object):
         self.password = password
         self.secret = secret
         self.device_type = device_type
-        self.ansi_escape_codes = False
+        self.ansi_escape_codes = ansi_escape_codes
         self.verbose = verbose
         self.timeout = timeout
         self.auth_timeout = auth_timeout


### PR DESCRIPTION
I was having problems testing netmiko on an Aruba 2930M switch, and stripping the ANSI codes fixed it. Not sure what effect this has on other Aruba devices such as controllers.

I also modified the BaseConnection constructor. I'm completely new to this project but it seems like it would make sense for `ansi_escape_codes` to be a constructor parameter that specific platforms can pass if they have to deal with ANSI codes.