### PR TITLE
Allow sending command to WLC with 'y' character

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -97,6 +97,23 @@ class CiscoWlcSSH(BaseConnection):
             output = self.strip_prompt(output)
         return output
 
+    def send_command_w_yes(self, *args, **kwargs):
+        """
+        For 'show interface summary' Cisco WLC adds a
+        'Would you like to display the next 15 entries?' message
+        Even though pagination is disabled
+        Arguments are the same as send_command_timing() method
+        """
+        output = self.send_command_timing(*args, **kwargs)
+        if "(y/n)" in output:
+            output += self.send_command_timing("y")
+        strip_prompt = kwargs.get("strip_prompt", True)
+        if strip_prompt:
+            # Had to strip trailing prompt twice.
+            output = self.strip_prompt(output)
+            output = self.strip_prompt(output)
+        return output
+
     def session_preparation(self):
         """
         Prepare the session after the connection has been established


### PR DESCRIPTION
On Cisco wireless controllers, a command like `show interface summary` may ask a prompt for showing more entries, such as:

```
(wlc) >show interface summary

 Number of Interfaces.......................... 17
Interface Name                   Port Vlan Id  IP Address      Type    Ap Mgr Guest
-------------------------------- ---- -------- --------------- ------- ------ -----
test       LAG  xxx      test-ip-addr  Dynamic No     No
test       LAG  xxx      test-ip-addr  Dynamic No     No
test       LAG  xxx      test-ip-addr  Dynamic No     No
...
test            LAG  xxx      test-ip-addr  Static  Yes    No
test            LAG  xxx      test-ip-addr  Static  No     No
test            -    untagged test-ip-addr  Static  No     No
Would you like to display the next 15 entries? (y/n) y
```

This prompt comes even after paging is disabled.
In such cases, `send_command` does not do the job as it does not get back the WLC prompt back. Hence, a method for this in the `CiscoWlcSSH` class would be needed which sends the `y` character to interact with the WLC as required.