### PR TITLE
add self.current_prompt attribute

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -312,6 +312,7 @@ class BaseConnection(object):
             self.global_delay_factor = 0.1
 
         # set in set_base_prompt method
+        self.current_prompt = ""
         self.base_prompt = ""
         self._session_locker = Lock()
 
@@ -1204,6 +1205,7 @@ Device settings: {self.device_type} {self.host}:{self.port}
         time.sleep(delay_factor * 0.1)
         self.clear_buffer()
         log.debug(f"[find_prompt()]: prompt is {prompt}")
+        self.current_prompt = prompt
         return prompt
 
     def clear_buffer(self, backoff=True):


### PR DESCRIPTION
This is an improvement suggestion that I currently use in my derived class but I realized that this attribute is better off added as a new instance attribute "self.current_prompt" to the BaseConnection class. This attribute gets updated every time the find_prompt() is called. Sometimes we need to know the current prompt before, as well as without, invoking the find_prompt() when checking the current prompt. This attribute can be very handy when trying to print to stdout the current prompt without invoking the find_prompt().