### PR TITLE
Update f5_tmsh_ssh.py

### DIFF
--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -34,10 +34,14 @@ class F5TmshSSH(BaseConnection):
 
 
     def config_mode(self, config_command=""):
-        """No config mode for F5 devices."""
+        """
+        No config mode for F5 devices.
+        """
         return ""
                                               
     def exit_config_mode(self, exit_config=""):
-        """No config mode for F5 devices."""
+        """
+        No config mode for F5 devices.
+        """
         return ""
 

--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -34,7 +34,7 @@ class F5TmshSSH(BaseConnection):
 
 
     def config_mode(self, config_command=""):
-        "No config mode for F5 devices."""
+        """No config mode for F5 devices."""
         return ""
                                               
     def exit_config_mode(self, exit_config=""):

--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -35,13 +35,13 @@ class F5TmshSSH(BaseConnection):
 
     def config_mode(self, config_command=""):
         """
-        No config mode for F5 devices.
+        #No config mode for F5 devices.
         """
         return ""
                                               
     def exit_config_mode(self, exit_config=""):
         """
-        No config mode for F5 devices.
+        #No config mode for F5 devices.
         """
         return ""
 

--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -25,23 +25,15 @@ class F5TmshSSH(BaseConnection):
         time.sleep(1 * delay_factor)
         self.clear_buffer()
         return None
-    
+
     def check_config_mode(self, check_string=") #", pattern=""):
-        """
-        #Checks if the device is in configuration mode or not.
-        """
+        """Checks if the device is in configuration mode or not."""
         return super().check_config_mode(check_string=check_string, pattern=pattern)
 
-
     def config_mode(self, config_command=""):
-        """
-        #No config mode for F5 devices.
-        """
-        return ""
-                                              
-    def exit_config_mode(self, exit_config=""):
-        """
-        #No config mode for F5 devices.
-        """
+        """No config mode for F5 devices."""
         return ""
 
+    def exit_config_mode(self, exit_config=""):
+        """No config mode for F5 devices."""
+        return ""

--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -25,3 +25,19 @@ class F5TmshSSH(BaseConnection):
         time.sleep(1 * delay_factor)
         self.clear_buffer()
         return None
+    
+    def check_config_mode(self, check_string=") #", pattern=""):
+        """
+        #Checks if the device is in configuration mode or not.
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+
+    def config_mode(self, config_command=""):
+        "No config mode for F5 devices."""
+        return ""
+                                              
+    def exit_config_mode(self, exit_config=""):
+        """No config mode for F5 devices."""
+        return ""
+


### PR DESCRIPTION
Extract from F5 Website (https://support.f5.com/csp/article/K12029):
```
Users can enter tmsh in two ways:

If you are granted Advanced shell (bash) access, you must type tmsh in to the command line after logging in to the BIG-IP system.
If you are granted tmsh access, you enter tmsh directly when logging in to the BIG-IP system.


```


Starting tests...good luck:
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/trasmontinho/tests_f5/tests
collected 22 items                                                                                                                                                                                                   

test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                               [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                               [  9%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                                  [ 13%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                               [ 18%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                          [ 22%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED                                                                                                                                            [ 27%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                                 [ 31%]
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED                                                                                                                                                   [ 36%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                                                                                                                         [ 40%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                                                                                                               [ 45%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                                  [ 50%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                                                                 [ 54%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                                                              [ 59%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                                                                   [ 63%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                                  [ 68%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                                 [ 72%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                                [ 77%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                          [ 81%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                                 [ 86%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                                  [ 90%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                                   [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                                                                                                         [100%]

====================================================================================== 18 passed, 4 skipped in 64.90s (0:01:04) ======================================================================================
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/trasmontinho/tests_f5/tests
collected 9 items                                                                                                                                                                                                    

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                                [ 11%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                                [ 22%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                                [ 33%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                           [ 44%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                                 [ 55%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                                     [ 66%]
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                                                            [ 77%]
test_netmiko_config.py::test_config_from_file PASSED                                                                                                                                                           [ 88%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                                 [100%]

================================================================================================= 9 passed in 14.49s =================================================================================================