### PR TITLE
Added Palo Alto auto detection entry in SSH_MAPPER_BASE

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -212,6 +212,12 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "paloalto_panos": {
+        "cmd": "show system info",
+        "search_patterns": [r"model:\s+PA"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
 }
 
 # Sort SSH_MAPPER_BASE such that the most common commands are first


### PR DESCRIPTION
See: https://github.com/ktbyers/netmiko/issues/1904

This change updates the auto detection module so that it can properly detect Palo Alto devices.

I have tested this on several PA devices, including both virtual and physical and the logic is valid for all.