### PR TITLE
fix dell_force10 autodetect

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -101,7 +101,7 @@ SSH_MAPPER_BASE = {
     },
     "dell_force10": {
         "cmd": "show version",
-        "search_patterns": [r"S4048-ON"],
+        "search_patterns": [r"Real Time Operating System Software"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Fixes #1283 

Current implementation has search pattern of 'S4048-ON'. Therefore it tries to detects the device based on the HW model and it's capable to detect only S4048-ON switches

"Real Time Operating System Software" is present on output of 'show version' on all HW platforms based on the documentation. This was also verified with switches which I have access to (3048, 4048, Z9100-ON).