### PR TITLE
fixes an issue with ssh _autodetect_remote_version

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -347,7 +347,7 @@ class SSHDetect(object):
             return cached_results
 
     def _autodetect_remote_version(
-        self, search_patterns=None, re_flags=re.IGNORECASE, priority=99
+        self, search_patterns=None, re_flags=re.IGNORECASE, priority=99, *args, **kwargs
     ):
         """
         Method to try auto-detect the device type, by matching a regular expression on the reported

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -347,7 +347,7 @@ class SSHDetect(object):
             return cached_results
 
     def _autodetect_remote_version(
-        self, search_patterns=None, re_flags=re.IGNORECASE, priority=99, *args, **kwargs
+        self, search_patterns=None, re_flags=re.IGNORECASE, priority=99, **kwargs
     ):
         """
         Method to try auto-detect the device type, by matching a regular expression on the reported


### PR DESCRIPTION
In #2032 a cmd key was introduced for the cisco_wlc dict.
This caused an issue for the _autodetect_remove_version function, which didn't accept the cmd kwarg.