### PR TITLE
Updated the Slack invitation link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ For all code contributions, please ensure that you have ran `black` against the 
 
 If you find an issue with Netmiko, then you can open an issue on this projects issue page here: [https://github.com/ktbyers/netmiko/issues](https://github.com/ktbyers/netmiko/issues). Please make sure you've read through the common issues and examples prior to opening an issue. Please only open issues for bugs, feature requests, or other topics related to development of Netmiko. If you simply have a question, join us on Slack...
 
-If you have questions or would like to discuss Netmiko, a #netmiko channel exists in [this Slack](https://pynet.slack.com) workspace. To join, use [this invitation](https://join.slack.com/t/pynet/shared_invite/enQtNTA2MDI3NjU0MTM0LTIyZDdhMTBlOWNmNDJhNjkxZTEyMDg3NTRkOWIxMTUwOTAzYmQ0ZjMwMGMyNTM4N2E1YzA3YWQ1MWFiOWM1YzU). Once you have entered the workspace, then you can join the #netmiko channel.
+If you have questions or would like to discuss Netmiko, a #netmiko channel exists in [this Slack](https://pynet.slack.com) workspace. To join, use [this invitation](https://join.slack.com/t/pynet/shared_invite/zt-km2k3upf-AkWHY4YEx3sI1R5irMmc7Q). Once you have entered the workspace, then you can join the #netmiko channel.
 
 
 ---


### PR DESCRIPTION
When visiting the current Slack invitation link you reach a page that displays the message
"This link is no longer active"

This commit updates the Slack invitation link in the README Questions/Discussion section.

https://join.slack.com/t/pynet/shared_invite/zt-km2k3upf-AkWHY4YEx3sI1R5irMmc7Q

Fixes #2122

	modified:   README.md