### PR TITLE
SCP nokia_sros: Fix to remote_file_size()

### DIFF
--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -279,7 +279,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
         if "File Not Found" in remote_out:
             raise IOError("Unable to find file on remote system")
 
-        dest_file_name = remote_file.replace('\\', '/').split('/')[-1]
+        dest_file_name = remote_file.replace("\\", "/").split("/")[-1]
         # Parse dir output for filename. Output format is:
         # "10/16/2019  10:00p                6738 {dest_file_name}"
 

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -248,7 +248,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
 
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = self._file_cmd_prefix() + "file dir {}\\{}".format(
+                remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
                     self.file_system, self.dest_file
                 )
             dest_file_name = self.dest_file.replace("\\", "/").split("/")[-1]

--- a/netmiko/nokia/nokia_sros_ssh.py
+++ b/netmiko/nokia/nokia_sros_ssh.py
@@ -248,7 +248,7 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
 
         if self.direction == "put":
             if not remote_cmd:
-                remote_cmd = self._file_cmd_prefix() + "file dir {}/{}".format(
+                remote_cmd = self._file_cmd_prefix() + "file dir {}\\{}".format(
                     self.file_system, self.dest_file
                 )
             dest_file_name = self.dest_file.replace("\\", "/").split("/")[-1]
@@ -279,10 +279,11 @@ class NokiaSrosFileTransfer(BaseFileTransfer):
         if "File Not Found" in remote_out:
             raise IOError("Unable to find file on remote system")
 
+        dest_file_name = remote_file.replace('\\', '/').split('/')[-1]
         # Parse dir output for filename. Output format is:
-        # "10/16/2019  10:00p                6738 {filename}"
+        # "10/16/2019  10:00p                6738 {dest_file_name}"
 
-        pattern = r"\S+\s+\S+\s+(\d+)\s+{}".format(re.escape(remote_file))
+        pattern = r"\S+\s+\S+\s+(\d+)\s+{}".format(re.escape(dest_file_name))
         match = re.search(pattern, remote_out)
 
         if not match:


### PR DESCRIPTION
This is supplementary fix to  #1724 - handling file_transfer to non_root directories.

Only filename is shown in the 'file dir' command output, need to isolate file basename for regex match. When uploading file to non-root location remote_file_size() method fails. It tries to match whole destination 'directory/file' against 'file dir directory/file' output, which contains only final path component:

```
*A:GJJAM003PAR01# file dir directory/file
Volume in drive cf3 on slot A has no label.

Volume in drive cf3 on slot A is formatted as FAT16

Directory of cf3:\directory

02/05/2021  03:42p                   2 file
               1 File(s)                      2 bytes.
               0 Dir(s)               146472960 bytes free.
```


```
with netmiko.Netmiko(**crede) as conn:
    file_transfer(
        conn, 
        source_file='file', 
        dest_file='directory/file', 
        file_system='cf3:', 
        overwrite_file=True, 
        direction='put'
)
```

gives:
```
Traceback (most recent call last):
  File "/tmp/crap.py", line 14, in <module>
    file_transfer(conn, source_file='file', dest_file='images/file', file_system='cf3:', overwrite_file=True, direction='put')
  File "/tmp/venv/lib/python3.9/site-packages/netmiko/scp_functions.py", line 137, in file_transfer
    if scp_transfer.verify_file():
  File "/tmp/venv/lib/python3.9/site-packages/netmiko/nokia/nokia_sros_ssh.py", line 297, in verify_file
    return os.stat(self.source_file).st_size == self.remote_file_size(
  File "/tmp/venv/lib/python3.9/site-packages/netmiko/nokia/nokia_sros_ssh.py", line 289, in remote_file_size
    raise ValueError("Filename entry not found in dir output")
ValueError: Filename entry not found in dir output
```