### PR TITLE
Add admin reboot upgrade and save_config fix in Nokia SR-OS

### DIFF
--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -186,6 +186,23 @@ class NokiaSrosSSH(BaseConnection):
         self._session_log_fin = True
         self.write_channel(command + self.RETURN)
 
+    def reboot_upgrade(self, *args, **kwargs):
+        """Restarting device for software upgrade."""
+        output = ""
+        try:
+            output += self.send_command(
+                command_string="/admin reboot upgrade",
+                expect_string="Are you sure you want to reboot"
+            )
+            # After calling following command there can be raised OSError, because the device is restarted and it's doesn't responding
+            output += self.send_command("y", max_loops=5,
+                                        auto_find_prompt=False)
+        except OSError:
+            pass
+        if output is not None:
+            log.info(f"{self.host} rebooted.")
+        return output
+
 
 class NokiaSrosFileTransfer(BaseFileTransfer):
     def __init__(

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -110,9 +110,9 @@ class NokiaSrosSSH(BaseConnection):
             # Model-driven CLI look for "exclusive"
             return super().check_config_mode(check_string=check_string, pattern=pattern)
 
-    def save_config(self, *args, **kwargs):
+    def save_config(self, expect_string=r"#", *args, **kwargs):
         """Persist configuration to cflash for Nokia SR OS"""
-        return self.send_command(command_string="/admin save", expect_string=r"#")
+        return self.send_command(command_string="/admin save", expect_string=expect_string)
 
     def send_config_set(self, config_commands=None, exit_config_mode=None, **kwargs):
         """Model driven CLI requires you not exit from configuration mode."""


### PR DESCRIPTION
PR includes two changes:
- new **reboot_upgrade** method that allows you to restart the device for software upgrade
- fix in **save_config** method