### PR TITLE
Add run_ttp method to base connection

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -31,6 +31,7 @@ from netmiko.utilities import (
     get_structured_data,
     get_structured_data_genie,
     get_structured_data_ttp,
+    run_ttp_template,
     select_cmd_verify,
 )
 from netmiko.utilities import m_exec_time  # noqa
@@ -2039,6 +2040,41 @@ Device settings: {self.device_type} {self.host}:{self.port}
         if self.session_log is not None and self._session_log_close:
             self.session_log.close()
             self.session_log = None
+
+    def run_ttp(self, template, res_kwargs={}, **kwargs):
+        """
+        Run TTP template parsing by using input parameters to collect
+        devices output.
+
+        :param template: template content, OS path to template or reference
+            to template within TTP templates collection in
+            ttp://path/to/template.txt format
+        :type template: str
+
+        :param res_kwargs: ``**res_kwargs`` arguments to pass to TTP result method
+        :type res_kwargs: dict
+
+        :param kwargs: any other ``**kwargs`` to use for TTP object instantiation
+        :type kwargs: dict
+
+        TTP template must have inputs defined together with below parameters.
+
+        :param method: name of Netmiko connection object method to call, default ``send_command``
+        :type method: str
+
+        :param kwargs: Netmiko connection object method arguments
+        :type kwargs: dict
+
+        :param commands: list of commands to collect
+        :type commands: list
+
+        Inputs' load could be of one of the supported formats and controlled by input's ``load``
+        attribute, supported values - python, yaml or json. For each input output collected
+        from device and parsed accordingly.
+        """
+        return run_ttp_template(
+            connection=self, template=template, res_kwargs=res_kwargs, **kwargs
+        )
 
 
 class TelnetConnection(BaseConnection):

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -408,9 +408,9 @@ def run_ttp_template(connection, template, res_kwargs, **kwargs):
             commands = input_params.get("commands", None)
 
             # run sanity checks
-            if not method in dir(connection):
+            if method not in dir(connection):
                 log.warning(
-                    "run_ttp_template: '{}' input referencing unsupported Netmiko connection method '{}', skipping".format(
+                    "run_ttp_template: '{}' input, unsupported method '{}', skipping".format(
                         input_name, method
                     )
                 )

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -414,12 +414,14 @@ def run_ttp_template(connection, template, res_kwargs, **kwargs):
                         input_name, method
                     )
                 )
+                continue
             elif not commands:
                 log.warning(
                     "run_ttp_template: '{}' input no commands to collect, skipping".format(
                         input_name
                     )
                 )
+                continue
 
             # collect commands output from device
             output = [

--- a/tests/test_ttp_run_template.py
+++ b/tests/test_ttp_run_template.py
@@ -3,10 +3,10 @@ import pytest
 
 sys.path.insert(0, "..")  # need it to run "python test_ttp_run_template.py"
 
-from netmiko import ConnectHandler # noqa
+from netmiko import ConnectHandler  # noqa
 
 try:
-    from ttp import ttp # noqa
+    from ttp import ttp  # noqa
 
     TTP_INSTALLED = True
 
@@ -14,7 +14,7 @@ except ImportError:
     TTP_INSTALLED = False
 
 try:
-    from ttp_templates import get_template # noqa
+    from ttp_templates import get_template  # noqa
 
     TTP_TEMPLATES_INSTALLED = True
 

--- a/tests/test_ttp_run_template.py
+++ b/tests/test_ttp_run_template.py
@@ -1,13 +1,12 @@
 import sys
-
-sys.path.insert(0, "..")  # need it to run "python test_ttp_run_template.py"
-import pprint
 import pytest
 
-from netmiko import ConnectHandler
+sys.path.insert(0, "..")  # need it to run "python test_ttp_run_template.py"
+
+from netmiko import ConnectHandler # noqa
 
 try:
-    from ttp import ttp
+    from ttp import ttp # noqa
 
     TTP_INSTALLED = True
 
@@ -15,7 +14,7 @@ except ImportError:
     TTP_INSTALLED = False
 
 try:
-    from ttp_templates import get_template
+    from ttp_templates import get_template # noqa
 
     TTP_TEMPLATES_INSTALLED = True
 
@@ -23,10 +22,10 @@ except ImportError:
     TTP_TEMPLATES_INSTALLED = False
 
 skip_if_no_ttp = pytest.mark.skipif(
-    TTP_INSTALLED == False, reason="Failed to import TTP module"
+    TTP_INSTALLED is False, reason="Failed to import TTP module"
 )
 skip_if_no_ttp_templates = pytest.mark.skipif(
-    TTP_TEMPLATES_INSTALLED == False, reason="Failed to import TTP templates module"
+    TTP_TEMPLATES_INSTALLED is False, reason="Failed to import TTP templates module"
 )
 
 lab = {
@@ -46,7 +45,7 @@ ntp server 8.8.8.8
 ntp server 7.7.7.8
 ntp server 1.1.1.2
 ntp server 3.3.3.3
-ntp server 7.7.7.7        
+ntp server 7.7.7.7
         """,
         "show run | inc aaa": """
 aaa new-model
@@ -111,7 +110,7 @@ commands:
   - show run | inc ntp
   - show run | inc aaa
 </input>
-    
+
 <input name="interfaces_cfg">
 commands = [
     "show run | sec interface"
@@ -201,7 +200,7 @@ commands:
   - show run | inc ntp
   - show run | inc aaa
 </input>
-    
+
 <input name="interfaces_cfg">
 commands = [
     "show run | sec interface"
@@ -536,7 +535,7 @@ commmmmands:
   - show run | inc ntp
   - show run | inc aaa
 </input>
-    
+
 <input name="interfaces_cfg">
 method = "does_not_exist"
 commands = [

--- a/tests/test_ttp_run_template.py
+++ b/tests/test_ttp_run_template.py
@@ -1,6 +1,6 @@
 import sys
 
-sys.path.insert(0, "..") # need it to run "python test_ttp_run_template.py"
+sys.path.insert(0, "..")  # need it to run "python test_ttp_run_template.py"
 import pprint
 import pytest
 

--- a/tests/test_ttp_run_template.py
+++ b/tests/test_ttp_run_template.py
@@ -1,0 +1,524 @@
+import sys
+
+sys.path.insert(0, "./netmiko/")
+import pprint
+import pytest
+
+from netmiko import ConnectHandler
+
+try:
+    from ttp import ttp
+
+    TTP_INSTALLED = True
+
+except ImportError:
+    TTP_INSTALLED = False
+
+try:
+    from ttp_templates import get_template
+
+    TTP_TEMPLATES_INSTALLED = True
+
+except ImportError:
+    TTP_TEMPLATES_INSTALLED = False
+
+skip_if_no_ttp = pytest.mark.skipif(
+    TTP_INSTALLED == False, reason="Failed to import TTP module"
+)
+skip_if_no_ttp_templates = pytest.mark.skipif(
+    TTP_TEMPLATES_INSTALLED == False, reason="Failed to import TTP templates module"
+)
+
+lab = {
+    "device_type": "cisco_ios",
+    "host": "1.2.3.4",
+    "username": "cisco",
+    "password": "cisco",
+    "auto_connect": False,  # stop Netmiko trying connect to device
+}
+
+
+@skip_if_no_ttp
+def mock_output(command_string, *args, **kwargs):
+    outputs = {
+        "show run | inc ntp": """
+ntp server 8.8.8.8
+ntp server 7.7.7.8
+ntp server 1.1.1.2
+ntp server 3.3.3.3
+ntp server 7.7.7.7        
+        """,
+        "show run | inc aaa": """
+aaa new-model
+aaa authentication login default local
+aaa authorization exec default local
+aaa session-id common
+        """,
+        "show run | sec interface": """
+interface Loopback0
+ description Routing Loopback
+ ip address 10.0.0.10 255.255.255.255
+ ip ospf 1 area 0
+ ipv6 address 2001::10/128
+interface Loopback100
+ ip address 1.1.1.100 255.255.255.255
+interface Ethernet0/0
+ description Main Interface for L3 features testing
+ no ip address
+ duplex auto
+interface Ethernet0/0.102
+ description to_vIOS1_Gi0/0.102
+ encapsulation dot1Q 102
+ ip address 10.1.102.10 255.255.255.0
+ ipv6 address 2001:102::10/64
+interface Ethernet0/0.107
+ description to_IOL2_Eth0/0.107
+ encapsulation dot1Q 107
+ ip address 10.1.107.10 255.255.255.0
+ ip ospf network point-to-point
+ ip ospf 1 area 0
+ ipv6 address 2001:107::10/64
+interface Ethernet0/0.2000
+ encapsulation dot1Q 2000
+ vrf forwarding MGMT
+ ip address 192.168.217.10 255.255.255.0
+interface Ethernet0/1
+ no ip address
+ duplex auto
+interface Ethernet0/2
+ no ip address
+ duplex auto
+interface Ethernet0/3
+ no ip address
+ shutdown
+ duplex auto
+        """,
+    }
+    return outputs[command_string]
+
+
+connection = ConnectHandler(**lab)
+
+# override send command method to return mock data
+setattr(connection, "send_command", mock_output)
+
+
+@skip_if_no_ttp
+def test_run_ttp_template_from_text():
+    template = """
+<input name="ntp_and_aaa" load="yaml">
+commands:
+  - show run | inc ntp
+  - show run | inc aaa
+</input>
+    
+<input name="interfaces_cfg">
+commands = [
+    "show run | sec interface"
+]
+</input>
+
+<group name="misc" input="ntp_and_aaa">
+ntp server {{ ntp_servers | joinmatches(",") }}
+aaa authentication login {{ authen | PHRASE }}
+aaa authorization exec {{ author_exec | PHRASE }}
+</group>
+
+<group name="interfaces" input="interfaces_cfg">
+interface {{ interface }}
+ description {{ description | re(".+") }}
+ encapsulation dot1Q {{ dot1q }}
+ ip address {{ ip }} {{ mask }}
+</group>
+    """
+    res = connection.run_ttp(template)
+    assert res == [
+        [
+            {
+                "misc": [
+                    {"ntp_servers": "8.8.8.8"},
+                    {"ntp_servers": "7.7.7.8"},
+                    {"ntp_servers": "1.1.1.2"},
+                    {"ntp_servers": "3.3.3.3"},
+                    {
+                        "authen": "default local",
+                        "author_exec": "default local",
+                        "ntp_servers": "7.7.7.7",
+                    },
+                ]
+            },
+            {
+                "interfaces": [
+                    {
+                        "description": "Routing Loopback",
+                        "interface": "Loopback0",
+                        "ip": "10.0.0.10",
+                        "mask": "255.255.255.255",
+                    },
+                    {
+                        "interface": "Loopback100",
+                        "ip": "1.1.1.100",
+                        "mask": "255.255.255.255",
+                    },
+                    {
+                        "description": "Main Interface for L3 features testing",
+                        "interface": "Ethernet0/0",
+                    },
+                    {
+                        "description": "to_vIOS1_Gi0/0.102",
+                        "dot1q": "102",
+                        "interface": "Ethernet0/0.102",
+                        "ip": "10.1.102.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {
+                        "description": "to_IOL2_Eth0/0.107",
+                        "dot1q": "107",
+                        "interface": "Ethernet0/0.107",
+                        "ip": "10.1.107.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {
+                        "dot1q": "2000",
+                        "interface": "Ethernet0/0.2000",
+                        "ip": "192.168.217.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {"interface": "Ethernet0/1"},
+                    {"interface": "Ethernet0/2"},
+                    {"interface": "Ethernet0/3"},
+                ]
+            },
+        ]
+    ]
+
+
+@skip_if_no_ttp
+def test_run_ttp_template_from_text_with_res_kwargs():
+    template = """
+<input name="ntp_and_aaa" load="yaml">
+commands:
+  - show run | inc ntp
+  - show run | inc aaa
+</input>
+    
+<input name="interfaces_cfg">
+commands = [
+    "show run | sec interface"
+]
+</input>
+
+<group name="misc" input="ntp_and_aaa">
+ntp server {{ ntp_servers | joinmatches(",") }}
+aaa authentication login {{ authen | PHRASE }}
+aaa authorization exec {{ author_exec | PHRASE }}
+</group>
+
+<group name="interfaces" input="interfaces_cfg">
+interface {{ interface }}
+ description {{ description | re(".+") }}
+ encapsulation dot1Q {{ dot1q }}
+ ip address {{ ip }} {{ mask }}
+</group>
+    """
+    res = connection.run_ttp(template, res_kwargs={"structure": "flat_list"})
+    assert res == [
+        {
+            "misc": [
+                {"ntp_servers": "8.8.8.8"},
+                {"ntp_servers": "7.7.7.8"},
+                {"ntp_servers": "1.1.1.2"},
+                {"ntp_servers": "3.3.3.3"},
+                {
+                    "authen": "default local",
+                    "author_exec": "default local",
+                    "ntp_servers": "7.7.7.7",
+                },
+            ]
+        },
+        {
+            "interfaces": [
+                {
+                    "description": "Routing Loopback",
+                    "interface": "Loopback0",
+                    "ip": "10.0.0.10",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "interface": "Loopback100",
+                    "ip": "1.1.1.100",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "description": "Main Interface for L3 features testing",
+                    "interface": "Ethernet0/0",
+                },
+                {
+                    "description": "to_vIOS1_Gi0/0.102",
+                    "dot1q": "102",
+                    "interface": "Ethernet0/0.102",
+                    "ip": "10.1.102.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "description": "to_IOL2_Eth0/0.107",
+                    "dot1q": "107",
+                    "interface": "Ethernet0/0.107",
+                    "ip": "10.1.107.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "dot1q": "2000",
+                    "interface": "Ethernet0/0.2000",
+                    "ip": "192.168.217.10",
+                    "mask": "255.255.255.0",
+                },
+                {"interface": "Ethernet0/1"},
+                {"interface": "Ethernet0/2"},
+                {"interface": "Ethernet0/3"},
+            ]
+        },
+    ]
+
+
+@skip_if_no_ttp
+def test_run_ttp_template_from_file():
+    template = "./test_ttp_run_template_1.txt"
+    res = connection.run_ttp(template)
+    assert res == [
+        [
+            {
+                "misc": [
+                    {"ntp_servers": "8.8.8.8"},
+                    {"ntp_servers": "7.7.7.8"},
+                    {"ntp_servers": "1.1.1.2"},
+                    {"ntp_servers": "3.3.3.3"},
+                    {
+                        "authen": "default local",
+                        "author_exec": "default local",
+                        "ntp_servers": "7.7.7.7",
+                    },
+                ]
+            },
+            {
+                "interfaces": [
+                    {
+                        "description": "Routing Loopback",
+                        "interface": "Loopback0",
+                        "ip": "10.0.0.10",
+                        "mask": "255.255.255.255",
+                    },
+                    {
+                        "interface": "Loopback100",
+                        "ip": "1.1.1.100",
+                        "mask": "255.255.255.255",
+                    },
+                    {
+                        "description": "Main Interface for L3 features testing",
+                        "interface": "Ethernet0/0",
+                    },
+                    {
+                        "description": "to_vIOS1_Gi0/0.102",
+                        "dot1q": "102",
+                        "interface": "Ethernet0/0.102",
+                        "ip": "10.1.102.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {
+                        "description": "to_IOL2_Eth0/0.107",
+                        "dot1q": "107",
+                        "interface": "Ethernet0/0.107",
+                        "ip": "10.1.107.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {
+                        "dot1q": "2000",
+                        "interface": "Ethernet0/0.2000",
+                        "ip": "192.168.217.10",
+                        "mask": "255.255.255.0",
+                    },
+                    {"interface": "Ethernet0/1"},
+                    {"interface": "Ethernet0/2"},
+                    {"interface": "Ethernet0/3"},
+                ]
+            },
+        ]
+    ]
+
+
+@skip_if_no_ttp
+@skip_if_no_ttp_templates
+def test_run_ttp_template_from_ttp_templates():
+    template = "ttp://misc/ttp_templates_tests/netmiko_cisco_ios_interfaces.txt"
+    res = connection.run_ttp(template)
+    assert res == [
+        {
+            "intf_cfg": [
+                {
+                    "description": "Routing Loopback",
+                    "interface": "Loopback0",
+                    "ip": "10.0.0.10",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "interface": "Loopback100",
+                    "ip": "1.1.1.100",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "description": "Main Interface for L3 features testing",
+                    "interface": "Ethernet0/0",
+                },
+                {
+                    "description": "to_vIOS1_Gi0/0.102",
+                    "interface": "Ethernet0/0.102",
+                    "ip": "10.1.102.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "description": "to_IOL2_Eth0/0.107",
+                    "interface": "Ethernet0/0.107",
+                    "ip": "10.1.107.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "interface": "Ethernet0/0.2000",
+                    "ip": "192.168.217.10",
+                    "mask": "255.255.255.0",
+                },
+                {"interface": "Ethernet0/1"},
+                {"interface": "Ethernet0/2"},
+                {"interface": "Ethernet0/3"},
+            ]
+        }
+    ]
+
+
+@skip_if_no_ttp
+def test_run_ttp_template_default_input():
+    template = """
+<doc>
+This template used in to test Netmiko run_ttp method
+</doc>
+
+<template name="interfaces" results="per_template">
+<input>
+commands = [
+    "show run | sec interface"
+]
+</input>
+
+<group name="intf_cfg">
+interface {{ interface }}
+ description {{ description | ORPHRASE }}
+ ip address {{ ip }} {{ mask }}
+</group>
+</template>
+    """
+    res = connection.run_ttp(template)
+    assert res == [
+        {
+            "intf_cfg": [
+                {
+                    "description": "Routing Loopback",
+                    "interface": "Loopback0",
+                    "ip": "10.0.0.10",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "interface": "Loopback100",
+                    "ip": "1.1.1.100",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "description": "Main Interface for L3 features testing",
+                    "interface": "Ethernet0/0",
+                },
+                {
+                    "description": "to_vIOS1_Gi0/0.102",
+                    "interface": "Ethernet0/0.102",
+                    "ip": "10.1.102.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "description": "to_IOL2_Eth0/0.107",
+                    "interface": "Ethernet0/0.107",
+                    "ip": "10.1.107.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "interface": "Ethernet0/0.2000",
+                    "ip": "192.168.217.10",
+                    "mask": "255.255.255.0",
+                },
+                {"interface": "Ethernet0/1"},
+                {"interface": "Ethernet0/2"},
+                {"interface": "Ethernet0/3"},
+            ]
+        }
+    ]
+
+
+@skip_if_no_ttp
+def test_run_ttp_template_dict_struct():
+    template = """
+<doc>
+This template used in to test Netmiko run_ttp method
+</doc>
+
+<template name="interfaces" results="per_template">
+<input>
+commands = [
+    "show run | sec interface"
+]
+</input>
+
+<group name="intf_cfg">
+interface {{ interface }}
+ description {{ description | ORPHRASE }}
+ ip address {{ ip }} {{ mask }}
+</group>
+</template>
+    """
+    res = connection.run_ttp(template, res_kwargs={"structure": "dictionary"})
+    assert res == {
+        "interfaces": {
+            "intf_cfg": [
+                {
+                    "description": "Routing Loopback",
+                    "interface": "Loopback0",
+                    "ip": "10.0.0.10",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "interface": "Loopback100",
+                    "ip": "1.1.1.100",
+                    "mask": "255.255.255.255",
+                },
+                {
+                    "description": "Main Interface for L3 features " "testing",
+                    "interface": "Ethernet0/0",
+                },
+                {
+                    "description": "to_vIOS1_Gi0/0.102",
+                    "interface": "Ethernet0/0.102",
+                    "ip": "10.1.102.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "description": "to_IOL2_Eth0/0.107",
+                    "interface": "Ethernet0/0.107",
+                    "ip": "10.1.107.10",
+                    "mask": "255.255.255.0",
+                },
+                {
+                    "interface": "Ethernet0/0.2000",
+                    "ip": "192.168.217.10",
+                    "mask": "255.255.255.0",
+                },
+                {"interface": "Ethernet0/1"},
+                {"interface": "Ethernet0/2"},
+                {"interface": "Ethernet0/3"},
+            ]
+        }
+    }

--- a/tests/test_ttp_run_template_1.txt
+++ b/tests/test_ttp_run_template_1.txt
@@ -1,0 +1,24 @@
+<input name="ntp_and_aaa" load="yaml">
+commands:
+  - show run | inc ntp
+  - show run | inc aaa
+</input>
+    
+<input name="interfaces_cfg">
+commands = [
+    "show run | sec interface"
+]
+</input>
+
+<group name="misc" input="ntp_and_aaa">
+ntp server {{ ntp_servers | joinmatches(",") }}
+aaa authentication login {{ authen | PHRASE }}
+aaa authorization exec {{ author_exec | PHRASE }}
+</group>
+
+<group name="interfaces" input="interfaces_cfg">
+interface {{ interface }}
+ description {{ description | re(".+") }}
+ encapsulation dot1Q {{ dot1q }}
+ ip address {{ ip }} {{ mask }}
+</group>


### PR DESCRIPTION
# Why?

To ease structured data extraction from network devices show commands output.

# How?

TTP templates can contain inputs tags, these tags can have various parameters defined, these parameters can be used by parent program to build a logic around adding data to TTP parser object.

# What?

Using new `run_ttp` method we can instruct Netmiko to collect output from devices, place it in appropriate inputs and parse it with TTP. For instance consider this template:

```
<input name="ntp_cfg" load="yaml">
method: send_command
kwargs: {}
commands:
  - show run | inc ntp
</input>
    
<input name="interfaces_cfg">
commands = [
    "show run | sec interface"
]
</input>

<group name="misc" input="ntp_cfg">
ntp server {{ ntp_servers }}
</group>

<group name="interfaces" input="interfaces_cfg">
interface {{ interface }}
 description {{ description | re(".+") }}
 encapsulation dot1Q {{ dot1q }}
 ip address {{ ip }} {{ mask }}
</group>
```

Sample code:

```
import pprint
from netmiko import ConnectHandler

lab = {
    "device_type": "cisco_ios",
    "host": "1.2.3.4",
    "username": "cisco",
    "password": "cisco",
}

connection = ConnectHandler(**lab)

res = connection.run_ttp(template)

pprint.pprint(res)
```

# Main features

- Can source templates from strings, files or TTP templates collection
- Any Netmiko connection object method can be called to collect devices output together with required arguments
- Multiple commands can be collected per input
- Additional arguments can be supplied to TTP object instantiation and TTP result method
- Allows to provide data to groups for certain commands output only, lowering probability of false matches