### PR TITLE
Fix tplink_jetstream to support cryptography 3.1+

### DIFF
--- a/netmiko/tplink/tplink_jetstream.py
+++ b/netmiko/tplink/tplink_jetstream.py
@@ -1,7 +1,6 @@
 import re
 import time
 
-from cryptography import utils as crypto_utils
 from cryptography.hazmat.primitives.asymmetric import dsa
 
 from netmiko import log
@@ -142,7 +141,7 @@ class TPLinkJetStreamSSH(TPLinkJetStreamBase):
 
         It's still not possible to remove this hack.
         """
-        if crypto_utils.bit_length(parameters.q) not in [160, 256]:
+        if parameters.q.bit_length() not in [160, 256]:
             raise ValueError("q must be exactly 160 or 256 bits long")
 
         if not (1 < parameters.g < parameters.p):


### PR DESCRIPTION
The commit [d272386](https://github.com/pyca/cryptography/pull/5360/commits/d27238613bdb89473f8b0d12b713b29b121b7fe0) on cryptography removed the bit_length() function from utils.py. That change broke the TPLink model.

This PR replaces the use of cryptography utils bit_length() function by a direct call to parameters.q.bit_length()

Fixes #1987 

After applying the fix did a test with cryptography 3.0.0 to prevent regressions:
```
punk@bat:~/Desktop/Projects/Software/External/netmiko/tests$ pip3 install --upgrade cryptography==3.0.0                       
Defaulting to user installation because normal site-packages is not writeable
Collecting cryptography==3.0.0
  Using cached cryptography-3.0-cp35-abi3-manylinux2010_x86_64.whl (2.7 MB)
Requirement already satisfied, skipping upgrade: cffi!=1.11.3,>=1.8 in /home/punk/.local/lib/python3.9/site-packages (from cryptography==3.0.0) (1.14.3)
Requirement already satisfied, skipping upgrade: six>=1.4.1 in /usr/lib64/python3.9/site-packages (from cryptography==3.0.0) (1.15.0)
Requirement already satisfied, skipping upgrade: pycparser in /home/punk/.local/lib/python3.9/site-packages (from cffi!=1.11.3,>=1.8->cryptography==3.0.0) (2.20)
Installing collected packages: cryptography
  Attempting uninstall: cryptography
    Found existing installation: cryptography 3.2.1
    Uninstalling cryptography-3.2.1:
      Successfully uninstalled cryptography-3.2.1
Successfully installed cryptography-3.0
punk@bat:~/Desktop/Projects/Software/External/netmiko/tests$ ./test_tplink_jetstream.sh                
Starting tests...good luck:
======================================================= test session starts ========================================================
platform linux -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, configfile: setup.cfg
collected 22 items                                                                                                                 

test_netmiko_show.py::test_disable_paging PASSED                                                                             [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                             [  9%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                [ 13%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                             [ 18%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                        [ 22%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED                                                          [ 27%]
test_netmiko_show.py::test_send_command PASSED                                                                               [ 31%]
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED                                                                 [ 36%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                                       [ 40%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                             [ 45%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                [ 50%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                      [ 54%]
test_netmiko_show.py::test_send_command_ttp SKIPPED                                                                          [ 59%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                        [ 63%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                [ 68%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                               [ 72%]
test_netmiko_show.py::test_strip_command PASSED                                                                              [ 77%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                        [ 81%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                               [ 86%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                [ 90%]
test_netmiko_show.py::test_disconnect PASSED                                                                                 [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                       [100%]

===================================================== short test summary info ======================================================
SKIPPED [1] test_netmiko_show.py:163: <Skipped instance>
SKIPPED [1] test_netmiko_show.py:184: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:206: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:243: Genie not supported on this platform
============================================= 18 passed, 4 skipped in 72.34s (0:01:12) =============================================
======================================================= test session starts ========================================================
platform linux -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, configfile: setup.cfg
collected 9 items                                                                                                                  

test_netmiko_config.py::test_ssh_connect PASSED                                                                              [ 11%]
test_netmiko_config.py::test_enable_mode PASSED                                                                              [ 22%]
test_netmiko_config.py::test_config_mode PASSED                                                                              [ 33%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                         [ 44%]
test_netmiko_config.py::test_config_set PASSED                                                                               [ 55%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                   [ 66%]
test_netmiko_config.py::test_config_hostname PASSED                                                                          [ 77%]
test_netmiko_config.py::test_config_from_file PASSED                                                                         [ 88%]
test_netmiko_config.py::test_disconnect PASSED                                                                               [100%]

======================================================== 9 passed in 16.99s ========================================================
```
And with cryptography 3.2.1
```
punk@bat:~/Desktop/Projects/Software/External/netmiko/tests$ pip3 install --upgrade cryptography
Defaulting to user installation because normal site-packages is not writeable
Collecting cryptography
  Using cached cryptography-3.2.1-cp35-abi3-manylinux2010_x86_64.whl (2.6 MB)
Requirement already satisfied, skipping upgrade: cffi!=1.11.3,>=1.8 in /home/punk/.local/lib/python3.9/site-packages (from cryptography) (1.14.3)
Requirement already satisfied, skipping upgrade: six>=1.4.1 in /usr/lib64/python3.9/site-packages (from cryptography) (1.15.0)
Requirement already satisfied, skipping upgrade: pycparser in /home/punk/.local/lib/python3.9/site-packages (from cffi!=1.11.3,>=1.8->cryptography) (2.20)
Installing collected packages: cryptography
  Attempting uninstall: cryptography
    Found existing installation: cryptography 3.0
    Uninstalling cryptography-3.0:
      Successfully uninstalled cryptography-3.0
Successfully installed cryptography-3.2.1
punk@bat:~/Desktop/Projects/Software/External/netmiko/tests$ ./test_tplink_jetstream.sh 
Starting tests...good luck:
======================================================= test session starts ========================================================
platform linux -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, configfile: setup.cfg
collected 22 items                                                                                                                 

test_netmiko_show.py::test_disable_paging PASSED                                                                             [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                             [  9%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                [ 13%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                             [ 18%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                        [ 22%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED                                                          [ 27%]
test_netmiko_show.py::test_send_command PASSED                                                                               [ 31%]
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED                                                                 [ 36%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                                       [ 40%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                             [ 45%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                [ 50%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                      [ 54%]
test_netmiko_show.py::test_send_command_ttp SKIPPED                                                                          [ 59%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                        [ 63%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                [ 68%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                               [ 72%]
test_netmiko_show.py::test_strip_command PASSED                                                                              [ 77%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                        [ 81%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                               [ 86%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                [ 90%]
test_netmiko_show.py::test_disconnect PASSED                                                                                 [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                       [100%]

===================================================== short test summary info ======================================================
SKIPPED [1] test_netmiko_show.py:163: <Skipped instance>
SKIPPED [1] test_netmiko_show.py:184: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:206: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:243: Genie not supported on this platform
============================================= 18 passed, 4 skipped in 72.23s (0:01:12) =============================================
======================================================= test session starts ========================================================
platform linux -- Python 3.9.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/punk/Desktop/Projects/Software/External/netmiko, configfile: setup.cfg
collected 9 items                                                                                                                  

test_netmiko_config.py::test_ssh_connect PASSED                                                                              [ 11%]
test_netmiko_config.py::test_enable_mode PASSED                                                                              [ 22%]
test_netmiko_config.py::test_config_mode PASSED                                                                              [ 33%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                         [ 44%]
test_netmiko_config.py::test_config_set PASSED                                                                               [ 55%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                   [ 66%]
test_netmiko_config.py::test_config_hostname PASSED                                                                          [ 77%]
test_netmiko_config.py::test_config_from_file PASSED                                                                         [ 88%]
test_netmiko_config.py::test_disconnect PASSED                                                                               [100%]

======================================================== 9 passed in 17.14s ========================================================
```