### PR TITLE
Dell EMC Networking Enterprise SONiC support

### DIFF
--- a/netmiko/dell/__init__.py
+++ b/netmiko/dell/__init__.py
@@ -2,6 +2,7 @@ from netmiko.dell.dell_dnos6 import DellDNOS6SSH
 from netmiko.dell.dell_dnos6 import DellDNOS6Telnet
 from netmiko.dell.dell_force10_ssh import DellForce10SSH
 from netmiko.dell.dell_os10_ssh import DellOS10SSH, DellOS10FileTransfer
+from netmiko.dell.dell_enterprise_sonic_ssh import DellEnterpriseSonicSSH
 from netmiko.dell.dell_powerconnect import DellPowerConnectSSH
 from netmiko.dell.dell_powerconnect import DellPowerConnectTelnet
 from netmiko.dell.dell_isilon_ssh import DellIsilonSSH
@@ -11,6 +12,7 @@ __all__ = [
     "DellPowerConnectSSH",
     "DellPowerConnectTelnet",
     "DellOS10SSH",
+    "DellEnterpriseSonicSSH",
     "DellOS10FileTransfer",
     "DellIsilonSSH",
     "DellDNOS6SSH",

--- a/netmiko/dell/dell_enterprise_sonic_ssh.py
+++ b/netmiko/dell/dell_enterprise_sonic_ssh.py
@@ -1,0 +1,47 @@
+"""Dell EMC PowerSwitch platforms running Enterprise SONiC Distribution by Dell Technologies Driver 
+- supports dellenterprisesonic."""
+
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko.scp_handler import BaseFileTransfer
+from netmiko import log
+import time
+
+
+class DellEnterpriseSonicSSH(CiscoSSHConnection):
+    """Dell EMC PowerSwitch platforms running Enterprise SONiC Distribution 
+       by Dell Technologies Driver - supports dellenterprisesonic."""
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"[>$#]")                
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+        self._enter_shell()
+        self.disable_paging()
+        self.set_base_prompt(alt_prompt_terminator="$")
+
+    def config_mode(self, config_command="configure terminal", pattern="#"):
+        return super().config_mode(config_command=config_command, pattern=pattern)
+
+    def _enter_shell(self):
+        """Enter the sonic-cli Shell."""
+        log.debug(f"Enter sonic-cli Shell.")
+        output = self.send_command("sonic-cli", expect_string=r"[\#]")
+        return output
+
+    def enable(self, *args, **kwargs):
+        """No enable mode on Enterprise SONiC."""
+        pass
+
+    def exit_enable_mode(self, *args, **kwargs):
+        """No enable mode on Enterprise SONiC."""
+        pass
+
+    def check_enable_mode(self, *args, **kwargs):
+        """No enable mode on Enterprise SONiC."""
+        pass
+
+    def _return_cli(self):
+        """Return to the CLI."""
+        return self.send_command("exit", expect_string=r"[\$]")

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -36,6 +36,7 @@ from netmiko.dell import DellDNOS6SSH
 from netmiko.dell import DellDNOS6Telnet
 from netmiko.dell import DellForce10SSH
 from netmiko.dell import DellOS10SSH, DellOS10FileTransfer
+from netmiko.dell import DellEnterpriseSonicSSH
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
 from netmiko.dell import DellIsilonSSH
@@ -150,6 +151,7 @@ CLASS_MAPPER_BASE = {
     "dell_os6": DellDNOS6SSH,
     "dell_os9": DellForce10SSH,
     "dell_os10": DellOS10SSH,
+    "dell_enterprise_sonic": DellEnterpriseSonicSSH,
     "dell_powerconnect": DellPowerConnectSSH,
     "dell_isilon": DellIsilonSSH,
     "dlink_ds": DlinkDSSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -255,10 +255,10 @@ dellos10:
 dell_enterprise_sonic:
   version: "show version"
   basic: "show ip interfaces"
-  extended_output: "show interface status"
+  extended_output: "show running-configuration"
   config:
-    - "interface Vlan 100"
-  config_verification: "show Vlan | grep 100"
+    - "interface Vlan100"
+  config_verification: "show running-configuration"
 
 dell_powerconnect:
   version: "show version"

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -252,6 +252,14 @@ dellos10:
     - "host-description node"
   config_verification: "show running-config"
 
+dell_enterprise_sonic:
+  version: "show version"
+  basic: "show ip interfaces"
+  extended_output: "show interface status"
+  config:
+    - "interface Vlan 100"
+  config_verification: "show Vlan | grep 100"
+
 dell_powerconnect:
   version: "show version"
   basic: "show ip interface vlan 1"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -110,6 +110,15 @@ dellos10:
   cmd_response_final: "host-description node"
   scp_remote_space: 1000
 
+dell_enterprise_sonic:
+  base_prompt: sonic
+  router_prompt : sonic#
+  interface_ip: 10.10.10.1
+  version_banner: "Software Version:"
+  multiple_line_output: "Name                Description         Admin          Oper           Speed          MTU"
+  cmd_response_init: ""
+  cmd_response_final: "100        Inactive"
+
 dell_powerconnect:
   base_prompt: myswitch
   router_prompt : myswitch#

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -113,11 +113,12 @@ dellos10:
 dell_enterprise_sonic:
   base_prompt: sonic
   router_prompt : sonic#
+  enable_prompt: sonic#
   interface_ip: 10.10.10.1
-  version_banner: "Software Version:"
-  multiple_line_output: "Name                Description         Admin          Oper           Speed          MTU"
+  version_banner: "Software Version"
+  multiple_line_output: "interface Management 0"
   cmd_response_init: ""
-  cmd_response_final: "100        Inactive"
+  cmd_response_final: "interface Vlan100"
 
 dell_powerconnect:
   base_prompt: myswitch

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -103,7 +103,7 @@ dellos10:
 
 dell_enterprise_sonic:
   device_type: dell_enterprise_sonic
-  ip: 192.168.23.129
+  ip: 192.168.23.130
   username: admin
   password: admin
 

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -101,6 +101,12 @@ dellos10:
   username: admin
   password: admin
 
+dell_enterprise_sonic:
+  device_type: dell_enterprise_sonic
+  ip: 192.168.23.129
+  username: admin
+  password: admin
+
 pluribus:
   device_type: pluribus_ssh
   ip: 172.17.19.1


### PR DESCRIPTION
root@fjaveed-dev:~/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests# python3.7 -m pytest -v test_netmiko_show.py --test_device dell_enterprise_sonic
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.7.9, pytest-5.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.7
cachedir: .pytest_cache
rootdir: /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing, inifile: setup.cfg
plugins: pylama-7.7.1
collected 22 items

test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                       [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                       [  9%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                          [ 13%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                       [ 18%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                  [ 22%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED                                                                                                                                    [ 27%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                         [ 31%]
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED                                                                                                                                           [ 36%]
test_netmiko_show.py::test_cmd_verify_decorator PASSED                                                                                                                                                 [ 40%]
test_netmiko_show.py::test_send_command_global_cmd_verify PASSED                                                                                                                                       [ 45%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                          [ 50%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED                                                                                                                                                [ 54%]
test_netmiko_show.py::test_send_command_ttp SKIPPED                                                                                                                                                    [ 59%]
test_netmiko_show.py::test_send_command_genie SKIPPED                                                                                                                                                  [ 63%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                          [ 68%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                         [ 72%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                        [ 77%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                  [ 81%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                         [ 86%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                          [ 90%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                           [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                                                                                                 [100%]

========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests/test_netmiko_show.py:163: <Skipped instance>
SKIPPED [1] /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests/test_netmiko_show.py:184: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests/test_netmiko_show.py:206: TTP template not existing for this platform
SKIPPED [1] /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests/test_netmiko_show.py:243: Genie not supported on this platform
================================================================================== 18 passed, 4 skipped in 76.65s (0:01:16) ==================================================================================
root@fjaveed-dev:~/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests# python3.7 -m pytest -v test_netmiko_config.py --test_device dell_enterprise_sonic
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.7.9, pytest-5.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.7
cachedir: .pytest_cache
rootdir: /root/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing, inifile: setup.cfg
plugins: pylama-7.7.1
collected 9 items

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                        [ 11%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                        [ 22%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                        [ 33%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                   [ 44%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                         [ 55%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                             [ 66%]
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                                                    [ 77%]
test_netmiko_config.py::test_config_from_file PASSED                                                                                                                                                   [ 88%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                         [100%]

============================================================================================= 9 passed in 49.30s =============================================================================================
root@fjaveed-dev:~/netmiko/netmiko/may2021/dellemc_sonic_support/netmiko_testing/tests#