### PR TITLE
Added two new examples

### DIFF
--- a/examples/save_output_to_file.py
+++ b/examples/save_output_to_file.py
@@ -1,0 +1,27 @@
+from netmiko import ConnectHandler
+from getpass import getpass
+
+# The command for to run.
+command = "sh ip int brief"
+
+# The credentials to the first device.
+# Add 'secret': getpass() if you are using an enable only command.
+cisco_ios = {
+    "device_type": "cisco_ios",
+    "host": "cisco1.lasthop.io",
+    "username": "pyclass",
+    "password": getpass(),
+}
+
+net_connect  = ConnectHandler(**cisco_ios)
+# Add this if you want to use enable mode.
+# net_connect.enable()
+
+# Output for the device.
+output = net_connect.send_command(command)
+
+# Creates the file and writes the output to it.
+backupFile = open("output_cmds.txt", "w+")
+backupFile.write(output)
+
+print("Outputted to output_cmds.txt!")

--- a/examples/send_command_two_devices.py
+++ b/examples/send_command_two_devices.py
@@ -1,0 +1,39 @@
+from netmiko import ConnectHandler
+from getpass import getpass
+
+# The command for both, assuming you want to run the same command on both of them.
+command = "sh ip int brief"
+
+# The credentials to the first device.
+# Add 'secret': getpass() if you are using an enable only command.
+cisco_ios_1 = {
+    "device_type": "cisco_ios",
+    "host": "cisco1.lasthop.io",
+    "username": "pyclass",
+    "password": getpass(),
+}
+
+# The credentials to the second device.
+# add 'secret': getpass() if you are using an enable only command.
+cisco_ios_2 = {
+    "device_type": "cisco_ios",
+    "host": "cisco1.lasthop.io",
+    "username": "pyclass",
+    "password": getpass(),
+}
+
+net_connect_1  = ConnectHandler(**cisco_ios_1)
+# Add this if you want to use enable mode.
+# net_connect_1.enable()
+
+net_connect_2  = ConnectHandler(**cisco_ios_2)
+# Add this if you want to use enable mode.
+# net_connect_2.enable()
+
+# Output for the first device and the second device.
+output_1 = net_connect_1.send_command(command)
+output_2 = net_connect_2.send_command(command)
+
+print(output_1)
+print("\n \n \n \n \n")
+print(output_2)


### PR DESCRIPTION
I added "examples/save_output_to_file.py", and "examples/send_command_two_devices.py". They do as they say. The "examples/save_output_to_file.py" creates a txt file and writes the output to it. "examples/send_command_two_devices.py" shows how to connect two devices at the same time and output the command. Obviously, they could be combined to save both outputs to two seperate files.