### PR TITLE
Add type hints and fix no_auth channel logic for HP drivers

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -617,12 +617,16 @@ class BaseConnection(object):
             ChannelClass = SSHChannel
         else:
             ChannelClass = ssh_channel_class
+        assert issubclass(ChannelClass, SSHChannel)
+
         self.channel = ChannelClass(
             ssh_params,
             device_type=self.device_type,
             ssh_hostkey_args=self.ssh_hostkey_args,
             encoding=self.encoding,
             session_log=self.session_log,
+            use_keys=self.use_keys,  # needed for making decision to use no_auth
+            password=self.password,  # needed for making decision to use no_auth
         )
         self.channel.establish_connection()
         self.special_login_handler()

--- a/netmiko/channel.py
+++ b/netmiko/channel.py
@@ -300,6 +300,10 @@ class SSHChannel(Channel):
         ssh_hostkey_args: Optional[Dict["str", Any]] = None,
         encoding: str = "ascii",
         session_log: Optional["SessionLog"] = None,
+        use_keys: bool = False,  # needed for making decision to use no_auth in some subclasses
+        password: Optional[
+            str
+        ] = None,  # needed for making decision to use no_auth in some subclasses
     ) -> None:
         self.ssh_params = ssh_params
         self.blocking_timeout = ssh_params.pop("blocking_timeout", 20)
@@ -313,6 +317,8 @@ class SSHChannel(Channel):
         self.remote_conn = None
         self.session_log = session_log
         self.encoding = encoding
+        self.use_keys = use_keys
+        self.password = password
 
     def __repr__(self) -> str:
         return "SSHChannel(ssh_params)"

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -3,14 +3,14 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
 class HPComwareBase(CiscoSSHConnection):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         # Comware doesn't have a way to set terminal width which breaks cmd_verify
         global_cmd_verify = kwargs.get("global_cmd_verify")
         if global_cmd_verify is None:
             kwargs["global_cmd_verify"] = False
         return super().__init__(**kwargs)
 
-    def session_preparation(self):
+    def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
         Extra time to read HP banners.
@@ -34,21 +34,25 @@ class HPComwareBase(CiscoSSHConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def config_mode(self, config_command="system-view"):
+    def config_mode(
+        self, config_command: str = "system-view", pattern: str = "", re_flags: int = 0
+    ) -> str:
         """Enter configuration mode."""
-        return super().config_mode(config_command=config_command)
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
 
-    def exit_config_mode(self, exit_config="return", pattern=r">"):
+    def exit_config_mode(self, exit_config="return", pattern=r">") -> str:
         """Exit config mode."""
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
-    def check_config_mode(self, check_string="]"):
+    def check_config_mode(self, check_string="]", pattern: str = "") -> bool:
         """Check whether device is in configuration mode. Return a boolean."""
-        return super().check_config_mode(check_string=check_string)
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
 
     def set_base_prompt(
         self, pri_prompt_terminator=">", alt_prompt_terminator="]", delay_factor=1
-    ):
+    ) -> str:
         """
         Sets self.base_prompt
 
@@ -71,19 +75,21 @@ class HPComwareBase(CiscoSSHConnection):
         self.base_prompt = prompt
         return self.base_prompt
 
-    def enable(self, cmd="system-view"):
+    def enable(
+        self, cmd: str = "system-view", pattern: str = "", re_flags: int = 0
+    ) -> str:
         """enable mode on Comware is system-view."""
-        return self.config_mode(config_command=cmd)
+        return self.config_mode(config_command=cmd, pattern=pattern, re_flags=re_flags)
 
-    def exit_enable_mode(self, exit_command="return"):
+    def exit_enable_mode(self, exit_command="return") -> str:
         """enable mode on Comware is system-view."""
         return self.exit_config_mode(exit_config=exit_command)
 
-    def check_enable_mode(self, check_string="]"):
+    def check_enable_mode(self, check_string="]") -> bool:
         """enable mode on Comware is system-view."""
         return self.check_config_mode(check_string=check_string)
 
-    def save_config(self, cmd="save force", confirm=False, confirm_response=""):
+    def save_config(self, cmd="save force", confirm=False, confirm_response="") -> str:
         """Save Config."""
         return super().save_config(
             cmd=cmd, confirm=confirm, confirm_response=confirm_response
@@ -95,7 +101,7 @@ class HPComwareSSH(HPComwareBase):
 
 
 class HPComwareTelnet(HPComwareBase):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         default_enter = kwargs.get("default_enter")
         kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
         super().__init__(*args, **kwargs)

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -46,7 +46,7 @@ class HPComwareBase(CiscoSSHConnection):
         """Exit config mode."""
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
-    def check_config_mode(self, check_string="]", pattern: str = "") -> bool:
+    def check_config_mode(self, check_string="]", pattern: str = "]") -> bool:
         """Check whether device is in configuration mode. Return a boolean."""
         return super().check_config_mode(check_string=check_string, pattern=pattern)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ pylama==7.7.1
 twine==1.13.0
 pysnmp==4.4.12
 pdoc3==0.6.3
+transitions==0.8.6
 -r requirements.txt
 -r requirements-ttp.txt


### PR DESCRIPTION
~needs~ needed some bugfixing because of this:
```
hp\hp_procurve.py:16: error: "HPProcurveSSHChannel" has no attribute "use_keys"
hp\hp_procurve.py:16: error: "HPProcurveSSHChannel" has no attribute "password"
```
```python
class HPProcurveSSHChannel(SSHChannel):
    def _build_ssh_client(self, no_auth=True) -> paramiko.SSHClient:
        """Allow passwordless authentication for HP devices being provisioned."""
        if not self.use_keys and not self.password:
            return super()._build_ssh_client(no_auth=no_auth)
        else:
            return super()._build_ssh_client(no_auth=False)

```

~that'll come in a following commit~
fixed