### PR TITLE
Add exception info to NetmikoTimeoutException message

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -934,6 +934,7 @@ Common causes of this problem are:
 3. Intermediate firewall blocking access.
 
 Device settings: {self.device_type} {self.host}:{self.port}
+Error info: [{conn_error.__class__.__name__}] {conn_error}
 
 """
 


### PR DESCRIPTION
Hi,

I was getting this NetmikoTimeoutException with current netmiko code:
```
TCP connection to device failed.

Common causes of this problem are:
1. Incorrect hostname or IP address.
2. Wrong TCP port.
3. Intermediate firewall blocking access.

Device settings: cisco_ios 10.0.0.98:22
```

One general issue with this mesage is that it's completely inaccurate:

- It was an SSH connection, which I could see clearly established, passing handshake and such - there was no issue of any kind on TCP level.

- Can you guess what was the actual error there?
    `[PermissionError] [Errno 13] Permission denied: '/etc/netbox/ssh_key'` - very unclear from above error, obviously.

I think this happens because socket.error is an alias for OSError, so applies to any kind of weirdness that has nothing to do with TCP or sockets.

This PR tries to address this in an easiest way possible - simply log the actual exception type and message, so that one can tell what the problem is, hopefully, instead of leading into a wrong and confusing direction (debugging ssh protocol and network stuff), and without the need to patch netmiko to get the true error info instead of false placeholder.

One potential caveat I see here is that sensitive information might propagate to exception message if it can end up in OSError.
But not sure if python can raise such OSErrors, and don't think paramiko should (that'd be a bug there), so probably not an issue?

paramiko seem to try actually reading key as late as possible, after establishing ssh connection and after `debug1: KEX done [preauth]` on sshd side (openssh `sshd -dddddd` output), which makes this non-connection error less obvious (as opposed to failing before even trying).
Not sure if maybe it's also a bug there, but pretty sure reporting all OSErrors as TCP issues is still worth addressing here.

Thanks.