### PR TITLE
Proposed fix for mikrotik issues

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Run mypy
         run: |
-          pip list | grep mypy
-          mypy --version
           mypy ./netmiko/*.py
           mypy ./netmiko/[a-d]*
           mypy ./netmiko/eltex/

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Run mypy
         run: |
+          pip list | grep mypy
+          mypy --version
           mypy ./netmiko/*.py
           mypy ./netmiko/[a-d]*
           mypy ./netmiko/eltex/

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -42,6 +42,7 @@ jobs:
           mypy ./netmiko/enterasys/
           mypy ./netmiko/ericsson/
           mypy ./netmiko/extreme/extreme_wing_ssh.py 
+          mypy ./netmiko/mikrotik/
 
       - name: Run Tests
         run: |

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1285,16 +1285,17 @@ Device settings: {self.device_type} {self.host}:{self.port}
 
     def clear_buffer(
         self, backoff: bool = True, delay_factor: Optional[float] = None
-    ) -> None:
+    ) -> str:
         """Read any data available in the channel."""
 
         if delay_factor is None:
             delay_factor = self.global_delay_factor
-
         sleep_time = 0.1 * delay_factor
+
+        data = ""
         for _ in range(10):
             time.sleep(sleep_time)
-            data = self.read_channel()
+            data += self.read_channel()
             if not data:
                 break
             # Double sleep time each time we detect data
@@ -1302,6 +1303,7 @@ Device settings: {self.device_type} {self.host}:{self.port}
             if backoff:
                 sleep_time *= 2
                 sleep_time = 3 if sleep_time >= 3 else sleep_time
+        return data
 
     def command_echo_read(self, cmd: str, read_timeout: float) -> str:
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1286,7 +1286,6 @@ Device settings: {self.device_type} {self.host}:{self.port}
         self,
         backoff: bool = True,
         backoff_max: float = 3.0,
-        strip_whitespace: bool = False,
         delay_factor: Optional[float] = None,
     ) -> str:
         """Read any data available in the channel."""
@@ -1300,8 +1299,6 @@ Device settings: {self.device_type} {self.host}:{self.port}
             time.sleep(sleep_time)
             data = self.read_channel()
             data = self.strip_ansi_escape_codes(data)
-            if strip_whitespace:
-                data = data.strip()
             output += data
             if not data:
                 break

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1287,9 +1287,7 @@ Device settings: {self.device_type} {self.host}:{self.port}
         self, backoff: bool = True, delay_factor: Optional[float] = None
     ) -> None:
         """Read any data available in the channel."""
-        import ipdb
 
-        ipdb.set_trace()
         if delay_factor is None:
             delay_factor = self.global_delay_factor
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1408,8 +1408,12 @@ Device settings: {self.device_type} {self.host}:{self.port}
         :param a_string: Returned string from device
         :type a_string: str
         """
-        response_list = a_string.split(self.RESPONSE_RETURN)
-        last_line = response_list[-1]
+        try:
+            response_list = a_string.split(self.RESPONSE_RETURN)
+            last_line = response_list[-1]
+        except IndexError:
+            return a_string
+
         if self.base_prompt in last_line:
             return self.RESPONSE_RETURN.join(response_list[:-1])
         else:

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1408,11 +1408,8 @@ Device settings: {self.device_type} {self.host}:{self.port}
         :param a_string: Returned string from device
         :type a_string: str
         """
-        try:
-            response_list = a_string.split(self.RESPONSE_RETURN)
-            last_line = response_list[-1]
-        except IndexError:
-            return a_string
+        response_list = a_string.split(self.RESPONSE_RETURN)
+        last_line = response_list[-1]
 
         if self.base_prompt in last_line:
             return self.RESPONSE_RETURN.join(response_list[:-1])

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -863,20 +863,15 @@ You can look at the Netmiko session_log or debug log for more information.
         early on in the session.
 
         In general, it should include:
-        self._test_channel_read()
+        self._test_channel_read(pattern=r"some_pattern")
         self.set_base_prompt()
-        self.disable_paging()
         self.set_terminal_width()
-        self.clear_buffer()
+        self.disable_paging()
         """
         self._test_channel_read()
         self.set_base_prompt()
         self.set_terminal_width()
         self.disable_paging()
-
-        # Clear the read buffer
-        time.sleep(0.3 * self.global_delay_factor)
-        self.clear_buffer()
 
     def _use_ssh_config(self, dict_arg: Dict[str, Any]) -> Dict[str, Any]:
         """Update SSH connection parameters based on contents of SSH config file.
@@ -1288,9 +1283,17 @@ Device settings: {self.device_type} {self.host}:{self.port}
         log.debug(f"[find_prompt()]: prompt is {prompt}")
         return prompt
 
-    def clear_buffer(self, backoff: bool = True) -> None:
+    def clear_buffer(
+        self, backoff: bool = True, delay_factor: Optional[float] = None
+    ) -> None:
         """Read any data available in the channel."""
-        sleep_time = 0.1 * self.global_delay_factor
+        import ipdb
+
+        ipdb.set_trace()
+        if delay_factor is None:
+            delay_factor = self.global_delay_factor
+
+        sleep_time = 0.1 * delay_factor
         for _ in range(10):
             time.sleep(sleep_time)
             data = self.read_channel()
@@ -1562,8 +1565,6 @@ where x is the total number of seconds to wait before timing out.\n"""
 
         if normalize:
             command_string = self.normalize_cmd(command_string)
-
-        self.clear_buffer()
 
         # Start the clock
         start_time = time.time()

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,8 +1,6 @@
 from typing import Any, Union, List, Dict, Optional
-import re
 from netmiko.no_enable import NoEnable
 from netmiko.cisco_base_connection import CiscoSSHConnection
-from netmiko.ssh_exception import ReadTimeout
 
 
 class MikrotikBase(NoEnable, CiscoSSHConnection):
@@ -36,6 +34,7 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         self,
         backoff: bool = True,
         backoff_max: float = 10.0,
+        strip_whitespace: bool = True,
         delay_factor: Optional[float] = 10,
     ) -> str:
         """
@@ -45,7 +44,10 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         space be returned. So strip that off.
         """
         output = super().clear_buffer(
-            backoff=backoff, backoff_max=backoff_max, delay_factor=delay_factor, strip_whitespace=True
+            backoff=backoff,
+            backoff_max=backoff_max,
+            delay_factor=delay_factor,
+            strip_whitespace=strip_whitespace,
         )
         return output.strip()
 
@@ -122,43 +124,6 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         return super().send_command_timing(
             command_string=command_string, cmd_verify=cmd_verify, **kwargs
         )
-
-#    def command_echo_read(self, cmd: str, read_timeout: float) -> str:
-#        """
-#                Mikrotik has some odd behavior where it repaints both the command and the line
-#
-#                This could result in the command being at the top of the output multiple times
-#                (once for the actual echo and once for the repainting).
-#
-#                Correct this behavior.
-#
-#                Example output:
-#
-#        DEBUG:netmiko:write_channel: b'ping count=5 1.0.0.1\r\n'
-#        DEBUG:netmiko:read_channel: ping count=5 1.0.0.1
-#        [admin@hostname] > ping count=5 1.0.0.1
-#
-#          SEQ HOST                                     SIZE TTL TIME  STATUS
-#            0 1.0.0.1                                    56  60 23ms
-#
-#        """
-#
-#        # First read--initial command echo
-#        _ = self.read_until_pattern(pattern=re.escape(cmd), read_timeout=read_timeout)
-#        try:
-#            # Now try to read the re-painted line if it exists
-#            # Use a short timeout in case it is not there.
-#            import ipdb; ipdb.set_trace()
-#            last_buffer = self._read_buffer
-#            _ = self.read_until_pattern(pattern=re.escape(cmd), read_timeout=1.5)
-#        except ReadTimeout:
-#            # You can run into a problem where the _read_buffer is lost if the second
-#            # repaint doesn't happen. So restore what was there before in this case.
-#            self._read_buffer = last_buffer
-#
-#        # Just return cmd and nothing after it.
-#        # This is different than normal Netmiko behavior
-#        return cmd
 
 
 class MikrotikRouterOsSSH(MikrotikBase):

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -34,9 +34,9 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
 
     def clear_buffer(
         self, backoff: bool = True, delay_factor: Optional[float] = 10
-    ) -> None:
+    ) -> str:
         """Mikrotik needs more delays to clear buffer properly."""
-        super().clear_buffer(backoff=backoff, delay_factor=delay_factor)
+        return super().clear_buffer(backoff=backoff, delay_factor=delay_factor)
 
     def disable_paging(self, *args: Any, **kwargs: Any) -> str:
         """Microtik does not have paging by default."""

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -101,7 +101,7 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         self.base_prompt = prompt
         return self.base_prompt
 
-    def send_command_timing(    # type: ignore
+    def send_command_timing(  # type: ignore
         self,
         command_string: str,
         cmd_verify: bool = True,

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,3 +1,4 @@
+from typing import Any
 from netmiko.no_enable import NoEnable
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
@@ -5,7 +6,7 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 class MikrotikBase(NoEnable, CiscoSSHConnection):
     """Common Methods for Mikrotik RouterOS and SwitchOS"""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         if kwargs.get("default_enter") is None:
             kwargs["default_enter"] = "\r\n"
 
@@ -13,15 +14,13 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
 
         return super().__init__(**kwargs)
 
-    def session_preparation(self, *args, **kwargs):
+    def session_preparation(self, *args: Any, **kwargs: Any) -> None:
         """Prepare the session after the connection has been established."""
         self.ansi_escape_codes = True
-        # Clear the read buffer
-        self.write_channel(self.RETURN)
+        self._test_channel_read(pattern=r"[\]>]")
         self.set_base_prompt()
-        self.clear_buffer()
 
-    def _modify_connection_params(self):
+    def _modify_connection_params(self) -> None:
         """Append login options to username
         c: disable console colors
         e: enable dumb terminal mode
@@ -31,13 +30,13 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         """
         self.username += "+cetw511h4098"
 
-    def disable_paging(self, *args, **kwargs):
+    def disable_paging(self, *args: Any, **kwargs: Any) -> str:
         """Microtik does not have paging by default."""
         return ""
 
-    def save_config(self, *args, **kwargs):
+    def save_config(self, *args: Any, **kwargs: Any) -> str:
         """No save command, all configuration is atomic"""
-        pass
+        return ""
 
     def config_mode(
         self, config_command: str = "", pattern: str = "", re_flags: int = 0
@@ -46,45 +45,14 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         self._in_config_mode = True
         return ""
 
-    def check_config_mode(self, check_string=""):
+    def check_config_mode(self, check_string: str = "", pattern: str = "") -> bool:
         """Checks whether in configuration mode. Returns a boolean."""
         return self._in_config_mode
 
-    def exit_config_mode(self, exit_config=">"):
+    def exit_config_mode(self, exit_config: str = ">", pattern: str = "") -> str:
         """No configuration mode on Microtik"""
         self._in_config_mode = False
         return ""
-
-    def strip_prompt(self, a_string):
-        """Strip the trailing router prompt from the output.
-        MT adds some garbage trailing newlines, so
-        trim the last two lines from the output.
-
-        :param a_string: Returned string from device
-        :type a_string: str
-        """
-        response_list = a_string.split(self.RESPONSE_RETURN)
-        last_line = response_list[-2]
-        if self.base_prompt in last_line:
-            return self.RESPONSE_RETURN.join(response_list[:-2])
-        else:
-            return a_string
-
-    def strip_command(self, command_string, output):
-        """
-        Strip command_string from output string
-
-        MT returns, the Command\nRouterpromptCommand\n\n
-        start the defaut return at len(self.get_prompt())+2*len(command)+1
-
-        :param command_string: The command string sent to the device
-        :type command_string: str
-
-        :param output: The returned output as a result of the command string sen
-        :type output: str
-        """
-        command_length = len(self.find_prompt()) + 2 * (len(command_string)) + 2
-        return output[command_length:]
 
 
 class MikrotikRouterOsSSH(MikrotikBase):

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, List, Dict, Optional
+from typing import Any, Union, List, Dict
 from netmiko.no_enable import NoEnable
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
@@ -29,27 +29,6 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         h4098: set term height
         """
         self.username += "+ctw511h4098"
-
-    def clear_buffer(
-        self,
-        backoff: bool = True,
-        backoff_max: float = 10.0,
-        strip_whitespace: bool = True,
-        delay_factor: Optional[float] = 10,
-    ) -> str:
-        """
-        Mikrotik needs more delays to clear buffer properly.
-
-        Also has some sort of a weird behavior where I am constantly seeing a single
-        space be returned. So strip that off.
-        """
-        output = super().clear_buffer(
-            backoff=backoff,
-            backoff_max=backoff_max,
-            delay_factor=delay_factor,
-            strip_whitespace=strip_whitespace,
-        )
-        return output.strip()
 
     def disable_paging(self, *args: Any, **kwargs: Any) -> str:
         """Microtik does not have paging by default."""

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, List, Dict
+from typing import Any, Union, List, Dict, Optional
 import re
 from netmiko.no_enable import NoEnable
 from netmiko.cisco_base_connection import CiscoSSHConnection
@@ -31,6 +31,12 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         h4098: set term height
         """
         self.username += "+cetw511h4098"
+
+    def clear_buffer(
+        self, backoff: bool = True, delay_factor: Optional[float] = 10
+    ) -> None:
+        """Mikrotik needs more delays to clear buffer properly."""
+        super().clear_buffer(backoff=backoff, delay_factor=delay_factor)
 
     def disable_paging(self, *args: Any, **kwargs: Any) -> str:
         """Microtik does not have paging by default."""
@@ -95,7 +101,7 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         self.base_prompt = prompt
         return self.base_prompt
 
-    def send_command_timing(
+    def send_command_timing(    # type: ignore
         self,
         command_string: str,
         cmd_verify: bool = True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,11 @@ warn_unused_ignores = True
 warn_return_any = True
 warn_redundant_casts = True
 
+[mypy-netmiko.base_connection]
+# CI-CD (GitHub actions was giving me errors on the two type: ignore lines
+# in base_connection.py associated with Tenacity.
+warn_unused_ignores = False
+
 [mypy-netmiko._textfsm._terminal]
 ignore_errors = True
 

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -327,16 +327,18 @@ def test_normalize_linefeeds(net_connect, commands, expected_responses):
 
 def test_clear_buffer(net_connect, commands, expected_responses):
     """Test that clearing the buffer works."""
+
+    # x!@#!# Mikrotik
+    enter = net_connect.RETURN
     # Manually send a command down the channel so that data needs read.
-    net_connect.write_channel(commands["basic"] + "\n")
+    net_connect.write_channel(f"{commands['basic']}{enter}")
     time.sleep(1)
     net_connect.clear_buffer()
     time.sleep(2)
 
     # Should not be anything there on the second pass
     clear_buffer_check = net_connect.clear_buffer()
-    print(clear_buffer_check)
-    assert clear_buffer_check is None
+    assert clear_buffer_check == ""
 
 
 def test_enable_mode(net_connect, commands, expected_responses):

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -329,12 +329,13 @@ def test_clear_buffer(net_connect, commands, expected_responses):
     """Test that clearing the buffer works."""
     # Manually send a command down the channel so that data needs read.
     net_connect.write_channel(commands["basic"] + "\n")
-    time.sleep(4)
-    net_connect.clear_buffer()
     time.sleep(1)
+    net_connect.clear_buffer()
+    time.sleep(2)
 
     # Should not be anything there on the second pass
     clear_buffer_check = net_connect.clear_buffer()
+    print(clear_buffer_check)
     assert clear_buffer_check is None
 
 

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -29,7 +29,9 @@ def test_disable_paging(net_connect, commands, expected_responses):
         # NX-OS logging buffer gets enormous (NX-OS fails when testing very high-latency +
         # packet loss)
         net_connect.send_command("clear logging logfile")
-    multiple_line_output = net_connect.send_command(commands["extended_output"])
+    multiple_line_output = net_connect.send_command(
+        commands["extended_output"], read_timeout=60
+    )
     assert expected_responses["multiple_line_output"] in multiple_line_output
 
 

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -331,6 +331,7 @@ def test_clear_buffer(net_connect, commands, expected_responses):
     net_connect.write_channel(commands["basic"] + "\n")
     time.sleep(4)
     net_connect.clear_buffer()
+    time.sleep(1)
 
     # Should not be anything there on the second pass
     clear_buffer_check = net_connect.clear_buffer()


### PR DESCRIPTION
You must have cmd_verify=True which should be the default. Otherwise, I think you will potentially run into issues with Mikrotik devices.

It looks like to me that Mikrotik repaints the line including both the router prompt and the command as part of the command echo process.

This was why we put some initial odd behaviors in for both strip_command and strip_prompt (in the Mikrotik driver). I think these problems go away with newer Netmiko and cmd_verify. So I removed the special strip_command and strip_prompt methods (from the mikrotik driver).