### PR TITLE
Set channel attribute when establishing SSH connection for BaseConnection object

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1059,12 +1059,12 @@ Device settings: {self.device_type} {self.host}:{self.port}
             if self.keepalive:
                 assert isinstance(self.remote_conn.transport, paramiko.Transport)
                 self.remote_conn.transport.set_keepalive(self.keepalive)
+            # Migrating communication to channel class
+            self.channel = SSHChannel(conn=self.remote_conn, encoding=self.encoding)
             self.special_login_handler()
             if self.verbose:
                 print("Interactive SSH session established")
 
-            # Migrating communication to channel class
-            self.channel = SSHChannel(conn=self.remote_conn, encoding=self.encoding)
         return None
 
     def _test_channel_read(self, count: int = 40, pattern: str = "") -> str:


### PR DESCRIPTION
Attempts to solve https://github.com/ktbyers/netmiko/issues/2524

When connecting to Cisco AireOS based wireless controllers using netmiko, during connection establishment netmiko attempts to log into the WLC. Cisco WLCs have a `special_login_handler` that is called, which attempts to read the channel and write the username/password based on the prompts thrown by the WLC.

The issue seen is that the `read_channel` method in the `BaseConnection` class [calls the `read_channel` method of the `channel` attribute](https://github.com/ktbyers/netmiko/blob/1400a730bd27b4aed0acff4823ef5aa798c40d54/netmiko/base_connection.py#L538) which could be an object of either the `SSHChannel`, or `TelnetChannel` or another channel based class.

This change ensures that when an SSH connection is being established and a special login is required, the channel attribute is set with the required paramiko connection object and encoding.

Please let me know if this is how it would need to be addressed, or there is a better way to handle this. Thanks!

