### PR TITLE
fix unbalanced parenthesis error from regex engine

### DIFF
--- a/netmiko/netgear/netgear_prosafe_ssh.py
+++ b/netmiko/netgear/netgear_prosafe_ssh.py
@@ -25,7 +25,7 @@ class NetgearProSafeSSH(CiscoSSHConnection):
     def check_config_mode(self, check_string="(Config)#"):
         return super().check_config_mode(check_string=check_string)
 
-    def config_mode(self, config_command="configure", pattern=r")#"):
+    def config_mode(self, config_command="configure", pattern=r"\)#"):
         return super().config_mode(config_command=config_command, pattern=pattern)
 
     def exit_config_mode(self, exit_config="exit", pattern="#"):


### PR DESCRIPTION
without escaping the ")" we end up with regexp error:


>>> from netmiko import ConnectHandler
>>> net_connect = ConnectHandler(device_type='netgear_prosafe', host='192.168.28.201', username='admin', password='nas', secret='nas') 
>>> output = net_connect.send_config_set(["interface 0/15", "no shutdown"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sahnetlink3/.local/lib/python3.6/site-packages/netmiko/base_connection.py", line 1837, in send_config_set
    output += self.config_mode(*cfg_mode_args)
  File "/home/sahnetlink3/.local/lib/python3.6/site-packages/netmiko/netgear/netgear_prosafe_ssh.py", line 29, in config_mode
    return super().config_mode(config_command=config_command, pattern=pattern)
  File "/home/sahnetlink3/.local/lib/python3.6/site-packages/netmiko/cisco_base_connection.py", line 41, in config_mode
    config_command=config_command, pattern=pattern, re_flags=re_flags
  File "/home/sahnetlink3/.local/lib/python3.6/site-packages/netmiko/base_connection.py", line 1728, in config_mode
    if not re.search(pattern, output, flags=re_flags):
  File "/usr/lib/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
  File "/usr/lib/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.6/sre_parse.py", line 869, in parse
    raise source.error("unbalanced parenthesis")
sre_constants.error: unbalanced parenthesis at position 0
