### PR TITLE
CiscoXRBase: improved session preparation

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -10,12 +10,9 @@ class CiscoXrBase(CiscoBaseConnection):
 
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
-        self._test_channel_read()
         self.set_base_prompt()
         self.disable_paging()
-        self.set_terminal_width(command="terminal width 511")
         # Clear the read buffer
-        time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
     def send_config_set(self, config_commands=None, exit_config_mode=False, **kwargs):

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -1,4 +1,3 @@
-import time
 import re
 from netmiko.cisco_base_connection import CiscoBaseConnection, CiscoFileTransfer
 


### PR DESCRIPTION
Fixed the issue https://github.com/ktbyers/netmiko/issues/1882 according to the issue discussion.

Confirmed that black ran successfully against the changed code.
```
(netmiko) TAISASAK-M-23C0:netmiko taisasak$ black netmiko/cisco/cisco_xr.py
All done! ✨ 🍰 ✨
1 file left unchanged.
```

