### PR TITLE
Strip ansi codes from Aruba switch output

### DIFF
--- a/netmiko/aruba/aruba_ssh.py
+++ b/netmiko/aruba/aruba_ssh.py
@@ -17,6 +17,9 @@ class ArubaSSH(CiscoSSHConnection):
 
     def session_preparation(self):
         """Aruba OS requires enable mode to disable paging."""
+        # Aruba switches output ansi codes
+        self.ansi_escape_codes = True
+        
         delay_factor = self.select_delay_factor(delay_factor=0)
         time.sleep(1 * delay_factor)
         self._test_channel_read()


### PR DESCRIPTION
I was testing netmiko on an Aruba 2930M switch and it was failing because this switch outputs ANSI escape codes. This pull request fixes that, though I'm not sure what effect it has on controllers.