### PR TITLE
fix fortigate autodetect

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -208,7 +208,7 @@ SSH_MAPPER_BASE = {
     },
     "fortinet": {
         "cmd": "get system status",
-        "search_patterns": [r"FortiOS"],
+        "search_patterns": [r"FortiOS", r"FortiGate"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Hi,

Tested with FortiGate firewalls running FortiOS 6.2.4 and 7.0 beta2 and "FortiOS" does not match, added "FortiGate" which does match.

Example output...

```
FGT1 # get system status
Version: FortiGate-30E v6.2.4,build1112,200511 (GA)
Virus-DB: 84.00912(2021-03-23 02:20)
Extended DB: 84.00912(2021-03-23 02:20)
...
```

Now matches are reports "fortinet" as device type.
