### PR TITLE
Create a new ConnLogOnly factory function

### DIFF
--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -5,6 +5,7 @@ log = logging.getLogger(__name__)  # noqa
 log.addHandler(logging.NullHandler())  # noqa
 
 from netmiko.ssh_dispatcher import ConnectHandler
+from netmiko.ssh_dispatcher import ConnLogOnly
 from netmiko.ssh_dispatcher import ssh_dispatcher
 from netmiko.ssh_dispatcher import redispatch
 from netmiko.ssh_dispatcher import platforms
@@ -32,6 +33,7 @@ Netmiko = ConnectHandler
 __version__ = "4.0.0a3"
 __all__ = (
     "ConnectHandler",
+    "ConnLogOnly",
     "ssh_dispatcher",
     "platforms",
     "SCPConn",

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1029,16 +1029,17 @@ Device settings: {self.device_type} {self.host}:{self.port}
 
                 msg += self.RETURN + str(auth_err)
                 raise NetmikoAuthenticationException(msg)
-            except paramiko.ssh_exception.SSHException as no_session_err:
+            except paramiko.ssh_exception.SSHException as e:
                 self.paramiko_cleanup()
-                if "No existing session" in str(no_session_err):
+                if "No existing session" in str(e):
                     msg = (
                         "Paramiko: 'No existing session' error: "
                         "try increasing 'conn_timeout' to 10 seconds or larger."
                     )
                     raise NetmikoTimeoutException(msg)
                 else:
-                    raise
+                    msg = "A paramiko SSHException occurred during connection creation:\n\nstr(e)"
+                    raise NetmikoTimeoutException(msg)
 
             if self.verbose:
                 print(f"SSH connection established to {self.host}:{self.port}")


### PR DESCRIPTION
New entry point for running Netmiko. Should cause messages to only be logged and should never be connection/authentication exceptions (should almost never be exceptions only log messages).