### PR TITLE
Modify yamaha exit_enable_mode

### DIFF
--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -28,7 +28,8 @@ class YamahaBase(BaseConnection):
             time.sleep(1)
             output = self.read_channel()
             if "(Y/N)" in output:
-                self.write_channel(f"N{self.default_enter}")
+                self.write_channel("N")
+            self.write_channel(self.RETURN)
             output += self.read_until_prompt()
             if self.check_enable_mode():
                 raise ValueError("Failed to exit enable mode.")


### PR DESCRIPTION
When exiting enable mode without changing configuration, the prompt `Save new configuration ? (Y/N)` will not appear.
In this case, the current code stops with the traceback below:

```
Traceback (most recent call last):
  File "send_config_file.py", line 26, in <module>
    output = net_connect.exit_enable_mode()
  File "/home/centos/venv_netmiko3.3.3dev/netmiko/netmiko/yamaha/yamaha.py", line 37, in exit_enable_mode
    output += self.read_until_prompt()
  File "/home/centos/venv_netmiko3.3.3dev/netmiko/netmiko/base_connection.py", line 647, in read_until_prompt
    return self._read_channel_expect(*args, **kwargs)
  File "/home/centos/venv_netmiko3.3.3dev/netmiko/netmiko/base_connection.py", line 592, in _read_channel_expect
    f"Timed-out reading channel, pattern not found in output: {pattern}"
netmiko.ssh_exception.NetmikoTimeoutException: Timed-out reading channel, pattern not found in output: yamaha1
```

By adding return(\n), this error is resolved.