### PR TITLE
Ubiquiti EdgeRouter support

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -86,6 +86,7 @@ from netmiko.sophos import SophosSfosSSH
 from netmiko.terminal_server import TerminalServerSSH
 from netmiko.terminal_server import TerminalServerTelnet
 from netmiko.tplink import TPLinkJetStreamSSH, TPLinkJetStreamTelnet
+from netmiko.ubiquiti import UbiquitiEdgeRouterSSH
 from netmiko.ubiquiti import UbiquitiEdgeSSH
 from netmiko.ubiquiti import UbiquitiUnifiSwitchSSH
 from netmiko.vyos import VyOSSSH
@@ -195,6 +196,7 @@ CLASS_MAPPER_BASE = {
     "sophos_sfos": SophosSfosSSH,
     "tplink_jetstream": TPLinkJetStreamSSH,
     "ubiquiti_edge": UbiquitiEdgeSSH,
+    "ubiquiti_edgerouter": UbiquitiEdgeRouterSSH,
     "ubiquiti_edgeswitch": UbiquitiEdgeSSH,
     "ubiquiti_unifiswitch": UbiquitiUnifiSwitchSSH,
     "vyatta_vyos": VyOSSSH,

--- a/netmiko/ubiquiti/__init__.py
+++ b/netmiko/ubiquiti/__init__.py
@@ -1,4 +1,10 @@
 from netmiko.ubiquiti.edge_ssh import UbiquitiEdgeSSH
+from netmiko.ubiquiti.edgerouter_ssh import UbiquitiEdgeRouterSSH
 from netmiko.ubiquiti.unifiswitch_ssh import UbiquitiUnifiSwitchSSH
 
-__all__ = ["UbiquitiEdgeSSH", "UnifiSwitchSSH", "UbiquitiUnifiSwitchSSH"]
+__all__ = [
+    "UbiquitiEdgeRouterSSH",
+    "UbiquitiEdgeSSH",
+    "UnifiSwitchSSH",
+    "UbiquitiUnifiSwitchSSH",
+]

--- a/netmiko/ubiquiti/edgerouter_ssh.py
+++ b/netmiko/ubiquiti/edgerouter_ssh.py
@@ -1,0 +1,25 @@
+import time
+from netmiko.vyos.vyos_ssh import VyOSSSH
+
+
+class UbiquitiEdgeRouterSSH(VyOSSSH):
+    """Implement methods for interacting with EdgeOS EdgeRouter network devices."""
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.set_terminal_width(command="terminal width 512")
+        self.disable_paging(command="terminal length 0")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def save_config(self, cmd="save", confirm=False, confirm_response=""):
+        """Saves Config."""
+        if confirm is True:
+            raise ValueError("EdgeRouter does not support save_config confirmation.")
+        output = self.send_command(command_string=cmd)
+        if "Done" not in output:
+            raise ValueError(f"Save failed with following errors:\n\n{output}")
+        return output

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -458,3 +458,13 @@ tplink_jetstream_telnet:
   config:
     - "no clipaging"
   config_verification: "show running-config | include clipaging"
+
+ubiquiti_edgerouter:
+  version: "show version"
+  basic: "show interfaces switch switch0"
+  extended_output: "show configuration all"
+  config:
+    - "set system coredump enabled true"
+    - "set system coredump enabled false"
+  support_commit: True
+  config_verification: "show system coredump enabled"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -308,3 +308,13 @@ tplink_jetstream_telnet:
   version_banner: "Software Version"
   multiple_line_output: "interface vlan 1"
   cmd_response_final: "no clipaging"
+
+ubiquiti_edgerouter:
+  base_prompt: "ubnt@edgerouter"
+  router_prompt: "ubnt@edgerouter:~$"
+  enable_prompt: "ubnt@edgerouter:~$"
+  interface_ip: "192.168.1.1"
+  version_banner: "Ubiquiti Networks, Inc"
+  multiple_line_output: "switch switch0 {"
+  cmd_response_init: "enabled true"
+  cmd_response_final: "enabled false"

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -233,3 +233,9 @@ tplink_jetstream_telnet:
   ip: 192.168.0.1
   username: admin
   password: 'admin'
+
+ubiquiti_edgerouter:
+  device_type: ubiquiti_edgerouter
+  ip: 192.168.1.1
+  username: ubnt
+  password: ubnt

--- a/tests/test_ubiquiti_edgerouter.sh
+++ b/tests/test_ubiquiti_edgerouter.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+RETURN_CODE=0
+
+# Exit on the first test failure and set RETURN_CODE = 1
+echo "Starting tests...good luck:" \
+&& py.test -v test_netmiko_show.py --test_device ubiquiti_edgerouter \
+&& py.test -v test_netmiko_config.py --test_device ubiquiti_edgerouter \
+|| RETURN_CODE=1
+
+exit $RETURN_CODE


### PR DESCRIPTION
This PR adds a new driver for Ubiquiti EdgeRouter devices. These network devices uses a fork of Vyatta known as EdgeOS. But the vyatta_vyos doesn't have the save_config method also, the commands used to set terminal width and length gives "Invalid Command" on EdgeOS.

I only have an Ubiquiti EdgeRouter device, so I can't test if the same fixes works or are needed by a VyOS device. That's why I choose to extend the VyOSSSH and create the UbiquitiEdgeRouterSSH.

I ran the tests against the new driver and the results are:
```
Starting tests...good luck:
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
tempdir: /tmp/tests
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, inifile: setup.cfg
plugins: tempdir-2019.10.12, helpers-namespace-2019.1.8, salt-2020.1.27, pylama-7.7.1
collected 21 items                                                                                                                 

test_netmiko_show.py::test_disable_paging PASSED                                                                             [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                             [  9%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                [ 14%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                             [ 19%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                        [ 23%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED                                                          [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                               [ 33%]
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED                                                                 [ 38%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                                       [ 42%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                             [ 47%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                [ 52%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                      [ 57%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                        [ 61%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                [ 66%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                               [ 71%]
test_netmiko_show.py::test_strip_command PASSED                                                                              [ 76%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                        [ 80%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                               [ 85%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                [ 90%]
test_netmiko_show.py::test_disconnect PASSED                                                                                 [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                       [100%]

===================================================== short test summary info ======================================================
SKIPPED [1] /home/punk/Desktop/Projects/Software/External/netmiko/tests/test_netmiko_show.py:162: <Skipped instance>
SKIPPED [1] /home/punk/Desktop/Projects/Software/External/netmiko/tests/test_netmiko_show.py:183: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /home/punk/Desktop/Projects/Software/External/netmiko/tests/test_netmiko_show.py:208: Genie not supported on this platform
================================================== 18 passed, 3 skipped in 59.56s ==================================================
======================================================= test session starts ========================================================
platform linux -- Python 3.8.5, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
tempdir: /tmp/tests
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, inifile: setup.cfg
plugins: tempdir-2019.10.12, helpers-namespace-2019.1.8, salt-2020.1.27, pylama-7.7.1
collected 9 items                                                                                                                  

test_netmiko_config.py::test_ssh_connect PASSED                                                                              [ 11%]
test_netmiko_config.py::test_enable_mode PASSED                                                                              [ 22%]
test_netmiko_config.py::test_config_mode PASSED                                                                              [ 33%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                         [ 44%]
test_netmiko_config.py::test_config_set PASSED                                                                               [ 55%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                   [ 66%]
test_netmiko_config.py::test_config_hostname PASSED                                                                          [ 77%]
test_netmiko_config.py::test_config_from_file PASSED                                                                         [ 88%]
test_netmiko_config.py::test_disconnect PASSED                                                                               [100%]

======================================================== 9 passed in 43.48s ========================================================
```