### PR TITLE
Adding pattern for hp_comware

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -140,7 +140,7 @@ SSH_MAPPER_BASE = {
     },
     "hp_comware": {
         "cmd": "display version",
-        "search_patterns": ["HPE Comware"],
+        "search_patterns": ["HPE Comware", "HP Comware"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Adding pattern to match these device

HP Comware Platform Software
Comware Software, Version 5.20.99, Release 2215
Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.
HP A5500-24G-PoE+ EI Switch with 2 Interface Slots uptime is 0 week, 1 day, 5 hours, 0 minute

HP A5500-24G-PoE+ EI Switch with 2 Interface Slots with 1 Processor
256M    bytes SDRAM
32768K  bytes Flash Memory

Hardware Version is REV.C
CPLD Version is 002
Bootrom Version is 715
[SubSlot 0] 24GE+4SFP+POE Plus Hardware Version is REV.C