### PR TITLE
Added initial support for TP-Link JetStream

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -84,6 +84,7 @@ from netmiko.sixwind import SixwindOSSSH
 from netmiko.sophos import SophosSfosSSH
 from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
+from netmiko.tplink import TPLinkSSH, TPLinkTelnet
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.ubiquiti import UbiquitiUnifiSwitchSSH
 from netmiko.vyos import VyOSSSH
@@ -190,6 +191,7 @@ CLASS_MAPPER_BASE = {
     "ruijie_os": RuijieOSSSH,
     "sixwind_os": SixwindOSSSH,
     "sophos_sfos": SophosSfosSSH,
+    "tplink_jetstream": TPLinkSSH,
     "ubiquiti_edge": UbiquitiEdgeSSH,
     "ubiquiti_edgeswitch": UbiquitiEdgeSSH,
     "ubiquiti_unifiswitch": UbiquitiUnifiSwitchSSH,
@@ -259,6 +261,7 @@ CLASS_MAPPER["rad_etx_telnet"] = RadETXTelnet
 CLASS_MAPPER["raisecom_telnet"] = RaisecomRoapTelnet
 CLASS_MAPPER["ruckus_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["ruijie_os_telnet"] = RuijieOSTelnet
+CLASS_MAPPER["tplink_jetstream_telnet"] = TPLinkTelnet
 CLASS_MAPPER["yamaha_telnet"] = YamahaTelnet
 CLASS_MAPPER["zte_zxros_telnet"] = ZteZxrosTelnet
 

--- a/netmiko/tplink/__init__.py
+++ b/netmiko/tplink/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.tplink.tplink_jetstream import TPLinkSSH, TPLinkTelnet
+
+__all__ = ["TPLinkSSH", "TPLinkTelnet"]

--- a/netmiko/tplink/tplink_jetstream.py
+++ b/netmiko/tplink/tplink_jetstream.py
@@ -1,0 +1,167 @@
+import re
+import time
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from cryptography.hazmat.primitives.asymmetric import dsa
+from cryptography import utils as crypto_utils
+
+class TPLinkBase(CiscoSSHConnection):
+    def __init__(self, **kwargs):
+        # TP-Link doesn't have a way to set terminal width which breaks cmd_verify
+        if kwargs.get("global_cmd_verify") is None:
+            kwargs["global_cmd_verify"] = False
+        # TP-Link uses "\r\n" as default_enter for SSH and Telnet
+        if kwargs.get("default_enter") is None:
+            kwargs["default_enter"] = "\r\n"
+        return super().__init__(**kwargs)
+
+    def session_preparation(self):
+        """
+        Prepare the session after the connection has been established.
+        """
+        delay_factor = self.select_delay_factor(delay_factor=0)
+        time.sleep(0.3 * delay_factor)
+        self.clear_buffer()
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging()
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def enable(self, cmd="", pattern="ssword", re_flags=re.IGNORECASE):
+        """
+        Enter enable mode.
+
+        If the user does not have the Admin role it will need to execute
+        enable-admin to really enable all functions.
+        """
+        output = ""
+        msg = (
+            "Failed to enter enable mode. Please ensure you pass "
+            "the 'secret' argument to ConnectHandler."
+        )
+        cmds = ["enable", "enable-admin"]
+        if not self.check_enable_mode():
+            for cmd in cmds:
+                self.write_channel(self.normalize_cmd(cmd))
+                try:
+                    output += self.read_until_prompt_or_pattern(
+                           pattern=pattern, re_flags=re_flags
+                           )
+                    self.write_channel(self.normalize_cmd(self.secret))
+                    output += self.read_until_prompt()
+                except NetmikoTimeoutException:
+                    raise ValueError(msg)
+                if not self.check_enable_mode():
+                    raise ValueError(msg)
+        return output
+
+    def config_mode(self, config_command="configure"):
+        """Enter configuration mode."""
+        return super().config_mode(config_command=config_command)
+
+    def exit_config_mode(self, exit_config="exit", pattern=r"#"):
+        """
+        Exit config mode.
+        
+        Like the Mellanox equipments, the TP-Link Jetstream does not 
+        support a single command to completely exit the configuration mode.
+
+        Consequently, need to keep checking and sending "exit".
+        """
+        output = ""
+        check_count = 12
+        while check_count >= 0:
+            if self.check_config_mode():
+                self.write_channel(self.normalize_cmd(exit_config))
+                output += self.read_until_pattern(pattern=pattern)
+            else:
+                break
+            check_count -= 1
+
+        if self.check_config_mode():
+            raise ValueError("Failed to exit configuration mode")
+            log.debug(f"exit_config_mode: {output}")
+
+        return output
+
+    def check_config_mode(self, check_string="(config", pattern=r"#"):
+        """Check whether device is in configuration mode. Return a boolean."""
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def set_base_prompt(
+        self, pri_prompt_terminator=">", alt_prompt_terminator="#", delay_factor=1
+    ):
+        """
+        Sets self.base_prompt
+
+        Used as delimiter for stripping of trailing prompt in output.
+
+        Should be set to something that is general and applies in multiple
+        contexts. For TP-Link  this will be the router prompt with > or # 
+        stripped off.
+
+        This will be set on logging in, but not when entering system-view
+        """
+        prompt = super().set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            delay_factor=delay_factor,
+        )
+
+        # Strip off leading character
+        prompt = prompt[1:]
+        prompt = prompt.strip()
+        self.base_prompt = prompt
+        return self.base_prompt
+
+
+class TPLinkSSH(TPLinkBase):
+    def _override_check_dsa_parameters(parameters):
+        """
+        Override check_dsa_parameters from cryptography's dsa.py
+
+        Without this the error below occurs:
+
+        ValueError: p must be exactly 1024, 2048, or 3072 bits long
+
+        Allows for shorter or longer parameters.p to be returned 
+        from the server's host key. This is a HORRIBLE hack and a
+        security risk, please remove if possible!
+
+        By now, with firmware:
+
+        2.0.5 Build 20200109 Rel.36203(s)
+        
+        It's still not possible to remove this hack
+        """
+        if crypto_utils.bit_length(parameters.q) not in [160, 256]:
+            raise ValueError("q must be exactly 160 or 256 bits long")
+
+        if not (1 < parameters.g < parameters.p):
+            raise ValueError("g, p don't satisfy 1 < g < p.")
+
+    dsa._check_dsa_parameters = _override_check_dsa_parameters
+
+
+class TPLinkTelnet(TPLinkBase):
+    def telnet_login(
+        self,
+        pri_prompt_terminator="#",
+        alt_prompt_terminator=">",
+        username_pattern=r"User:",
+        pwd_pattern=r"Password:",
+        delay_factor=1,
+        max_loops=60,
+    ):
+        """Telnet login: can be username/password or just password."""
+        super().telnet_login(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            username_pattern=username_pattern,
+            pwd_pattern=pwd_pattern,
+            delay_factor=delay_factor,
+            max_loops=max_loops,
+        )
+

--- a/netmiko/tplink/tplink_jetstream.py
+++ b/netmiko/tplink/tplink_jetstream.py
@@ -1,8 +1,13 @@
 import re
 import time
-from netmiko.cisco_base_connection import CiscoSSHConnection
-from cryptography.hazmat.primitives.asymmetric import dsa
+
 from cryptography import utils as crypto_utils
+from cryptography.hazmat.primitives.asymmetric import dsa
+
+from netmiko import log
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko.ssh_exception import NetmikoTimeoutException
+
 
 class TPLinkBase(CiscoSSHConnection):
     def __init__(self, **kwargs):
@@ -47,8 +52,8 @@ class TPLinkBase(CiscoSSHConnection):
                 self.write_channel(self.normalize_cmd(cmd))
                 try:
                     output += self.read_until_prompt_or_pattern(
-                           pattern=pattern, re_flags=re_flags
-                           )
+                        pattern=pattern, re_flags=re_flags
+                    )
                     self.write_channel(self.normalize_cmd(self.secret))
                     output += self.read_until_prompt()
                 except NetmikoTimeoutException:
@@ -64,8 +69,8 @@ class TPLinkBase(CiscoSSHConnection):
     def exit_config_mode(self, exit_config="exit", pattern=r"#"):
         """
         Exit config mode.
-        
-        Like the Mellanox equipments, the TP-Link Jetstream does not 
+
+        Like the Mellanox equipments, the TP-Link Jetstream does not
         support a single command to completely exit the configuration mode.
 
         Consequently, need to keep checking and sending "exit".
@@ -99,7 +104,7 @@ class TPLinkBase(CiscoSSHConnection):
         Used as delimiter for stripping of trailing prompt in output.
 
         Should be set to something that is general and applies in multiple
-        contexts. For TP-Link  this will be the router prompt with > or # 
+        contexts. For TP-Link  this will be the router prompt with > or #
         stripped off.
 
         This will be set on logging in, but not when entering system-view
@@ -110,8 +115,6 @@ class TPLinkBase(CiscoSSHConnection):
             delay_factor=delay_factor,
         )
 
-        # Strip off leading character
-        prompt = prompt[1:]
         prompt = prompt.strip()
         self.base_prompt = prompt
         return self.base_prompt
@@ -126,14 +129,14 @@ class TPLinkSSH(TPLinkBase):
 
         ValueError: p must be exactly 1024, 2048, or 3072 bits long
 
-        Allows for shorter or longer parameters.p to be returned 
+        Allows for shorter or longer parameters.p to be returned
         from the server's host key. This is a HORRIBLE hack and a
         security risk, please remove if possible!
 
         By now, with firmware:
 
         2.0.5 Build 20200109 Rel.36203(s)
-        
+
         It's still not possible to remove this hack
         """
         if crypto_utils.bit_length(parameters.q) not in [160, 256]:
@@ -164,4 +167,3 @@ class TPLinkTelnet(TPLinkBase):
             delay_factor=delay_factor,
             max_loops=max_loops,
         )
-

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -442,3 +442,19 @@ huawei_smartax:
   config:
     - acl 2456
   config_verification: "display current-configuration | include acl 2456"
+
+tplink_jetstream:
+  version: "show system-info"
+  basic: "show interface vlan 1"
+  extended_output: "show running-config all"
+  config:
+    - "no clipaging"
+  config_verification: "show running-config | include clipaging"
+
+tplink_jetstream_telnet:
+  version: "show system-info"
+  basic: "show interface vlan 1"
+  extended_output: "show running-config all"
+  config:
+    - "no clipaging"
+  config_verification: "show running-config | include clipaging"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -290,3 +290,21 @@ huawei_smartax:
   interface_ip: 192.0.2.1
   version_banner: "VERSION :"
   multiple_line_output: ""
+
+tplink_jetstream:
+  base_prompt: "T1500G-10PS"
+  router_prompt: "T1500G-10PS>"
+  enable_prompt: "T1500G-10PS#"
+  interface_ip: 192.168.0.1
+  version_banner: "Software Version"
+  multiple_line_output: "interface vlan 1"
+  cmd_response_final: "no clipaging"
+
+tplink_jetstream_telnet:
+  base_prompt: "T1500G-10PS"
+  router_prompt: "T1500G-10PS>"
+  enable_prompt: "T1500G-10PS#"
+  interface_ip: 192.168.0.1
+  version_banner: "Software Version"
+  multiple_line_output: "interface vlan 1"
+  cmd_response_final: "no clipaging"

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -221,3 +221,15 @@ huawei_smartax:
   ip: 192.0.2.1
   username: TEST
   password: TEST
+
+tplink_jetstream:
+  device_type: tplink_jetstream
+  ip: 192.168.0.1
+  username: admin
+  password: 'admin'
+
+tplink_jetstream_telnet:
+  device_type: tplink_jetstream_telnet
+  ip: 192.168.0.1
+  username: admin
+  password: 'admin'

--- a/tests/test_tplink_jetstream.sh
+++ b/tests/test_tplink_jetstream.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device tplink_jetstream \
+&& py.test -v test_netmiko_config.py --test_device tplink_jetstream \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE

--- a/tests/test_tplink_jetstream_telnet.sh
+++ b/tests/test_tplink_jetstream_telnet.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device tplink_jetstream_telnet \
+&& py.test -v test_netmiko_config.py --test_device tplink_jetstream_telnet \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
This PR adds a new driver to support TP-Link JetStream switches, accepting connections through SSH or Telnet. It borrows the dsa code sample from #1250 and builds over the "unable to find prompt" discussion there.

The driver was tested in a TP-Link JetStream T1500G-10PS 2.0 both using tplink_jetstream device, connected by SSH, and tplink_jetstream_telnet device, connected by Telnet. It sucessfully login, enter in enable and configure mode, sends commands, saves the configuration, exit enable and configure mode, etc.

This PR closes issue #1911 