### PR TITLE
Add telnet support for Cisco SG300

### DIFF
--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -12,6 +12,7 @@ from netmiko.cisco.cisco_nxos_ssh import CiscoNxosSSH, CiscoNxosFileTransfer
 from netmiko.cisco.cisco_xr import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer
 from netmiko.cisco.cisco_wlc_ssh import CiscoWlcSSH
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
+from netmiko.cisco.cisco_s300 import CiscoS300TELNET
 from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
 from netmiko.cisco.cisco_viptela import CiscoViptelaSSH
 
@@ -25,6 +26,7 @@ __all__ = [
     "CiscoXrTelnet",
     "CiscoWlcSSH",
     "CiscoS300SSH",
+    "CiscoS300Telnet",
     "CiscoTpTcCeSSH",
     "CiscoViptelaSSH",
     "CiscoIosBase",

--- a/netmiko/cisco/cisco_s300.py
+++ b/netmiko/cisco/cisco_s300.py
@@ -2,7 +2,7 @@ import time
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
-class CiscoS300SSH(CiscoSSHConnection):
+class CiscoS300SSH(CiscoBaseConnection):
     """
     Support for Cisco SG300 series of devices.
 
@@ -10,6 +10,28 @@ class CiscoS300SSH(CiscoSSHConnection):
 
     configure terminal
     ip ssh password-auth
+    """
+
+    def session_preparation(self):
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.set_terminal_width(command="terminal width 511", pattern="terminal")
+        self.disable_paging(command="terminal datadump")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+
+    def save_config(self, cmd="write memory", confirm=True, confirm_response="Y"):
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+class CiscoS300Telnet(CiscoBaseConnection):
+    """
+    Support for Cisco SG300 series of devices, with telnet.
+    Note: can be used with Sx200 series, with telnet enabled. 
+    
     """
 
     def session_preparation(self):

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -22,6 +22,7 @@ from netmiko.cisco import (
     CiscoIosFileTransfer,
     CiscoIosTelnet,
     CiscoIosSerial,
+    CiscoS300TELNET,
 )
 from netmiko.cisco import CiscoNxosSSH, CiscoNxosFileTransfer
 from netmiko.cisco import CiscoS300SSH
@@ -264,6 +265,7 @@ CLASS_MAPPER["centec_os_telnet"] = CentecOSTelnet
 CLASS_MAPPER["ciena_saos_telnet"] = CienaSaosTelnet
 CLASS_MAPPER["cisco_ios_telnet"] = CiscoIosTelnet
 CLASS_MAPPER["cisco_xr_telnet"] = CiscoXrTelnet
+CLASS_MAPPER["cisco_s300_telnet"] = CiscoS300Telnet
 CLASS_MAPPER["dell_dnos6_telnet"] = DellDNOS6Telnet
 CLASS_MAPPER["dell_powerconnect_telnet"] = DellPowerConnectTelnet
 CLASS_MAPPER["dlink_ds_telnet"] = DlinkDSTelnet


### PR DESCRIPTION
This is to add support for Telnet to the SG300 series of switches. 
this can be used with the Sx200 series of switches too, if you enable the telnet server via modifying the running config. 