### PR TITLE
Add Escape Sequences for cursor forward and wrap around

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2054,8 +2054,10 @@ You can also look at the Netmiko session_log or debug log for more information.
         code_attrs_off = chr(27) + r"\[0m"
         code_reverse = chr(27) + r"\[7m"
         code_cursor_left = chr(27) + r"\[\d+D"
-        code_cursor_forward = chr(27) + r"\[\d+C"
+        code_cursor_forward = chr(27) + r"\[\d*C"
+        code_cursor_up = chr(27) + r"\[\d*A"
         code_wrap_around = chr(27) + r"\[\?7h"
+        code_bracketed_paste_mode = chr(27) + r"\[\?2004h"
 
         code_set = [
             code_position_cursor,
@@ -2080,8 +2082,10 @@ You can also look at the Netmiko session_log or debug log for more information.
             code_attrs_off,
             code_reverse,
             code_cursor_left,
+            code_cursor_up,
             code_cursor_forward,
-            code_wrap_around
+            code_wrap_around,
+            code_bracketed_paste_mode
         ]
 
         output = string_buffer

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2054,6 +2054,8 @@ You can also look at the Netmiko session_log or debug log for more information.
         code_attrs_off = chr(27) + r"\[0m"
         code_reverse = chr(27) + r"\[7m"
         code_cursor_left = chr(27) + r"\[\d+D"
+        code_cursor_forward = chr(27) + r"\[\d+C"
+        code_wrap_around = chr(27) + r"\[\?7h"
 
         code_set = [
             code_position_cursor,
@@ -2078,6 +2080,8 @@ You can also look at the Netmiko session_log or debug log for more information.
             code_attrs_off,
             code_reverse,
             code_cursor_left,
+            code_cursor_forward,
+            code_wrap_around
         ]
 
         output = string_buffer


### PR DESCRIPTION
Currently netmiko fails to connect to Nokia SRLinux devices with a "ValueError cannot find prompt" exception, because there there are two ANSI Escape codes missing from stripped codes list that are sent by device on connect: cursor forward and wrap around. This patch adds these two ANSI escape sequences.

Once added, netmiko successfully connects to Nokia SRLinux devices using the "linux" device_type.

In case you are not aware: SRLinux is the new OS that replaces SROS/TiMOS in a new line of Nokia routers.