### PR TITLE
Fix autodetect for 3850s

### DIFF
--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -96,7 +96,7 @@ class PaloAltoPanosBase(BaseConnection):
             if device_and_network:
                 command_string += " device-and-network"
             if policy_and_objects:
-                command_string += " device-and-network"
+                command_string += " policy-and-objects"
             if no_vsys:
                 command_string += " no-vsys"
             command_string += " excluded"

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -59,7 +59,7 @@ SNMP_MAPPER_BASE = {
     },
     "cisco_xe": {
         "oid": ".1.3.6.1.2.1.1.1.0",
-        "expr": re.compile(r".*IOS-XE Software,.*", re.IGNORECASE),
+        "expr": re.compile(r".*Catalyst L3 Switch Software.*", re.IGNORECASE),
         "priority": 99,
     },
     "cisco_xr": {

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -56,13 +56,13 @@ SSH_MAPPER_BASE = {
     },
     "alcatel_sros": {
         "cmd": "show version",
-        "search_patterns": ["Nokia", "Alcatel"],
+        "search_patterns": [r"Nokia", r"Alcatel"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
     "apresia_aeos": {
         "cmd": "show system",
-        "search_patterns": ["Apresia"],
+        "search_patterns": [r"Apresia"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
@@ -81,8 +81,8 @@ SSH_MAPPER_BASE = {
     "cisco_ios": {
         "cmd": "show version",
         "search_patterns": [
-            "Cisco IOS Software",
-            "Cisco Internetwork Operating System Software",
+            r"Cisco IOS Software,",
+            r"Cisco Internetwork Operating System Software",
         ],
         "priority": 99,
         "dispatch": "_autodetect_std",
@@ -90,6 +90,12 @@ SSH_MAPPER_BASE = {
     "cisco_nxos": {
         "cmd": "show version",
         "search_patterns": [r"Cisco Nexus Operating System", r"NX-OS"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "cisco_xe": {
+        "cmd": "show version",
+        "search_patterns": [r"Cisco IOS XE Software", r"IOS-EX"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -45,6 +45,7 @@ SHOW_RUN_MAPPER = {
     "brocade_fastiron": "show running-config",
     "brocade_netiron": "show running-config",
     "alcatel_aos": "show configuration snapshot",
+    "paloalto_panos": "show config running",
 }
 
 # Expand SHOW_RUN_MAPPER to include '_ssh' key


### PR DESCRIPTION
Autodetect for 3850s would use cisco_ios when this should be cisco_xe.  Fixed for both SSH and SNMP.  Also added Panos running config mapper command "show config running".