### PR TITLE
Fix _autodetect_remote_version in ssh_autodetect

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -347,7 +347,7 @@ class SSHDetect(object):
             return cached_results
 
     def _autodetect_remote_version(
-        self, search_patterns=None, re_flags=re.IGNORECASE, priority=99
+        self, cmd="", search_patterns=None, re_flags=re.IGNORECASE, priority=99
     ):
         """
         Method to try auto-detect the device type, by matching a regular expression on the reported
@@ -355,6 +355,9 @@ class SSHDetect(object):
 
         Parameters
         ----------
+        cmd : str, optional, unused
+            This parameter is not used here, it is necessary to match the signature of the other
+            _autodetect_std method
         search_patterns : list
             A list of regular expression to look for in the reported remote SSH version
             (default: None).


### PR DESCRIPTION
# Error

When running SSHDetect on an unknown device, there is a chance for the `autodetect` method to raise the following exception:

```
_autodetect_remote_version() got an unexpected keyword argument 'cmd'
```

This happens when the `autodetect` passes over the `cisco_wlc` type and calls `_autodetect_remote_version` with an extra unexpected argument `"cmd"`.

# Analysis

- fd67d8ff2741cfd3a2dd391a34fcca8c304cb87c introduced a new detection method based on the SSH signature (`_autodetect_remote_version`).
- 66dccecf5e59bb002ab9b5c91c297b285b2b996c later introduced a method to sort the commands to run based on the most frequent ones and introduced with it a `"cmd"` key in the `cisco_wlc` device dict (https://github.com/ktbyers/netmiko/blob/develop/netmiko/ssh_autodetect.py#L192).
- This led the `autodetect_method` (https://github.com/ktbyers/netmiko/blob/develop/netmiko/ssh_autodetect.py#L286) to have an extra unexpected `cmd` argument when `autodetect_method` is `_autodetect_remote_version`. 

# Fix

This PR addresses this issue by adding the `cmd` keyword argument to the signature of `_autodetect_remote_version`.

I believe that in the future attention should be paid so as to make sure that all new detection methods added match the signature of the base `_autodetect_std` method.