### PR TITLE
Corrected ArubaOS command to disable paging

### DIFF
--- a/netmiko/aruba/aruba_ssh.py
+++ b/netmiko/aruba/aruba_ssh.py
@@ -26,7 +26,7 @@ class ArubaSSH(CiscoSSHConnection):
         self._test_channel_read(pattern=r"[>#]")
         self.set_base_prompt()
         self.enable()
-        self.disable_paging(command="no paging")
+        self.disable_paging(command="no page")
 
     def check_config_mode(
         self, check_string: str = "(config) #", pattern: str = r"[>#]"


### PR DESCRIPTION
In the latest versions of ArubaOS the correct command to disable paging in enable mode is no page [1][2]

The command no paging is valid only in config mode [3]

[1] https://www.arubanetworks.com/techdocs/ArubaOS_61/ArubaOS_61_CLI/page.htm
[2] https://myworldofit.net/?p=10826
[3] https://www.arubanetworks.com/techdocs/ArubaOS_61/ArubaOS_61_CLI/paging.htm