### PR TITLE
fix yotc driver

### DIFF
--- a/netmiko/yotc/yotc.py
+++ b/netmiko/yotc/yotc.py
@@ -42,11 +42,7 @@ class YotcBase(CiscoBaseConnection):
 
         while prompt not in new_data:
             new_data = self.send_command_timing(
-                "m",
-                use_textfsm=False,
-                use_genie=False,
-                strip_prompt=False,
-                **kwargs,
+                "m", use_textfsm=False, use_genie=False, strip_prompt=False, **kwargs,
             )
             output += new_data
         output = re.sub(more_str_re, "", output)
@@ -70,9 +66,7 @@ class YotcBase(CiscoBaseConnection):
 
         if use_genie:
             structured_output = get_structured_data_genie(
-                output,
-                platform=self.device_type,
-                command=command_string.strip(),
+                output, platform=self.device_type, command=command_string.strip(),
             )
             # If we have structured data; return it.
             if not isinstance(structured_output, str):
@@ -82,22 +76,15 @@ class YotcBase(CiscoBaseConnection):
 
     def check_config_mode(self, check_string=")#", pattern="#"):
         """Checks if the device is in configuration mode or not."""
-        return super().check_config_mode(
-            check_string=check_string, pattern=pattern
-        )
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
 
     def save_config(self, cmd="wr", confirm=True, confirm_response="y"):
         """Saves Config."""
         self.exit_config_mode()
         self.enable()
-        output = self.send_command_timing(
-            cmd, strip_prompt=False, strip_command=False
-        )
+        output = self.send_command_timing(cmd, strip_prompt=False, strip_command=False)
         output += self.send_command_timing(
-            confirm_response,
-            strip_prompt=False,
-            strip_command=False,
-            normalize=False,
+            confirm_response, strip_prompt=False, strip_command=False, normalize=False,
         )
         return output
 
@@ -144,9 +131,7 @@ class YotcTelnet(YotcBase):
                 # negotiate about window size
                 telnet_sock.sendall(IAC + WILL + opt)
                 # Width:500, Weight:50
-                telnet_sock.sendall(
-                    IAC + SB + NAWS + b"\x01\xf4\x00\x32" + IAC + SE
-                )
+                telnet_sock.sendall(IAC + SB + NAWS + b"\x01\xf4\x00\x32" + IAC + SE)
             else:
                 telnet_sock.sendall(IAC + WONT + opt)
 

--- a/netmiko/yotc/yotc.py
+++ b/netmiko/yotc/yotc.py
@@ -42,7 +42,11 @@ class YotcBase(CiscoBaseConnection):
 
         while prompt not in new_data:
             new_data = self.send_command_timing(
-                "m", use_textfsm=False, use_genie=False, strip_prompt=False, **kwargs,
+                "m",
+                use_textfsm=False,
+                use_genie=False,
+                strip_prompt=False,
+                **kwargs,
             )
             output += new_data
         output = re.sub(more_str_re, "", output)
@@ -66,7 +70,9 @@ class YotcBase(CiscoBaseConnection):
 
         if use_genie:
             structured_output = get_structured_data_genie(
-                output, platform=self.device_type, command=command_string.strip()
+                output,
+                platform=self.device_type,
+                command=command_string.strip(),
             )
             # If we have structured data; return it.
             if not isinstance(structured_output, str):
@@ -76,15 +82,22 @@ class YotcBase(CiscoBaseConnection):
 
     def check_config_mode(self, check_string=")#", pattern="#"):
         """Checks if the device is in configuration mode or not."""
-        return super().check_config_mode(check_string=check_string, pattern=pattern)
+        return super().check_config_mode(
+            check_string=check_string, pattern=pattern
+        )
 
     def save_config(self, cmd="wr", confirm=True, confirm_response="y"):
         """Saves Config."""
         self.exit_config_mode()
         self.enable()
-        output = self.send_command_timing(cmd, strip_prompt=False, strip_command=False)
+        output = self.send_command_timing(
+            cmd, strip_prompt=False, strip_command=False
+        )
         output += self.send_command_timing(
-            confirm_response, strip_prompt=False, strip_command=False, normalize=False
+            confirm_response,
+            strip_prompt=False,
+            strip_command=False,
+            normalize=False,
         )
         return output
 
@@ -131,7 +144,9 @@ class YotcTelnet(YotcBase):
                 # negotiate about window size
                 telnet_sock.sendall(IAC + WILL + opt)
                 # Width:500, Weight:50
-                telnet_sock.sendall(IAC + SB + NAWS + b"\x01\xf4\x00\x32" + IAC + SE)
+                telnet_sock.sendall(
+                    IAC + SB + NAWS + b"\x01\xf4\x00\x32" + IAC + SE
+                )
             else:
                 telnet_sock.sendall(IAC + WONT + opt)
 

--- a/netmiko/yotc/yotc.py
+++ b/netmiko/yotc/yotc.py
@@ -36,19 +36,12 @@ class YotcBase(CiscoBaseConnection):
         prompt = self.find_prompt()
         more_str_re = r"\s--More--\s*"
         new_data = self.send_command_timing(
-            command_string=command_string, 
-            use_textfsm=False, 
-            use_genie=False, 
-            **kwargs,
+            command_string=command_string, use_textfsm=False, use_genie=False, **kwargs,
         )
         output = new_data
         while prompt not in new_data:
             new_data = self.send_command_timing(
-                "m", 
-                use_textfsm=False, 
-                use_genie=False, 
-                strip_prompt=False, 
-                **kwargs,
+                "m", use_textfsm=False, use_genie=False, strip_prompt=False, **kwargs,
             )
             output += new_data
         output = re.sub(more_str_re, "", output)
@@ -88,14 +81,12 @@ class YotcBase(CiscoBaseConnection):
         """Saves Config."""
         self.exit_config_mode()
         self.enable()
-        output = self.send_command_timing(
-            cmd, strip_prompt=False, strip_command=False
-        )
+        output = self.send_command_timing(cmd, strip_prompt=False, strip_command=False)
         output += self.send_command_timing(
             confirm_response, strip_prompt=False, strip_command=False, normalize=False
         )
         return output
-    
+
     def cleanup(self):
         """Don't use 'exit' to disconnect, and reset command max-lines to default"""
         self.send_config_set("no command max-lines")

--- a/netmiko/yotc/yotc.py
+++ b/netmiko/yotc/yotc.py
@@ -36,9 +36,10 @@ class YotcBase(CiscoBaseConnection):
         prompt = self.find_prompt()
         more_str_re = r"\s--More--\s*"
         new_data = self.send_command_timing(
-            command_string=command_string, use_textfsm=False, use_genie=False, **kwargs,
+            command_string, use_textfsm=False, use_genie=False, **kwargs,
         )
         output = new_data
+
         while prompt not in new_data:
             new_data = self.send_command_timing(
                 "m", use_textfsm=False, use_genie=False, strip_prompt=False, **kwargs,

--- a/netmiko/yotc/yotc.py
+++ b/netmiko/yotc/yotc.py
@@ -18,7 +18,7 @@ class YotcBase(CiscoBaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def send_command_more(
+    def _send_command_more(
         self,
         command_string,
         use_textfsm=False,
@@ -34,21 +34,12 @@ class YotcBase(CiscoBaseConnection):
         cisco_wlc_ssh.py has similar function: send_command_w_enter().
         """
         prompt = self.find_prompt()
-        more_str_re = r"\s--More--\s*"
-        new_data = self.send_command_timing(
-            command_string=command_string, 
-            use_textfsm=False, 
-            use_genie=False, 
-            **kwargs,
-        )
-        output = new_data
+        more_str_re = r".*--More--.*"
+        new_data = ""
+        output = ""
         while prompt not in new_data:
             new_data = self.send_command_timing(
-                "m", 
-                use_textfsm=False, 
-                use_genie=False, 
-                strip_prompt=False, 
-                **kwargs,
+                " ", cmd_verify=False, use_textfsm=False, use_genie=False, **kwargs
             )
             output += new_data
         output = re.sub(more_str_re, "", output)
@@ -87,18 +78,13 @@ class YotcBase(CiscoBaseConnection):
     def save_config(self, cmd="wr", confirm=True, confirm_response="y"):
         """Saves Config."""
         self.exit_config_mode()
-        self.enable()
-        output = self.send_command_timing(
-            cmd, strip_prompt=False, strip_command=False
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
         )
-        output += self.send_command_timing(
-            confirm_response, strip_prompt=False, strip_command=False, normalize=False
-        )
-        return output
-    
+
     def cleanup(self):
-        """Don't use 'exit' to disconnect, and reset command max-lines to default"""
-        self.send_config_set("no command max-lines")
+        """Don't use 'exit' to disconnect."""
+        pass
 
 
 class YotcSSH(YotcBase):


### PR DESCRIPTION
fix yotc driver

1.```send_command_more```as default send_command func for yotc device, so its need send command to get the first response, then get ```--more--``` responses
2.fix save_config:
```save_config``` must be in enable mode and not in config mode, otherwise it cant be inputed, and there is a reason why I cant use the ```super.save_config``` that it need confirm_response the "y" without "\n"
,that means once you type "y", it will respond immediately
3.add cleanup():
reset the "command max-lines" to default

are these code styles ok? after this check I will re-run the tests