### PR TITLE
Add a new vendor: CoreEdge Networks

### DIFF
--- a/netmiko/coreedge/__init__.py
+++ b/netmiko/coreedge/__init__.py
@@ -1,0 +1,4 @@
+from netmiko.coreedge.cenet_cenos_a import CenetOSASSH
+from netmiko.coreedge.cenet_cenos_b import CenetOSBSSH
+
+__all__ = ["CenetOSASSH", "CenetOSBSSH"]

--- a/netmiko/coreedge/cenet_base.py
+++ b/netmiko/coreedge/cenet_base.py
@@ -1,0 +1,55 @@
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class CenetBase(CiscoSSHConnection):
+    def check_config_mode(self, check_string=")#", pattern=r"[>\#]"):
+
+        """
+        Checks if the device is in configuration mode or not.
+        CENOS uses "<hostname>(config)#" as config prompt
+        """
+
+        self.write_channel(self.RETURN)
+        output = self.read_until_pattern(pattern=pattern)
+        return check_string in output
+
+    def save_config(
+        self,
+        cmd: str = "write",
+        confirm: bool = True,
+        confirm_response: str = "Yes",
+    ) -> str:
+
+        """Save config: write"""
+        if confirm:
+            output = self.send_command_timing(
+                command_string=cmd,
+                strip_prompt=False,
+                strip_command=False,
+            )
+            if confirm_response:
+                output += self.send_command_timing(
+                    command_string=confirm_response,
+                    strip_prompt=False,
+                    strip_command=False,
+                )
+                self.send_command(
+                    self.RETURN,
+                    strip_prompt=False,
+                    strip_command=False,
+                    expect_string=r"#",
+                )
+            else:
+                # Send enter by default
+                output += self.send_command_timing(
+                    self.RETURN,
+                    strip_prompt=False,
+                    strip_command=False,
+                )
+        else:
+            output = self.send_command(
+                command_string=cmd,
+                strip_prompt=False,
+                strip_command=False,
+            )
+        return output

--- a/netmiko/coreedge/cenet_cenos_a.py
+++ b/netmiko/coreedge/cenet_cenos_a.py
@@ -1,0 +1,11 @@
+from netmiko.coreedge.cenet_base import CenetBase
+
+
+class CenetOSASSH(CenetBase):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.disable_paging(command="more off")
+
+    pass

--- a/netmiko/coreedge/cenet_cenos_b.py
+++ b/netmiko/coreedge/cenet_cenos_b.py
@@ -1,0 +1,27 @@
+import re
+from netmiko.coreedge.cenet_base import CenetBase
+
+
+class CenetOSBSSH(CenetBase):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read()
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging(command="more off")
+
+    def enable(
+        self,
+        cmd="enable",
+        pattern="ssword",
+        enable_pattern=r"\#",
+        re_flags=re.IGNORECASE,
+    ):
+        return super().enable(
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            re_flags=re_flags,
+        )
+
+    pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -107,6 +107,7 @@ from netmiko.zte import ZteZxrosSSH
 from netmiko.zte import ZteZxrosTelnet
 from netmiko.supermicro import SmciSwitchSmisSSH
 from netmiko.supermicro import SmciSwitchSmisTelnet
+from netmiko.coreedge import CenetOSASSH, CenetOSBSSH
 
 if TYPE_CHECKING:
     from netmiko.base_connection import BaseConnection
@@ -229,6 +230,8 @@ CLASS_MAPPER_BASE = {
     "watchguard_fireware": WatchguardFirewareSSH,
     "zte_zxros": ZteZxrosSSH,
     "yamaha": YamahaSSH,
+    "cenet_osa": CenetOSASSH,
+    "cenet_osb": CenetOSBSSH,
 }
 
 FILE_TRANSFER_MAP = {

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -490,3 +490,13 @@ ubiquiti_edgerouter:
     - "set system coredump enabled false"
   support_commit: True
   config_verification: "show system coredump enabled"
+
+cenet_osa:
+  version: "show version"
+  basic: "show ip interface brief"
+  extended_output: "show running-config"
+
+cenet_osb:
+  version: "show version"
+  basic: "show ip interface brief"
+  extended_output: "show running-config"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -339,3 +339,17 @@ ubiquiti_edgerouter:
   multiple_line_output: "switch switch0 {"
   cmd_response_init: "enabled true"
   cmd_response_final: "enabled false"
+
+cenet_osa:
+  base_prompt: "switch"
+  router_prompt: "switch>"
+  enable_prompt: "switch#"
+  interface_ip: "192.168.0.81"
+  version_banner: "CEN Operating System Software"
+
+cenet_osb:
+  base_prompt: "switch"
+  router_prompt: "switch>"
+  enable_prompt: "switch#"
+  interface_ip: "192.168.0.82"
+  version_banner: "CEN Operating System Software"

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -251,3 +251,16 @@ ubiquiti_edgerouter:
   ip: 192.168.1.1
   username: ubnt
   password: ubnt
+
+cenet_osa:
+  device_type: cenet_osa
+  ip: 192.168.0.81
+  username: root
+  password: Qwe123!@#$
+
+cenet_osb:
+  device_type: cenet_osb
+  ip: 192.168.0.82
+  username: root
+  password: Qwe123!@#$
+  secret: Qwe123!@#$


### PR DESCRIPTION
There are two types of OS.
In the case of  Type A(cenet_osa), cannot connect with the same ID or same privilege. So test_ssh_connect_cm had an error.
Please refer to the test result and the attached image below.

![image](https://user-images.githubusercontent.com/37614326/141299032-73e2f426-90b0-4a46-9d87-e2137068e051.png)


**cenet_osa**
- py.test -v test_netmiko_show.py --test_device cenet_osa
```
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/aiden/.pyenv/versions/3.9.5/envs/py-netconf/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/aiden/myCode/netmiko, configfile: setup.cfg
collected 24 items                                                                                                                               

test_netmiko_show.py::test_disable_paging PASSED                                                                                           [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                           [  8%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                              [ 12%]
test_netmiko_show.py::test_ssh_connect_cm ERROR                                                                                            [ 16%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                      [ 20%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                       [ 25%]
test_netmiko_show.py::test_send_command PASSED                                                                                             [ 29%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                              [ 33%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                              [ 37%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                             [ 41%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                          [ 45%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                               [ 50%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                   [ 54%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                          [ 58%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                   [ 62%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                   [ 66%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                              [ 70%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                             [ 75%]
test_netmiko_show.py::test_strip_command PASSED                                                                                            [ 79%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                      [ 83%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                             [ 87%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                              [ 91%]
test_netmiko_show.py::test_disconnect PASSED                                                                                               [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                                     [100%]

===================================================================== ERRORS =====================================================================
_____________________________________________________ ERROR at setup of test_ssh_connect_cm ______________________________________________________

request = <SubRequest 'net_connect_cm' for <Function test_ssh_connect_cm>>

    @pytest.fixture()
    def net_connect_cm(request):
        """
        Create the SSH connection to the remote device using a context manager
        retrieve the find_prompt() data and close the connection.
        """
        device_under_test = request.config.getoption("test_device")
        test_devices = parse_yaml(PWD + "/etc/test_devices.yml")
        device = test_devices[device_under_test]
        device["verbose"] = False
        my_prompt = ""
>       with ConnectHandler(**device) as conn:

conftest.py:87: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../netmiko/ssh_dispatcher.py:342: in ConnectHandler
    return ConnectionClass(*args, **kwargs)
../netmiko/base_connection.py:413: in __init__
    self._open()
../netmiko/base_connection.py:419: in _open
    self._try_session_preparation()
../netmiko/base_connection.py:858: in _try_session_preparation
    self.session_preparation()
../netmiko/coreedge/cenet_cenos_a.py:7: in session_preparation
    self._test_channel_read()
../netmiko/base_connection.py:1099: in _test_channel_read
    new_data += self.read_channel_timing()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <netmiko.coreedge.cenet_cenos_a.CenetOSASSH object at 0x7fe893f55190>, last_read = 2.0, read_timeout = 120.0, delay_factor = 1.0
max_loops = 150

        def read_channel_timing(
            self,
            last_read: float = 2.0,
            read_timeout: float = 120.0,
            delay_factor: float = 1.0,
            max_loops: int = 150,
        ) -> str:
            """Read data on the channel based on timing delays.
    
            General pattern is keep reading until no new data is read.
            Once no new data is read wait `last_read` amount of time (one last read).
            As long as no new data, then return data.
    
            `read_timeout` is an absolute timer for how long to keep reading (which presupposes
            we are still getting new data).
    
            Setting `read_timeout` to zero will cause read_channel_timing to never expire based
            on an absolute timeout. It will only complete based on timeout based on their being
            no new data.
    
            :param delay_factor: Deprecated in Netmiko 4.x. Will be eliminated in Netmiko 5.
    
            :param max_loops: Deprecated in Netmiko 4.x. Will be eliminated in Netmiko 5.
            """
    
            if delay_factor is not None or max_loops is not None:
                warnings.warn(DELAY_FACTOR_DEPR_SIMPLE_MSG, DeprecationWarning)
    
            if self.read_timeout_override:
                read_timeout = self.read_timeout_override
    
            # Time to delay in each read loop
            loop_delay = 0.1
            channel_data = ""
            start_time = time.time()
    
            # Set read_timeout to 0 to never timeout
            while (time.time() - start_time < read_timeout) or (not read_timeout):
                time.sleep(loop_delay)
                new_data = self.read_channel()
                # gather new output
                if new_data:
                    channel_data += new_data
                # if we have some output, but nothing new, then do the last read
                elif channel_data != "":
                    # Make sure really done (i.e. no new data)
                    time.sleep(last_read)
                    new_data = self.read_channel()
                    if not new_data:
                        break
                    else:
                        channel_data += new_data
            else:
                msg = f"""\n
    read_channel_timing's absolute timer expired.
    
    The network device was continually outputting data for longer than {read_timeout}
    seconds.
    
    If this is expected i.e. the command you are executing is continually emitting
    data for a long period of time, then you can set 'read_timeout=x' seconds. If
    you want Netmiko to keep reading indefinitely (i.e. to only stop when there is
    no new data), then you can set 'read_timeout=0'.
    
    You can look at the Netmiko session_log or debug log for more information.
    
    """
>               raise ReadTimeout(msg)
E               netmiko.exceptions.ReadTimeout: 
E               
E               read_channel_timing's absolute timer expired.
E               
E               The network device was continually outputting data for longer than 120.0
E               seconds.
E               
E               If this is expected i.e. the command you are executing is continually emitting
E               data for a long period of time, then you can set 'read_timeout=x' seconds. If
E               you want Netmiko to keep reading indefinitely (i.e. to only stop when there is
E               no new data), then you can set 'read_timeout=0'.
E               
E               You can look at the Netmiko session_log or debug log for more information.

../netmiko/base_connection.py:699: ReadTimeout
================================================================ warnings summary ================================================================
tests/test_netmiko_show.py::test_disable_paging
tests/test_netmiko_show.py::test_ssh_connect_cm
tests/test_netmiko_show.py::test_send_command_timing
tests/test_netmiko_show.py::test_strip_prompt
tests/test_netmiko_show.py::test_strip_command
tests/test_netmiko_show.py::test_normalize_linefeeds
tests/test_netmiko_show.py::test_disconnect_no_enable
  /home/aiden/myCode/netmiko/netmiko/base_connection.py:658: DeprecationWarning: 
  
  Netmiko 4.x and later has deprecated the use of delay_factor and/or max_loops in
  this context. You should remove any use of delay_factor=x from this method call.
  
    warnings.warn(DELAY_FACTOR_DEPR_SIMPLE_MSG, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================ short test summary info =============================================================
SKIPPED [1] test_netmiko_show.py:70: Skipped
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:110: Skipped
SKIPPED [1] test_netmiko_show.py:131: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:153: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:193: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:213: Skipped
SKIPPED [1] test_netmiko_show.py:229: Skipped
SKIPPED [1] test_netmiko_show.py:254: Skipped
SKIPPED [1] test_netmiko_show.py:278: Skipped
======================================== 13 passed, 10 skipped, 7 warnings, 1 error in 142.73s (0:02:22) =========================================
```

**cenet_osb**
- py.test -v test_netmiko_show.py --test_device cenet_osb
```
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/aiden/.pyenv/versions/3.9.5/envs/py-netconf/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/aiden/myCode/netmiko, configfile: setup.cfg
collected 24 items                                                                                                                               

test_netmiko_show.py::test_disable_paging PASSED                                                                                           [  4%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                           [  8%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                              [ 12%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                           [ 16%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                      [ 20%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                       [ 25%]
test_netmiko_show.py::test_send_command PASSED                                                                                             [ 29%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                              [ 33%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                              [ 37%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                             [ 41%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                          [ 45%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                               [ 50%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                   [ 54%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                          [ 58%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                   [ 62%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                   [ 66%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                              [ 70%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                             [ 75%]
test_netmiko_show.py::test_strip_command PASSED                                                                                            [ 79%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                      [ 83%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                             [ 87%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                              [ 91%]
test_netmiko_show.py::test_disconnect PASSED                                                                                               [ 95%]
test_netmiko_show.py::test_disconnect_no_enable PASSED                                                                                     [100%]

================================================================ warnings summary ================================================================
tests/test_netmiko_show.py::test_disable_paging
tests/test_netmiko_show.py::test_ssh_connect_cm
tests/test_netmiko_show.py::test_send_command_timing
tests/test_netmiko_show.py::test_strip_prompt
tests/test_netmiko_show.py::test_strip_command
tests/test_netmiko_show.py::test_normalize_linefeeds
tests/test_netmiko_show.py::test_disconnect_no_enable
  /home/aiden/myCode/netmiko/netmiko/base_connection.py:658: DeprecationWarning: 
  
  Netmiko 4.x and later has deprecated the use of delay_factor and/or max_loops in
  this context. You should remove any use of delay_factor=x from this method call.
  
    warnings.warn(DELAY_FACTOR_DEPR_SIMPLE_MSG, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================ short test summary info =============================================================
SKIPPED [1] test_netmiko_show.py:70: Skipped
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:110: Skipped
SKIPPED [1] test_netmiko_show.py:131: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:153: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:193: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:213: Skipped
SKIPPED [1] test_netmiko_show.py:229: Skipped
SKIPPED [1] test_netmiko_show.py:254: Skipped
SKIPPED [1] test_netmiko_show.py:278: Skipped
================================================== 14 passed, 10 skipped, 7 warnings in 26.97s ===================================================```