### PR TITLE
Adding aruba_os on the autodetect dictionary

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -72,6 +72,12 @@ SSH_MAPPER_BASE = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "aruba_os" : {
+        "cmd": "show tech buffers",
+        "search_patterns": [r"HP"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "cisco_asa": {
         "cmd": "show version",
         "search_patterns": [r"Cisco Adaptive Security Appliance", r"Cisco ASA"],


### PR DESCRIPTION
Example of output of "show tech buffers" : 

Cmd Info : show tech buffers

show time
Tue Jan  2 02:03:40 1990

CRASHData
--- Length 25
--- Rec Ptr ffe7d20
No Crash data available!

CRASHLogfileshow

...Crash Log File Header..........................
Product:   HP J9779A
Name:      HP 2530-24-PoEP Switch
Date:      Apr 19 2018 11:24:07
Build:     702
Version:   YB.16.05.0008
Directory: /ws/swbuildm/rel_venice_qt3_qaoff/code/
CPU:       arm9e
  crash rec index = 0
   boot type    = POWER ON
   willBootType = UNKNOWN BOOT
..................................................
  No Saved Crash Information


MSGpoolStatsShow
             total   free  allocated  min-free  missed  corrupt
             -----  -----  ---------  --------  ------  -------
  MSG_BUF     4000   3893      107       3765        0       0


Checking buffer pool structures... PASSED

Allocation statistics for MSG buffer pool:
Current system time: 01/02/90 02:03:40
   OwnerName    OwnerID    #Owned        Oldest
  -----------   --------   ------   -----------------
    mInstCtrl    df34cc0       2    13853 ms
       (null)    df5f380      57    499 ms
   mAdMgrCtrl    df2e200       1    13713 ms
   mcrlMgrCtrl    df22600       1    5221 ms
     mSshAlrm    df1e280       1    10176 ms
   mIpAdMCtrl    df1ea00       3    15771 ms
      mIpCtrl    df19500       1    18771 ms
    mDiscCtrl    df05580       1    17821 ms
    mGarpCtrl    defe480       1    18771 ms
         mMLD    def8b80       1    18121 ms
    mIgmpCtrl    def43c0       1    18121 ms
     midmCtrl    def0a80       1    16263 ms
    mAcctCtrl    deeb600       1    18121 ms
   m8021xCtrl    deebb80       1    18121 ms
     mWebAuth    deebe40       1    18121 ms
     mCdpCtrl    dedf000       1    4100 ms
    mlldpCtrl    dedf500       1    18121 ms
     mSnmpEvt    dee5440       2    5238 ms
    mEaseCtrl    dedfa00       1    18121 ms
    mbyodCtrl    ded40c0       1    18788 ms
   mPoeMgrCtl    df3ccc0       1    18304 ms
      muiCore    df349c0       9    514 ms
       mSess4    dec1400       1    513 ms
     mSesInp4    debbb40       1    513 ms
       mSess5    dec1780       1    515 ms
     mSesInp5    deb4040       1    515 ms
       mSess6    dec1b00       1    518 ms
     mSesInp6    deb4540       1    518 ms
   mPpmgrCtrl    df2ec00       1    18688 ms
      mFfCtrl    deae040       1    18504 ms
   mCntrsCtrl    deb4dc0       1    13346 ms
    mHttpCtUp    dea2f00       1    17788 ms
   mStackCtrl    df05c00       1    14521 ms
    mLinkTest    de9ffc0       1    18121 ms
   mDHCPClint    df19dc0       1    8712 ms
  Note: (null) indicates buffer allocated at init time (not used since).


PKTpoolStatsShow
             total   free  allocated  min-free  missed  corrupt
             -----  -----  ---------  --------  ------  -------
  PKT_BUF     3072   2559      513       2532        0       0


Checking buffer pool structures... PASSED

Allocation statistics for PKT buffer pool:
Current system time: 01/02/90 02:03:40
   OwnerName    OwnerID    #Owned        Oldest
  -----------   --------   ------   -----------------
   tDevPollRx    df420c0     504    256 ms
   mIpPktRecv    df19780       1    18837 ms
   InetServer    df69d80       0    21474 ms
  Note: (null) indicates buffer allocated at init time (not used since).


PKTs on hardware rings:    RxRing: 100  TxRing:   0
PKTs on LAN_DEVICE rings:  RxRing:   0  TxRing:   0

show sw-debug-jumper
Auto Reset Value: 3 <AUTO_RESET_PASS_THRU>

Info: Physical jumper is used to determine the behavior of the switch.
show time
Tue Jan  2 02:03:40 1990


=== The command has completed successfully. ===