### PR TITLE
Fix path for pip installed ntc_templates on 3.9+

### DIFF
--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -279,10 +279,10 @@ Alternatively, `pip install ntc-templates` (if using ntc-templates).
         # Try 'pip installed' ntc-templates
         try:
             with importresources_path(
-                package="ntc_templates", resource="templates"
+                package="ntc_templates", resource="parse.py"
             ) as posix_path:
                 # Example: /opt/venv/netmiko/lib/python3.8/site-packages/ntc_templates/templates
-                template_dir = str(posix_path)
+                template_dir = str(posix_path.parent.joinpath("templates"))
                 # This is for Netmiko automated testing
                 if _skip_ntc_package:
                     raise ModuleNotFoundError()


### PR DESCRIPTION
Workaround for the change in behavior of importlib.resources.path on Python 3.9, with minimal modifications. (Also 3.8, though it apparently still worked there). Since the docs say it will only return a file within a package, and no directories, changed to lookup the parse.py file in the root of the package. Gets the parent dir of that file and appends the `templates` directory. In testing, fixes the errors seen on #2048 and #2073 on my local systems. 