### PR TITLE
Update AdtranOS enable pattern

### DIFF
--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -22,7 +22,7 @@ class AdtranOSBase(CiscoBaseConnection):
     def check_enable_mode(self, check_string="#"):
         return super().check_enable_mode(check_string=check_string)
 
-    def enable(self, cmd="enable", pattern="", re_flags=re.IGNORECASE):
+    def enable(self, cmd="enable", pattern="ssword", re_flags=re.IGNORECASE):
         return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
 
     def exit_enable_mode(self, exit_command="disable"):


### PR DESCRIPTION
I'm not sure what flavor of Adtran the current implementation is built against, but below is an example of Adtran's TA (TotalAccess) series cli.
```
SomeHostname>enable   
Password: 
SomeHostname#
```