### PR TITLE
More accurate ArubaOS-Switch driver

### DIFF
--- a/netmiko/aruba/__init__.py
+++ b/netmiko/aruba/__init__.py
@@ -1,3 +1,4 @@
 from netmiko.aruba.aruba_ssh import ArubaSSH
+from netmiko.aruba.aruba_switch_ssh import ArubaSwitchSSH
 
-__all__ = ["ArubaSSH"]
+__all__ = ["ArubaSSH", "ArubaSwitchSSH"]

--- a/netmiko/aruba/__init__.py
+++ b/netmiko/aruba/__init__.py
@@ -1,4 +1,4 @@
 from netmiko.aruba.aruba_ssh import ArubaSSH
-from netmiko.aruba.aruba_switch_ssh import ArubaSwitchSSH
+from netmiko.aruba.arubaos_switch_ssh import ArubaOSSwitchSSH
 
-__all__ = ["ArubaSSH", "ArubaSwitchSSH"]
+__all__ = ["ArubaSSH", "ArubaOSSwitchSSH"]

--- a/netmiko/aruba/aruba_ssh.py
+++ b/netmiko/aruba/aruba_ssh.py
@@ -17,9 +17,6 @@ class ArubaSSH(CiscoSSHConnection):
 
     def session_preparation(self):
         """Aruba OS requires enable mode to disable paging."""
-        # Aruba switches output ansi codes
-        self.ansi_escape_codes = True
-
         delay_factor = self.select_delay_factor(delay_factor=0)
         time.sleep(1 * delay_factor)
         self._test_channel_read()

--- a/netmiko/aruba/aruba_switch_ssh.py
+++ b/netmiko/aruba/aruba_switch_ssh.py
@@ -1,5 +1,7 @@
 from netmiko.hp.hp_procurve import HPProcurveBase
 
+
 class ArubaSwitchSSH(HPProcurveBase):
     """ArubaOS Switch is basically a rebranding of the Procurve OS."""
+
     pass

--- a/netmiko/aruba/aruba_switch_ssh.py
+++ b/netmiko/aruba/aruba_switch_ssh.py
@@ -1,0 +1,5 @@
+from netmiko.hp.hp_procurve import HPProcurveBase
+
+class ArubaSwitchSSH(HPProcurveBase):
+    """ArubaOS Switch is basically a rebranding of the Procurve OS."""
+    pass

--- a/netmiko/aruba/arubaos_switch_ssh.py
+++ b/netmiko/aruba/arubaos_switch_ssh.py
@@ -1,7 +1,7 @@
 from netmiko.hp.hp_procurve import HPProcurveBase
 
 
-class ArubaSwitchSSH(HPProcurveBase):
+class ArubaOSSwitchSSH(HPProcurveBase):
     """ArubaOS Switch is basically a rebranding of the Procurve OS."""
 
     pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -6,7 +6,7 @@ from netmiko.alcatel import AlcatelAosSSH
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
-from netmiko.aruba import ArubaSSH, ArubaSwitchSSH
+from netmiko.aruba import ArubaSSH, ArubaOSSwitchSSH
 from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
 from netmiko.centec import CentecOSSSH, CentecOSTelnet
@@ -108,7 +108,7 @@ CLASS_MAPPER_BASE = {
     "apresia_aeos": ApresiaAeosSSH,
     "arista_eos": AristaSSH,
     "aruba_os": ArubaSSH,
-    "aruba_osswitch": ArubaSwitchSSH,
+    "arubaos_switch": ArubaOSSwitchSSH,
     "avaya_ers": ExtremeErsSSH,
     "avaya_vsp": ExtremeVspSSH,
     "broadcom_icos": BroadcomIcosSSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -6,7 +6,7 @@ from netmiko.alcatel import AlcatelAosSSH
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
-from netmiko.aruba import ArubaSSH
+from netmiko.aruba import ArubaSSH, ArubaSwitchSSH
 from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
 from netmiko.centec import CentecOSSSH, CentecOSTelnet
@@ -108,6 +108,7 @@ CLASS_MAPPER_BASE = {
     "apresia_aeos": ApresiaAeosSSH,
     "arista_eos": AristaSSH,
     "aruba_os": ArubaSSH,
+    "aruba_osswitch": ArubaSwitchSSH,
     "avaya_ers": ExtremeErsSSH,
     "avaya_vsp": ExtremeVspSSH,
     "broadcom_icos": BroadcomIcosSSH,


### PR DESCRIPTION
I rescind my previous pull request and present this one instead. ArubaOS is a unique operating system for Aruba controllers. ArubaOS-Switch is different, and it more closely resembles the HP Procurve operating system.

Fixes #1809 

```
================================================= test session starts ==================================================
platform linux -- Python 3.6.9, pytest-5.1.2, py-1.8.2, pluggy-0.13.1 -- /mnt/c/Users/me/workspace/netmiko/venv/bi
n/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/me/workspace/netmiko, inifile: setup.cfg
plugins: pylama-7.7.1
collected 19 items

test_netmiko_show.py::test_disable_paging PASSED                                                                 [  5%]
test_netmiko_show.py::test_terminal_width PASSED                                                                 [ 10%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                    [ 15%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                 [ 21%]
test_netmiko_show.py::test_send_command_timing PASSED                                                            [ 26%]
test_netmiko_show.py::test_send_command PASSED                                                                   [ 31%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                           [ 36%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                 [ 42%]
test_netmiko_show.py::test_send_command_juniper SKIPPED                                                          [ 47%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                          [ 52%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                            [ 57%]
test_netmiko_show.py::test_base_prompt PASSED                                                                    [ 63%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                   [ 68%]
test_netmiko_show.py::test_strip_command PASSED                                                                  [ 73%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                            [ 78%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                   [ 84%]
test_netmiko_show.py::test_enable_mode PASSED                                                                    [ 89%]
test_netmiko_show.py::test_disconnect PASSED                                                                     [ 94%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                           [100%]

=============================================== short test summary info ================================================
SKIPPED [1] /mnt/c/Users/me/workspace/netmiko/tests/test_netmiko_show.py:132: <Skipped instance>
SKIPPED [1] /mnt/c/Users/me/workspace/netmiko/tests/test_netmiko_show.py:153: TextFSM/ntc-templates not supported
on this platform
SKIPPED [1] /mnt/c/Users/me/workspace/netmiko/tests/test_netmiko_show.py:178: Genie not supported on this platform
======================================= 16 passed, 3 skipped in 84.06s (0:01:24) =======================================
```
```
================================================= test session starts ==================================================
platform linux -- Python 3.6.9, pytest-5.1.2, py-1.8.2, pluggy-0.13.1 -- /mnt/c/Users/me/workspace/netmiko/venv/bi
n/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/me/workspace/netmiko, inifile: setup.cfg
plugins: pylama-7.7.1
collected 8 items

test_netmiko_config.py::test_ssh_connect PASSED                                                                  [ 12%]
test_netmiko_config.py::test_enable_mode PASSED                                                                  [ 25%]
test_netmiko_config.py::test_config_mode PASSED                                                                  [ 37%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                             [ 50%]
test_netmiko_config.py::test_config_set PASSED                                                                   [ 62%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                       [ 75%]
test_netmiko_config.py::test_config_from_file PASSED                                                             [ 87%]
test_netmiko_config.py::test_disconnect PASSED                                                                   [100%]

============================================= 8 passed in 81.37s (0:01:21) =============================================
```