### PR TITLE
Add PowerConnect to SNMP autodetect

### DIFF
--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -109,6 +109,11 @@ SNMP_MAPPER_BASE = {
         "expr": re.compile(r".*TiMOS.*"),
         "priority": 99,
     },
+    "dell_powerconnect" = {
+        "oid": ".1.3.6.1.2.1.1.1.0",
+        "expr": re.compile(r"PowerConnect.*", re.IGNORECASE),
+        "priority": 50
+    }
 }
 
 # Ensure all SNMP device types are supported by Netmiko


### PR DESCRIPTION
Adding a Dell PowerConnect listing into the SNMP mapper to allow the devices to be automatically detected.