### PR TITLE
Modify Yamaha telnet default enter

### DIFF
--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -29,6 +29,7 @@ class YamahaBase(BaseConnection):
             output = self.read_channel()
             if "(Y/N)" in output:
                 self.write_channel("N")
+            self.write_channel("\n")
             output += self.read_until_prompt()
             if self.check_enable_mode():
                 raise ValueError("Failed to exit enable mode.")
@@ -66,5 +67,7 @@ class YamahaSSH(YamahaBase):
 
 class YamahaTelnet(YamahaBase):
     """Yamaha Telnet driver."""
-
-    pass
+    def __init__(self, *args, **kwargs):
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
When trying `yamaha_telnet` driver, `send_command()` failed with error below:

```python:send_config_telnet.py
from netmiko import ConnectHandler

device = {
    "host": "x.x.xx.xx",
    "username": "xxx",
    "password": "xxx",
    "secret": "xxx",
    "device_type": "yamaha_telnet",
}

net_connect = ConnectHandler(**device)
output = net_connect.send_command("show status lan1")
print(output)
```

```
$ python send_config_telnet.py
Traceback (most recent call last):
  File "send_config_telnet.py", line 12, in <module>
    output = net_connect.send_command("show status lan1")
  File "/home/centos/venv_netmiko3.3.2/lib64/python3.6/site-packages/netmiko/utilities.py", line 429, in wrapper_decorator
    return func(self, *args, **kwargs)
  File "/home/centos/venv_netmiko3.3.2/lib64/python3.6/site-packages/netmiko/base_connection.py", line 1527, in send_command
    search_pattern
OSError: Search pattern never detected in send_command: yamaha1\>
```

In `_first_line_handler()` of BaseConnection  class below, as return code is wrong, failing to split data and prompt(pattern) disappeared. So I modified YamahaTelnet class.

```python:base_connection.py
            lines = data.split(self.RETURN)
            first_line = lines[0]
            if BACKSPACE_CHAR in first_line:
                pattern = search_pattern + r".*$"
                first_line = re.sub(pattern, repl="", string=first_line)
```

Also, in some cases, `exit_enable_mode()` failed to get prompt so I added `self.write_channel("\n")` before that.