### PR TITLE
Fix ASA enable() issue in session_preparation

### DIFF
--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -14,23 +14,11 @@ class CiscoAsaSSH(CiscoSSHConnection):
         kwargs.setdefault("allow_auto_change", True)
         return super().__init__(*args, **kwargs)
 
-    def check_config_mode(self, check_string=")#", pattern=r"[>\#]"):
-        return super().check_config_mode(check_string=check_string, pattern=pattern)
-
-    def enable(
-        self,
-        cmd="enable",
-        pattern="ssword",
-        enable_pattern=r"\#",
-        re_flags=re.IGNORECASE,
-    ):
-        return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
-        )
-
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
 
+        # The 'enable' call requires the base_prompt to be set.
+        self.set_base_prompt()
         if self.secret:
             self.enable()
         else:
@@ -48,6 +36,20 @@ class CiscoAsaSSH(CiscoSSHConnection):
             self.global_cmd_verify = False
 
         self.set_base_prompt()
+
+    def check_config_mode(self, check_string=")#", pattern=r"[>\#]"):
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def enable(
+        self,
+        cmd="enable",
+        pattern="ssword",
+        enable_pattern=r"\#",
+        re_flags=re.IGNORECASE,
+    ):
+        return super().enable(
+            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+        )
 
     def send_command_timing(self, *args, **kwargs):
         """

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -17,6 +17,11 @@ class CiscoAsaSSH(CiscoSSHConnection):
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
 
+        # Make sure the ASA is ready
+        command = "show curpriv\n"
+        self.write_channel(command)
+        self.read_until_pattern(pattern=re.escape(command.strip()))
+
         # The 'enable' call requires the base_prompt to be set.
         self.set_base_prompt()
         if self.secret:


### PR DESCRIPTION
In cases where end-users were already in enable-mode, session_preparation would incorrectly believe you were not in enable mode (in other words check_enable_mode() would fail due to the base_prompt not being set).

This would generate an exception for the end-user.