### PR TITLE
Allow for clean login in WLC special login handler

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -44,7 +44,7 @@ class CiscoWlcSSH(BaseConnection):
                     break
                 time.sleep(delay_factor * 1)
             else:
-                self.write_channel(self.RETURN)
+                # no output read, sleep and go for one more round of read channel
                 time.sleep(delay_factor * 1.5)
             i += 1
 


### PR DESCRIPTION
In the AireOS based Cisco WLC special login handler method, login is attempted by reading the channel output in a looped fashion, with time delays and device prompt pattern checks to understand how to provide the username and password to the WLC to log into it.

For multiple slower Cisco WLCs that we have in our network, this special login handler was unable to log into the device because it would write a new line character to the channel when nothing was found in the read channel operation- sometimes after the username was written into the channel, which would add unnecessary newline characters and interfere with the login process. Example shown in the logs below:

```log
DEBUG:netmiko:read_channel: 
(Cisco Controller) 
User: 
DEBUG:netmiko:write_channel: b'example_username\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\n'
DEBUG:netmiko:read_channel: e
DEBUG:netmiko:read_channel: xample_username
Password:
User:
DEBUG:netmiko:write_channel: b'example_username\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\n'
DEBUG:netmiko:read_channel: example_username
Password:
DEBUG:netmiko:write_channel: b'example_password\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
User:
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: example_password
Password:
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
```

This change removes the newline char write operation and instead just makes the process sleep for the time delay defined in the method and move onto the next while loop iteration when the read channel operation gives an empty output