### PR TITLE
Update fortinet_ssh.py

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -106,8 +106,8 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode(self, config_command="", pattern="", re_flags=0):
         """
-        Enter into configuration mode on remote device. 
-        Function particularly usefull when VDOMs are configured on it
+        #Enter into configuration mode on remote device. 
+        #Function particularly usefull when VDOMs are configured on it
         """
 
         if not pattern:

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -118,19 +118,22 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode_vdom(self, vdom_name="", new_vdom=False, pattern="", re_flags=0):
         """
-        Function That will allow the user to enter in config vdom mode. This function will control
-        if the VDOM exist or not if the new_VDOM is not changed to True
-
+        Function That will allow the user to enter in config vdom mode.
+        This function will control if the VDOM exist or not if the new_VDOM is not changed to True
         Args:
-            vdom_name (str, optional): [description]. Defaults to "". Supply here the name of the VDOM to edit
-            new_vdom (bool, optional): [description]. Defaults to False. Change it to True to create a new VDOM
-            pattern (str, optional): [description]. Defaults to "". The pattern used to identify that the output is complete
-            re_flags (int, optional): [description]. Defaults to 0. regex flags used in conjunction with pattern to search for prompt
+            vdom_name (str, optional): [description]. Defaults to "".
+                Supply here the name of the VDOM to edit
+            new_vdom (bool, optional): [description]. Defaults to False.
+                Change it to True to create a new VDOM
+            pattern (str, optional): [description]. Defaults to "".
+                The pattern used to identify that the output is complete
+            re_flags (int, optional): [description]. Defaults to 0.
+                regex flags used in conjunction with pattern to search for prompt
         """
         delay_factor = self.select_delay_factor(delay_factor=0)
         self.write_channel("config vdom\n")
         time.sleep(0.33 * delay_factor)
-        if new_vdom == True:
+        if new_vdom:
             assert (
                 vdom_name != ""
             ), "If you would like the creation of a new VDOM, please provide it"
@@ -144,7 +147,8 @@ class FortinetSSH(CiscoSSHConnection):
             vdom_list = output[2:-2]
             assert (
                 vdom_name in vdom_list
-            ), "VDOM Name not in the existing VDOMs. If you expect a creation of it, change new_vdom to True "
+            ), "VDOM Name not in the existing VDOMs. \
+            If you expect a creation of it, change new_vdom to True "
             command = vdom_name + "\n"
             print(command)
             self.write_channel(command)

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -106,9 +106,7 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode(self, config_command="", pattern="", re_flags=0):
         """
-        Enter into configuration mode on remote device.
-
-        Several commands available only in config global mode or config vdom mode
+        Enter into configuration mode on remote device. Function particularly usefull when VDOMs are configured on it
         """
 
         if not pattern:

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -97,6 +97,7 @@ class FortinetSSH(CiscoSSHConnection):
             for command in enable_paging_commands:
                 self.send_command_timing(command)
         return super().cleanup(command=command)
+    
     def check_config_mode(self, check_string=") #", pattern=""):
         """
         Checks if the device is in configuration mode or not.
@@ -106,14 +107,12 @@ class FortinetSSH(CiscoSSHConnection):
     def config_mode(self, config_command="config global", pattern="", re_flags=0):
         """
         Enter into configuration mode on remote device.
-
         Several commands available only in config global mode or config vdom mode
         """
         if not pattern:
             pattern = re.escape(self.base_prompt[:16])
-        return super().config_mode(
-            config_command=config_command, pattern=pattern, re_flags=re_flags
-        )
+        
+        return super().config_mode(config_command=config_command, pattern=pattern, re_flags=re_flags)
 
     def exit_config_mode(self, exit_config="end", pattern='#'):
         """Exit from configuration mode."""

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -97,14 +97,27 @@ class FortinetSSH(CiscoSSHConnection):
             for command in enable_paging_commands:
                 self.send_command_timing(command)
         return super().cleanup(command=command)
+    def check_config_mode(self, check_string=") #", pattern=""):
+        """
+        Checks if the device is in configuration mode or not.
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
 
-    def config_mode(self, config_command=""):
-        """No config mode for Fortinet devices."""
-        return ""
+    def config_mode(self, config_command="config global", pattern="", re_flags=0):
+        """
+        Enter into configuration mode on remote device.
 
-    def exit_config_mode(self, exit_config=""):
-        """No config mode for Fortinet devices."""
-        return ""
+        Several commands available only in config global mode or config vdom mode
+        """
+        if not pattern:
+            pattern = re.escape(self.base_prompt[:16])
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
+
+    def exit_config_mode(self, exit_config="end", pattern='#'):
+        """Exit from configuration mode."""
+        return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
     def save_config(self, *args, **kwargs):
         """Not Implemented"""

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -106,7 +106,7 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode(self, config_command="", pattern="", re_flags=0):
         """
-        #Enter into configuration mode on remote device. 
+        #Enter into configuration mode on remote device.
         #Function particularly usefull when VDOMs are configured on it
         """
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -97,7 +97,7 @@ class FortinetSSH(CiscoSSHConnection):
             for command in enable_paging_commands:
                 self.send_command_timing(command)
         return super().cleanup(command=command)
-    
+
     def check_config_mode(self, check_string=") #", pattern=""):
         """
         Checks if the device is in configuration mode or not.
@@ -107,15 +107,18 @@ class FortinetSSH(CiscoSSHConnection):
     def config_mode(self, config_command="config global", pattern="", re_flags=0):
         """
         Enter into configuration mode on remote device.
+
         Several commands available only in config global mode or config vdom mode
         """
+
         if not pattern:
             pattern = re.escape(self.base_prompt[:16])
-        
-        return super().config_mode(config_command=config_command, pattern=pattern, re_flags=re_flags)
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
 
-    def exit_config_mode(self, exit_config="end", pattern='#'):
-        """Exit from configuration mode."""
+    def exit_config_mode(self, exit_config=""):
+        """No config mode for Fortinet devices."""
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
     def save_config(self, *args, **kwargs):

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -117,7 +117,7 @@ class FortinetSSH(CiscoSSHConnection):
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )
 
-    def exit_config_mode(self, exit_config=""):
+    def exit_config_mode(self, exit_config="", pattern=""):
         """No config mode for Fortinet devices."""
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -106,7 +106,8 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode(self, config_command="", pattern="", re_flags=0):
         """
-        Enter into configuration mode on remote device. Function particularly usefull when VDOMs are configured on it
+        Enter into configuration mode on remote device. 
+        Function particularly usefull when VDOMs are configured on it
         """
 
         if not pattern:

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -104,7 +104,7 @@ class FortinetSSH(CiscoSSHConnection):
         """
         return super().check_config_mode(check_string=check_string, pattern=pattern)
 
-    def config_mode(self, config_command="config global", pattern="", re_flags=0):
+    def config_mode(self, config_command="", pattern="", re_flags=0):
         """
         Enter into configuration mode on remote device.
 

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -118,7 +118,7 @@ class FortinetSSH(CiscoSSHConnection):
 
     def config_mode_vdom(self, vdom_name="", new_vdom=False, pattern="", re_flags=0):
         """
-        Function That will allow the user to enter in config vdom mode. This function will control 
+        Function That will allow the user to enter in config vdom mode. This function will control
         if the VDOM exist or not if the new_VDOM is not changed to True
 
         Args:
@@ -130,29 +130,35 @@ class FortinetSSH(CiscoSSHConnection):
         delay_factor = self.select_delay_factor(delay_factor=0)
         self.write_channel("config vdom\n")
         time.sleep(0.33 * delay_factor)
-        if new_vdom==True:    
-            assert(vdom_name!=""), "If you would like the creation of a new VDOM, please provide it"
-            self.write_channel("edit " + vdom_name+"\n")
+        if new_vdom == True:
+            assert (
+                vdom_name != ""
+            ), "If you would like the creation of a new VDOM, please provide it"
+            self.write_channel("edit " + vdom_name + "\n")
         else:
-            assert (vdom_name!= ""), "Supply a VDOM name to enter in config mode on it"
+            assert vdom_name != "", "Supply a VDOM name to enter in config mode on it"
             self.write_channel("edit ?")
             time.sleep(0.33 * delay_factor)
             output = self.read_channel().splitlines()
             self.clear_buffer()
-            vdom_list= output[2:-2]
-            assert (vdom_name in vdom_list), "VDOM Name not in the existing VDOMs. If you expect a creation of it, change new_vdom to True "          
-            command=vdom_name + "\n"
+            vdom_list = output[2:-2]
+            assert (
+                vdom_name in vdom_list
+            ), "VDOM Name not in the existing VDOMs. If you expect a creation of it, change new_vdom to True "
+            command = vdom_name + "\n"
             print(command)
             self.write_channel(command)
             time.sleep(0.33 * delay_factor)
             self.set_base_prompt()
             self.clear_buffer()
-            
-    def config_mode_global(self, config_command="config global", pattern="", re_flags=0):
+
+    def config_mode_global(
+        self, config_command="config global", pattern="", re_flags=0
+    ):
         self.config_mode(config_command, pattern, re_flags)
-    
+
     def exit_config_mode(self, exit_config="end", pattern="#"):
-        #print(pattern)
+        # print(pattern)
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
     def save_config(self, *args, **kwargs):

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -117,7 +117,7 @@ class FortinetSSH(CiscoSSHConnection):
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )
 
-    def exit_config_mode(self, exit_config="", pattern=""):
+    def exit_config_mode(self, exit_config="end", pattern=""):
         """No config mode for Fortinet devices."""
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 


### PR DESCRIPTION
Several commands in Fortinet needs to be in config mode. The idea here is to propose this feature and be able to pass them. I put by default the config global mode but the user should modify this parameter if wants to enter in the config vdom mode.

I've added also the check_config_mode function & modify consequently the exit_config_mode. 

All those updates it's basically a copy paste of the functions available on Cisco and modified to be relative to fortinet devices.

Sam