### PR TITLE
Improvements for send_command_w_yes method in Cisco WLC SSH Connection class

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -108,8 +108,15 @@ class CiscoWlcSSH(BaseConnection):
         Arguments are the same as send_command_timing() method
         """
         output = self._send_command_timing_str(*args, **kwargs)
+
         if "(y/n)" in output:
-            output += self._send_command_timing_str("y")
+            output = "\n".join(output.split("\n")[:-1])  # stripping y/n prompt line
+            new_args = list(args)
+            if len(args) == 1:
+                new_args[0] = "y"
+            else:
+                kwargs["command_string"] = "y"
+            output += self._send_command_timing_str(*new_args, **kwargs)
         strip_prompt = kwargs.get("strip_prompt", True)
         if strip_prompt:
             # Had to strip trailing prompt twice.

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -107,6 +107,13 @@ class CiscoWlcSSH(BaseConnection):
         Even though pagination is disabled
         Arguments are the same as send_command_timing() method
         """
+        if len(args) > 1:
+            raise ValueError("Must pass in delay_factor as keyword argument")
+
+        # If no delay_factor use 1 for default value
+        delay_factor = kwargs.get("delay_factor", 1)
+        kwargs["delay_factor"] = self.select_delay_factor(delay_factor)
+
         output = self._send_command_timing_str(*args, **kwargs)
 
         if "(y/n)" in output:


### PR DESCRIPTION
Related to PR #2247

- The method `send_command_w_yes` would allow interacting with a command such as `show interface summary` appropriately, but the output would contain the "Would you like to display the next 15 entries? (y/n)" line in the output. This change strips that prompt line from the output so that it does not show up in the returned output.

- This change also allows for positional arguments and keyword arguments to be applied to the second call of the `send_command_timing` method in `send_command_w_yes`.

- Support for the setting of `delay_factor` for `send_command_w_yes` method to allow for higher delay tolerance when dealing with commands that would require the `send_command_w_yes` method