### PR TITLE
add progress, progress4 to file_transfer

### DIFF
--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -71,6 +71,8 @@ class InLineTransfer(CiscoIosFileTransfer):
         direction="put",
         source_config=None,
         socket_timeout=10.0,
+        progress=None,
+        progress4=None,
     ):
         if source_file and source_config:
             msg = "Invalid call to InLineTransfer both source_file and source_config specified."
@@ -98,6 +100,9 @@ class InLineTransfer(CiscoIosFileTransfer):
             self.file_system = file_system
 
         self.socket_timeout = socket_timeout
+        # not useful for text files but has to exist
+        self.progress = progress
+        self.progress4 = progress4
 
     @staticmethod
     def _read_file(file_name):

--- a/netmiko/cisco/cisco_nxos_ssh.py
+++ b/netmiko/cisco/cisco_nxos_ssh.py
@@ -39,6 +39,8 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
         file_system="bootflash:",
         direction="put",
         socket_timeout=10.0,
+        progress=None,
+        progress4=None,
     ):
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file
@@ -60,6 +62,8 @@ class CiscoNxosFileTransfer(CiscoFileTransfer):
             raise ValueError("Invalid direction specified")
 
         self.socket_timeout = socket_timeout
+        self.progress = progress
+        self.progress4 = progress4
 
     def check_file_exists(self, remote_cmd=""):
         """Check if the dest_file already exists on the file system (return boolean)."""

--- a/netmiko/scp_functions.py
+++ b/netmiko/scp_functions.py
@@ -27,6 +27,8 @@ def file_transfer(
     inline_transfer=False,
     overwrite_file=False,
     socket_timeout=10.0,
+    progress=None,
+    progress4=None,
     verify_file=None,
 ):
     """Use Secure Copy or Inline (IOS-only) to transfer files to/from network devices.
@@ -72,6 +74,8 @@ def file_transfer(
         "dest_file": dest_file,
         "direction": direction,
         "socket_timeout": socket_timeout,
+        "progress": progress,
+        "progress4": progress4,
     }
     if file_system is not None:
         scp_args["file_system"] = file_system

--- a/netmiko/scp_handler.py
+++ b/netmiko/scp_handler.py
@@ -22,9 +22,11 @@ class SCPConn(object):
     Must close the SCP connection to get the file to write to the remote filesystem
     """
 
-    def __init__(self, ssh_conn, socket_timeout=10.0):
+    def __init__(self, ssh_conn, socket_timeout=10.0, progress=None, progress4=None):
         self.ssh_ctl_chan = ssh_conn
         self.socket_timeout = socket_timeout
+        self.progress = progress
+        self.progress4 = progress4
         self.establish_scp_conn()
 
     def establish_scp_conn(self):
@@ -33,7 +35,10 @@ class SCPConn(object):
         self.scp_conn = self.ssh_ctl_chan._build_ssh_client()
         self.scp_conn.connect(**ssh_connect_params)
         self.scp_client = scp.SCPClient(
-            self.scp_conn.get_transport(), socket_timeout=self.socket_timeout
+            self.scp_conn.get_transport(),
+            socket_timeout=self.socket_timeout,
+            progress=self.progress,
+            progress4=self.progress4,
         )
 
     def scp_transfer_file(self, source_file, dest_file):
@@ -64,6 +69,8 @@ class BaseFileTransfer(object):
         file_system=None,
         direction="put",
         socket_timeout=10.0,
+        progress=None,
+        progress4=None,
         hash_supported=True,
     ):
         self.ssh_ctl_chan = ssh_conn
@@ -71,6 +78,8 @@ class BaseFileTransfer(object):
         self.dest_file = dest_file
         self.direction = direction
         self.socket_timeout = socket_timeout
+        self.progress = progress
+        self.progress4 = progress4
 
         auto_flag = (
             "cisco_ios" in ssh_conn.device_type
@@ -107,7 +116,12 @@ class BaseFileTransfer(object):
 
     def establish_scp_conn(self):
         """Establish SCP connection."""
-        self.scp_conn = SCPConn(self.ssh_ctl_chan, socket_timeout=self.socket_timeout)
+        self.scp_conn = SCPConn(
+            self.ssh_ctl_chan,
+            socket_timeout=self.socket_timeout,
+            progress=self.progress,
+            progress4=self.progress4,
+        )
 
     def close_scp_chan(self):
         """Close the SCP connection to the remote network device."""


### PR DESCRIPTION
When transferring large device binary images over low bandwidth connections we can often wait for hours for a transfer to complete.  A nice-to-have feature would be knowing an approximate completion time for these transfers like we have by using a shell script and scp commands.  Netmiko simplifies copying these files and adds a lot of robustness to the process but we have no way of knowing when to expect the transfer to complete.

Since netmiko uses scp from pypi there is already a great solution for this inside of the scp project.  The only issue is we have no way to access it through netmiko without code modification.

Please let me know if I should re-run a documentation script on this or if you think we need tests for this pass-through.  Also, I've pasted the script I used to test that my changes do work and to allow me to access the progress arguments.  I can put a modified version of this in the examples folder if desired although we probably need to leave the large binary file out of the repo.

```
#!/usr/bin/env python3
import sys
import argparse
import ipaddress
import scp
import netmiko


# Define progress callback that prints the current percentage completed for the file
def progress(filename, size, sent):
    sys.stdout.write(
        "%s's progress: %.2f%%   \r" % (filename.decode(), float(sent) / float(size) * 100)
    )


# you can also use progress4, which adds a 4th parameter to track IP and port
# useful with multiple threads to track source
def progress4(filename, size, sent, peername):
    sys.stdout.write(
        "(%s:%s) %s's progress: %.2f%%   \r"
        % (peername[0], peername[1], filename.decode(), float(sent) / float(size) * 100)
    )


arg_parser = argparse.ArgumentParser()
for argument in ("dst_name", "dst_host", "src_file", "dst_file", "user", "password"):
    arg_parser.add_argument(argument)
args = arg_parser.parse_args()

if args.dst_name == args.dst_host:
    print(f"Transfering {args.src_file} to {args.dst_name}:{args.dst_file}...")
else:
    print(
        f"Transfering {args.src_file} to {args.dst_name}({args.dst_host}):{args.dst_file}"
    )
sys.stdout.flush()

device = {
    "device_type": "cisco_ios",
    "username": args.user,
    "password": args.password,
}

try:
    device["ip"] = str(ipaddress.ip_address(args.dst_host))
except ValueError:
    device["host"] = args.dst_host

with netmiko.ConnectHandler(**device) as net_connect:
    transfer_dict = netmiko.file_transfer(
        net_connect,
        source_file=args.src_file,
        dest_file=args.dst_file,
        file_system="flash:",
        direction="put",
        overwrite_file=True,
        progress=progress,
    )
    print(f"\n{transfer_dict}")

    transfer_dict = netmiko.file_transfer(
        net_connect,
        source_file=args.src_file,
        dest_file=f"{args.dst_file}2",
        file_system="flash:",
        direction="put",
        overwrite_file=True,
        progress4=progress4,
    )
    print(f"\n{transfer_dict}")

```