### PR TITLE
Changed SSH terminal height in CiscoXrBase

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -4,6 +4,10 @@ from netmiko.cisco_base_connection import CiscoBaseConnection, CiscoFileTransfer
 
 
 class CiscoXrBase(CiscoBaseConnection):
+    def establish_connection(self):
+        """Establish SSH connection to the network device"""
+        super().establish_connection(width=511, height=511)
+
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
         self._test_channel_read()


### PR DESCRIPTION
Fixed the issue https://github.com/ktbyers/netmiko/issues/1875.

Confirmed that black ran successfully against the changed code.
```
(netmiko) TAISASAK-M-23C0:netmiko taisasak$ black netmiko/cisco/cisco_xr.py
All done! ✨ 🍰 ✨
1 file left unchanged.
```