### PR TITLE
Add Mixin Classes for #2188

### DIFF
--- a/netmiko/alcatel/alcatel_aos_ssh.py
+++ b/netmiko/alcatel/alcatel_aos_ssh.py
@@ -1,9 +1,11 @@
 """Alcatel-Lucent Enterprise AOS support (AOS6 and AOS8)."""
 import time
+
+from netmiko.base_connection import NoConfigMixin, NoEnableMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class AlcatelAosSSH(CiscoSSHConnection):
+class AlcatelAosSSH(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):
     """Alcatel-Lucent Enterprise AOS support (AOS6 and AOS8)."""
 
     def session_preparation(self):
@@ -13,30 +15,6 @@ class AlcatelAosSSH(CiscoSSHConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-
-    def check_enable_mode(self, *args, **kwargs):
-        """No enable mode on AOS"""
-        pass
-
-    def enable(self, *args, **kwargs):
-        """No enable mode on AOS"""
-        pass
-
-    def exit_enable_mode(self, *args, **kwargs):
-        """No enable mode on AOS"""
-        pass
-
-    def check_config_mode(self, *args, **kwargs):
-        """No config mode on AOS"""
-        pass
-
-    def config_mode(self, *args, **kwargs):
-        """No config mode on AOS"""
-        return ""
-
-    def exit_config_mode(self, *args, **kwargs):
-        """No config mode on AOS"""
-        return ""
 
     def save_config(
         self, cmd="write memory flash-synchro", confirm=False, confirm_response=""

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1947,7 +1947,8 @@ class TelnetConnection(BaseConnection):
 
 
 class NoConfigMixin:
-    """Mixin class for devices with no 'config' mode (because they allow config changes by default)"""
+    """Mixin class for devices with no 'config' mode
+    (because they allow config changes by default)"""
 
     def check_config_mode(self, check_string: str = "", pattern: str = "") -> bool:
         return True
@@ -1962,7 +1963,8 @@ class NoConfigMixin:
 
 
 class NoEnableMixin:
-    """Mixin class for devices with no 'enable' mode (because they allow privileged access by default)"""
+    """Mixin class for devices with no 'enable' mode
+    (because they allow privileged access by default)"""
 
     def check_enable_mode(self, check_string: str = "") -> bool:
         return True
@@ -1978,8 +1980,8 @@ class NoEnableMixin:
 
 class NoChangesMixin:
     """Mixin class for devices that cannot apply any config changes via CLI.
-    Indicates `False` for enable and config mode checks, and raises NotImplementedError if you attempt to enter those
-    modes."""
+    Indicates `False` for enable and config mode checks, and raises NotImplementedError
+    if you attempt to enter those modes."""
 
     def check_enable_mode(self, check_string: str = "") -> bool:
         return False

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1944,3 +1944,50 @@ class BaseConnection(object):
 
 class TelnetConnection(BaseConnection):
     pass
+
+
+class NoConfigMixin:
+    """Mixin class for devices with no 'config' mode (because they allow config changes by default)"""
+
+    def check_config_mode(self, check_string: str = "", pattern: str = "") -> bool:
+        return True
+
+    def config_mode(
+        self, config_command: str = "", pattern: str = "", re_flags: int = 0
+    ) -> str:
+        return ""
+
+    def exit_config_mode(self, exit_config: str = "", pattern: str = "") -> str:
+        return ""
+
+
+class NoEnableMixin:
+    """Mixin class for devices with no 'enable' mode (because they allow privileged access by default)"""
+
+    def check_enable_mode(self, check_string: str = "") -> bool:
+        return True
+
+    def enable(
+        self, cmd: str = "", pattern: str = "ssword", re_flags: int = re.IGNORECASE
+    ) -> str:
+        return ""
+
+    def exit_enable_mode(self, exit_command: str = "") -> str:
+        return ""
+
+
+class NoChangesMixin:
+    """Mixin class for devices that cannot apply any config changes via CLI.
+    Indicates `False` for enable and config mode checks, and raises NotImplementedError if you attempt to enter those
+    modes."""
+
+    def check_enable_mode(self, check_string: str = "") -> bool:
+        return False
+
+    def enable(
+        self, cmd: str = "", pattern: str = "ssword", re_flags: int = re.IGNORECASE
+    ) -> str:
+        raise NotImplementedError
+
+    def exit_enable_mode(self, exit_command: str = "") -> str:
+        return ""

--- a/netmiko/ciena/ciena_saos.py
+++ b/netmiko/ciena/ciena_saos.py
@@ -2,11 +2,11 @@
 import time
 import re
 import os
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoConfigMixin, NoEnableMixin
 from netmiko.scp_handler import BaseFileTransfer
 
 
-class CienaSaosBase(BaseConnection):
+class CienaSaosBase(NoEnableMixin, NoConfigMixin, BaseConnection):
     """
     Ciena SAOS support.
 
@@ -35,30 +35,6 @@ class CienaSaosBase(BaseConnection):
     def _return_cli(self):
         """Return to the Ciena SAOS CLI."""
         return self.send_command("exit", expect_string=r"[>]")
-
-    def check_enable_mode(self, *args, **kwargs):
-        """No enable mode on Ciena SAOS."""
-        return True
-
-    def enable(self, *args, **kwargs):
-        """No enable mode on Ciena SAOS."""
-        return ""
-
-    def exit_enable_mode(self, *args, **kwargs):
-        """No enable mode on Ciena SAOS."""
-        return ""
-
-    def check_config_mode(self, check_string=">", pattern=""):
-        """No config mode on Ciena SAOS."""
-        return False
-
-    def config_mode(self, config_command=""):
-        """No config mode on Ciena SAOS."""
-        return ""
-
-    def exit_config_mode(self, exit_config=""):
-        """No config mode on Ciena SAOS."""
-        return ""
 
     def save_config(self, cmd="configuration save", confirm=False, confirm_response=""):
         """Saves Config."""

--- a/netmiko/cisco/cisco_ftd_ssh.py
+++ b/netmiko/cisco/cisco_ftd_ssh.py
@@ -1,27 +1,12 @@
 """Subclass specific to Cisco FTD."""
+from netmiko.base_connection import NoChangesMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class CiscoFtdSSH(CiscoSSHConnection):
+class CiscoFtdSSH(NoChangesMixin, CiscoSSHConnection):
     """Subclass specific to Cisco FTD."""
 
     def session_preparation(self):
         """Prepare the session after the connection has been established."""
         self._test_channel_read()
         self.set_base_prompt()
-
-    def send_config_set(self, *args, **kwargs):
-        """Canot change config on FTD via ssh"""
-        raise NotImplementedError
-
-    def enable(self, *args, **kwargs):
-        """No enable mode on firepower ssh"""
-        return ""
-
-    def config_mode(self, *args, **kwargs):
-        """No config mode on firepower ssh"""
-        return ""
-
-    def check_config_mode(self, *args, **kwargs):
-        """No config mode on firepower ssh"""
-        return False

--- a/netmiko/dell/dell_isilon_ssh.py
+++ b/netmiko/dell/dell_isilon_ssh.py
@@ -1,10 +1,10 @@
 import time
 import re
 
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoEnableMixin
 
 
-class DellIsilonSSH(BaseConnection):
+class DellIsilonSSH(NoEnableMixin, BaseConnection):
     def set_base_prompt(
         self, pri_prompt_terminator="$", alt_prompt_terminator="#", delay_factor=1
     ):
@@ -49,18 +49,6 @@ class DellIsilonSSH(BaseConnection):
         """Isilon doesn't have paging by default."""
         pass
 
-    def check_enable_mode(self, *args, **kwargs):
-        """No enable mode on Isilon."""
-        pass
-
-    def enable(self, *args, **kwargs):
-        """No enable mode on Isilon."""
-        pass
-
-    def exit_enable_mode(self, *args, **kwargs):
-        """No enable mode on Isilon."""
-        pass
-
     def check_config_mode(self, check_string="#"):
         return super().check_config_mode(check_string=check_string)
 
@@ -82,5 +70,5 @@ class DellIsilonSSH(BaseConnection):
         return output
 
     def exit_config_mode(self, exit_config="exit"):
-        """Exit enable mode."""
+        """Exit config mode."""
         return super().exit_config_mode(exit_config=exit_config)

--- a/netmiko/dlink/dlink_ds.py
+++ b/netmiko/dlink/dlink_ds.py
@@ -1,9 +1,11 @@
 import time
 from typing import Any, Optional
+
+from netmiko.base_connection import NoConfigMixin, NoEnableMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class DlinkDSBase(CiscoSSHConnection):
+class DlinkDSBase(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):
     """Supports D-Link DGS/DES device series (there are some DGS/DES devices that are web-only)"""
 
     def session_preparation(self) -> None:
@@ -29,30 +31,6 @@ class DlinkDSBase(CiscoSSHConnection):
             cmd_verify=cmd_verify,
             pattern=pattern,
         )
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No implemented enable mode on D-Link yet"""
-        return ""
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No implemented enable mode on D-Link yet"""
-        return True
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No implemented enable mode on D-Link yet"""
-        return ""
-
-    def check_config_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No config mode on D-Link"""
-        return True
-
-    def config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No config mode on D-Link"""
-        return ""
-
-    def exit_config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No config mode on D-Link"""
-        return ""
 
     def save_config(
         self, cmd: str = "save", confirm: bool = False, confirm_response: str = ""

--- a/netmiko/flexvnf/flexvnf_ssh.py
+++ b/netmiko/flexvnf/flexvnf_ssh.py
@@ -2,10 +2,10 @@ import re
 import time
 from typing import Optional
 
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoEnableMixin
 
 
-class FlexvnfSSH(BaseConnection):
+class FlexvnfSSH(NoEnableMixin, BaseConnection):
     def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
@@ -41,18 +41,6 @@ class FlexvnfSSH(BaseConnection):
             elif ">" in cur_prompt or "%" in cur_prompt:
                 break
             count += 1
-
-    def check_enable_mode(self, *args, **kwargs) -> bool:
-        """No enable mode on flexvnf."""
-        return False
-
-    def enable(self, *args, **kwargs) -> str:
-        """No enable mode on flexvnf."""
-        return ""
-
-    def exit_enable_mode(self, *args, **kwargs) -> str:
-        """No enable mode on flexvnf."""
-        return ""
 
     def check_config_mode(self, check_string: str = "]", *args, **kwargs) -> bool:
         """Checks if the device is in configuration mode or not."""

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -1,10 +1,12 @@
 import paramiko
 import time
 import re
+
+from netmiko.base_connection import NoConfigMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class FortinetSSH(CiscoSSHConnection):
+class FortinetSSH(NoConfigMixin, CiscoSSHConnection):
     # FIX: Probably should move to channel.py
     def _modify_connection_params(self) -> None:
         """Modify connection parameters prior to SSH connection."""
@@ -103,16 +105,6 @@ class FortinetSSH(CiscoSSHConnection):
             for command in enable_paging_commands:
                 self.send_command_timing(command)
         return super().cleanup(command=command)
-
-    def config_mode(
-        self, config_command: str = "", pattern: str = "", re_flags: int = 0
-    ) -> str:
-        """No config mode for Fortinet devices."""
-        return ""
-
-    def exit_config_mode(self, exit_config: str = "", pattern: str = "") -> str:
-        """No config mode for Fortinet devices."""
-        return ""
 
     def save_config(self, *args, **kwargs) -> str:
         """Not Implemented"""

--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -2,6 +2,8 @@ from typing import Any
 from typing import TYPE_CHECKING
 import time
 import re
+
+from netmiko.base_connection import NoEnableMixin
 from netmiko.cisco_base_connection import CiscoBaseConnection
 from netmiko.ssh_exception import NetmikoAuthenticationException
 from netmiko import log
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
     from telnetlib import Telnet
 
 
-class HuaweiBase(CiscoBaseConnection):
+class HuaweiBase(NoEnableMixin, CiscoBaseConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
         self.ansi_escape_codes = True
@@ -51,18 +53,6 @@ class HuaweiBase(CiscoBaseConnection):
     def check_config_mode(self, check_string: str = "]", pattern: str = "") -> bool:
         """Checks whether in configuration mode. Returns a boolean."""
         return super().check_config_mode(check_string=check_string, pattern=pattern)
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """Huawei has no enable mode."""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """Huawei has no enable mode."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """Huawei has no enable mode."""
-        return ""
 
     def set_base_prompt(
         self,

--- a/netmiko/juniper/juniper.py
+++ b/netmiko/juniper/juniper.py
@@ -2,11 +2,11 @@ from typing import Any, Optional, Union, Iterable
 import re
 import time
 
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoEnableMixin
 from netmiko.scp_handler import BaseFileTransfer
 
 
-class JuniperBase(BaseConnection):
+class JuniperBase(NoEnableMixin, BaseConnection):
     """
     Implement methods for interacting with Juniper Networks devices.
 
@@ -64,18 +64,6 @@ class JuniperBase(BaseConnection):
             elif ">" in cur_prompt or "#" in cur_prompt:
                 break
             count += 1
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on Juniper."""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on Juniper."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on Juniper."""
-        return ""
 
     def check_config_mode(self, check_string: str = "]", pattern: str = "") -> bool:
         """Checks if the device is in configuration mode or not."""

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -1,9 +1,9 @@
 from typing import Any
 import time
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoConfigMixin, NoEnableMixin
 
 
-class JuniperScreenOsSSH(BaseConnection):
+class JuniperScreenOsSSH(NoEnableMixin, NoConfigMixin, BaseConnection):
     """
     Implement methods for interacting with Juniper ScreenOS devices.
     """
@@ -21,30 +21,6 @@ class JuniperScreenOsSSH(BaseConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on Juniper ScreenOS."""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on Juniper ScreenOS."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on Juniper ScreenOS."""
-        return ""
-
-    def check_config_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No configuration mode on Juniper ScreenOS."""
-        return True
-
-    def config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No configuration mode on Juniper ScreenOS."""
-        return ""
-
-    def exit_config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No configuration mode on Juniper ScreenOS."""
-        return ""
 
     def save_config(
         self,

--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -1,4 +1,3 @@
-from typing import Any
 import time
 from netmiko.base_connection import BaseConnection, NoConfigMixin, NoEnableMixin
 

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,17 +1,17 @@
 from typing import Any
+
+from netmiko.base_connection import NoEnableMixin, NoConfigMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class MikrotikBase(CiscoSSHConnection):
+class MikrotikBase(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):
     """Common Methods for Mikrotik RouterOS and SwitchOS"""
 
     def __init__(self, **kwargs: Any) -> None:
         if kwargs.get("default_enter") is None:
             kwargs["default_enter"] = "\r\n"
 
-        self._in_config_mode = False
-
-        return super().__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
@@ -35,35 +35,9 @@ class MikrotikBase(CiscoSSHConnection):
         """Microtik does not have paging by default."""
         return ""
 
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on RouterOS"""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on RouterOS."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on RouterOS."""
-        return ""
-
     def save_config(self, *args: Any, **kwargs: Any) -> str:
         """No save command, all configuration is atomic"""
         pass
-
-    def config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No configuration mode on Microtik"""
-        self._in_config_mode = True
-        return ""
-
-    def check_config_mode(self, check_string: str = "", pattern: str = "") -> bool:
-        """Checks whether in configuration mode. Returns a boolean."""
-        return self._in_config_mode
-
-    def exit_config_mode(self, exit_config: str = ">", pattern: str = "") -> str:
-        """No configuration mode on Microtik"""
-        self._in_config_mode = False
-        return ""
 
     def strip_prompt(self, a_string: str) -> str:
         """Strip the trailing router prompt from the output.

--- a/netmiko/netapp/netapp_cdot_ssh.py
+++ b/netmiko/netapp/netapp_cdot_ssh.py
@@ -1,8 +1,8 @@
 from typing import Any
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoEnableMixin
 
 
-class NetAppcDotSSH(BaseConnection):
+class NetAppcDotSSH(NoEnableMixin, BaseConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
         self.set_base_prompt()
@@ -37,15 +37,3 @@ class NetAppcDotSSH(BaseConnection):
         pattern: str = "",
     ) -> str:
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on NetApp."""
-        return ""
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on NetApp."""
-        return True
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on NetApp."""
-        return ""

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional
 import time
 import re
-from netmiko.base_connection import BaseConnection
+from netmiko.base_connection import BaseConnection, NoEnableMixin
 
 
-class PaloAltoPanosBase(BaseConnection):
+class PaloAltoPanosBase(NoEnableMixin, BaseConnection):
     """
     Implement methods for interacting with PaloAlto devices.
 
@@ -25,18 +25,6 @@ class PaloAltoPanosBase(BaseConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on PaloAlto."""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on PaloAlto."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on PaloAlto."""
-        return ""
 
     def check_config_mode(self, check_string: str = "]", pattern: str = "") -> bool:
         """Checks if the device is in configuration mode or not."""

--- a/netmiko/sixwind/sixwind_os.py
+++ b/netmiko/sixwind/sixwind_os.py
@@ -1,9 +1,11 @@
 from typing import Any
 import time
+
+from netmiko.base_connection import NoEnableMixin
 from netmiko.cisco_base_connection import CiscoBaseConnection
 
 
-class SixwindOSBase(CiscoBaseConnection):
+class SixwindOSBase(NoEnableMixin, CiscoBaseConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
         self.ansi_escape_codes = True
@@ -90,21 +92,6 @@ class SixwindOSBase(CiscoBaseConnection):
         return super().save_config(
             cmd=cmd, confirm=confirm, confirm_response=confirm_response
         )
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """6WIND has no enable mode."""
-
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """6WIND has no enable mode."""
-
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """6WIND has no enable mode."""
-
-        return ""
 
 
 class SixwindOSSSH(SixwindOSBase):

--- a/netmiko/sophos/sophos_sfos_ssh.py
+++ b/netmiko/sophos/sophos_sfos_ssh.py
@@ -1,10 +1,12 @@
 """SophosXG (SFOS) Firewall support"""
 from typing import Any
 import time
+
+from netmiko.base_connection import NoEnableMixin, NoConfigMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class SophosSfosSSH(CiscoSSHConnection):
+class SophosSfosSSH(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
         self._test_channel_read()
@@ -30,30 +32,6 @@ class SophosSfosSSH(CiscoSSHConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on SFOS"""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on SFOS"""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on SFOS"""
-        return ""
-
-    def check_config_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No config mode on SFOS"""
-        return False
-
-    def config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No config mode on SFOS"""
-        return ""
-
-    def exit_config_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No config mode on SFOS"""
-        return ""
 
     def save_config(self, *args: Any, **kwargs: Any) -> str:
         """Not Implemented"""

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -1,10 +1,12 @@
 from typing import Any, Union, Iterable
 import time
 import io
+
+from netmiko.base_connection import NoEnableMixin
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class VyOSSSH(CiscoSSHConnection):
+class VyOSSSH(NoEnableMixin, CiscoSSHConnection):
     """Implement methods for interacting with VyOS network devices."""
 
     def session_preparation(self) -> None:
@@ -16,18 +18,6 @@ class VyOSSSH(CiscoSSHConnection):
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
-
-    def check_enable_mode(self, *args: Any, **kwargs: Any) -> bool:
-        """No enable mode on VyOS."""
-        return True
-
-    def enable(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on VyOS."""
-        return ""
-
-    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
-        """No enable mode on VyOS."""
-        return ""
 
     def check_config_mode(self, check_string: str = "#", pattern: str = "") -> bool:
         """Checks if the device is in configuration mode"""


### PR DESCRIPTION
mixin classes described in #2188  

The more I thought about it, the more this approach made sense to me, so I tossed together an implementation.  

In addition to reducing boilerplate code required for various drivers, it would also enforce consistency in the API.  Some existing drivers were explicitly violating guidance from #2188, etc.  This brings them into line with *my understanding of their behavior*.  

Some amount of domain knowledge (or guesswork) are required to distinguish device types that disallow config changes or privileged commands vs. those that permit the same without any explicit enable or config modes.  For clarity, here's the drivers I identified as belonging to each bucket:


# Enable: no; Config: no; Changes: no
class CiscoFtdSSH(NoChangesMixin, CiscoSSHConnection):


# Enable: no; Config: no; Changes: yes
class AlcatelAosSSH(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):

class CienaSaosBase(NoEnableMixin, NoConfigMixin, BaseConnection):

class DlinkDSBase(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):

class JuniperScreenOsSSH(NoEnableMixin, NoConfigMixin, BaseConnection):

class MikrotikBase(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):

class SophosSfosSSH(NoEnableMixin, NoConfigMixin, CiscoSSHConnection):


# Enable: yes; Config: no; Changes: yes
class FortinetSSH(NoConfigMixin, CiscoSSHConnection):



# Enable: no; Config: yes; Changes: yes
class DellIsilonSSH(NoEnableMixin, BaseConnection):

class FlexvnfSSH(NoEnableMixin, BaseConnection):

class HuaweiBase(NoEnableMixin, CiscoBaseConnection):

class JuniperBase(NoEnableMixin, BaseConnection):

class VyOSSSH(NoEnableMixin, CiscoSSHConnection):


```python
class NoConfigMixin:
    """Mixin class for devices with no 'config' mode (because they allow config changes by default)"""

class NoEnableMixin:
    """Mixin class for devices with no 'enable' mode (because they allow privileged access by default)"""

class NoChangesMixin:
    """Mixin class for devices that cannot apply any config changes via CLI.
    Indicates `False` for enable and config mode checks, and raises NotImplementedError if you attempt to enter those
    modes."""
```