### PR TITLE
prevent secrets leaking to debug logs (#2597)

### DIFF
--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -4,19 +4,6 @@ import logging
 log = logging.getLogger(__name__)  # noqa
 log.addHandler(logging.NullHandler())  # noqa
 
-
-class SecretsFilter(logging.Filter):
-    def __init__(self, no_log=None):
-        self.no_log = no_log
-
-    def filter(self, record):
-        """Removes secrets (no_log) from messages"""
-        if self.no_log:
-            for hidden_data in self.no_log.values():
-                record.msg = record.msg.replace(hidden_data, "********")
-        return True
-
-
 from netmiko.ssh_dispatcher import ConnectHandler
 from netmiko.ssh_dispatcher import ConnLogOnly
 from netmiko.ssh_dispatcher import ConnUnify
@@ -73,3 +60,16 @@ __all__ = (
 
 # Cisco cntl-shift-six sequence
 CNTL_SHIFT_6 = chr(30)
+
+
+# Logging filter for #2597
+class SecretsFilter(logging.Filter):
+    def __init__(self, no_log=None):
+        self.no_log = no_log
+
+    def filter(self, record):
+        """Removes secrets (no_log) from messages"""
+        if self.no_log:
+            for hidden_data in self.no_log.values():
+                record.msg = record.msg.replace(hidden_data, "********")
+        return True

--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -4,6 +4,19 @@ import logging
 log = logging.getLogger(__name__)  # noqa
 log.addHandler(logging.NullHandler())  # noqa
 
+
+class SecretsFilter(logging.Filter):
+    def __init__(self, no_log=None):
+        self.no_log = no_log
+
+    def filter(self, record):
+        """Removes secrets (no_log) from messages"""
+        if self.no_log:
+            for hidden_data in self.no_log.values():
+                record.msg = record.msg.replace(hidden_data, "********")
+        return True
+
+
 from netmiko.ssh_dispatcher import ConnectHandler
 from netmiko.ssh_dispatcher import ConnLogOnly
 from netmiko.ssh_dispatcher import ConnUnify

--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -28,8 +28,6 @@ from netmiko.ssh_autodetect import SSHDetect
 from netmiko.base_connection import BaseConnection
 from netmiko.scp_functions import file_transfer, progress_bar
 
-from typing import Any, Dict, Optional
-
 # Alternate naming
 Netmiko = ConnectHandler
 
@@ -62,16 +60,3 @@ __all__ = (
 
 # Cisco cntl-shift-six sequence
 CNTL_SHIFT_6 = chr(30)
-
-
-# Logging filter for #2597
-class SecretsFilter(logging.Filter):
-    def __init__(self, no_log: Optional[Dict[Any, str]] = None) -> None:
-        self.no_log = no_log
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Removes secrets (no_log) from messages"""
-        if self.no_log:
-            for hidden_data in self.no_log.values():
-                record.msg = record.msg.replace(hidden_data, "********")
-        return True

--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -28,6 +28,8 @@ from netmiko.ssh_autodetect import SSHDetect
 from netmiko.base_connection import BaseConnection
 from netmiko.scp_functions import file_transfer, progress_bar
 
+from typing import Any, Dict, Optional
+
 # Alternate naming
 Netmiko = ConnectHandler
 
@@ -64,10 +66,10 @@ CNTL_SHIFT_6 = chr(30)
 
 # Logging filter for #2597
 class SecretsFilter(logging.Filter):
-    def __init__(self, no_log=None):
+    def __init__(self, no_log: Optional[Dict[Any, str]] = None) -> None:
         self.no_log = no_log
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         """Removes secrets (no_log) from messages"""
         if self.no_log:
             for hidden_data in self.no_log.values():

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -316,12 +316,12 @@ class BaseConnection:
         self.sock = sock
 
         # prevent logging secret data
-        self.no_log = {}
+        no_log = {}
         if self.password:
-            self.no_log["password"] = self.password
+            no_log["password"] = self.password
         if self.secret:
-            self.no_log["secret"] = self.secret
-        log.addFilter(SecretsFilter(no_log=self.no_log))
+            no_log["secret"] = self.secret
+        log.addFilter(SecretsFilter(no_log=no_log))
 
         # Netmiko will close the session_log if we open the file
         self.session_log = None
@@ -332,7 +332,7 @@ class BaseConnection:
                 self.session_log = SessionLog(
                     file_name=session_log,
                     file_mode=session_log_file_mode,
-                    no_log=self.no_log,
+                    no_log=no_log,
                     record_writes=session_log_record_writes,
                 )
                 self.session_log.open()
@@ -340,7 +340,7 @@ class BaseConnection:
                 # In-memory buffer or an already open file handle
                 self.session_log = SessionLog(
                     buffered_io=session_log,
-                    no_log=self.no_log,
+                    no_log=no_log,
                     record_writes=session_log_record_writes,
                 )
             else:

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -115,6 +115,12 @@ class BaseConnection:
     Otherwise method left as a stub method.
     """
 
+    # resolve typing
+    session_log: Union[SessionLog, None]
+    _legacy_mode: bool
+    fast_cli: bool
+    global_cmd_verify: Union[bool, None]
+
     def __init__(
         self,
         ip: str = "",


### PR DESCRIPTION
**Fixes** #2597

We introduce a logging filter that replaces the secret strings with asterisks. We attach the filter to the `netmiko` logger object during the `BaseConnection` initialization as soon as the secret data patters are available.

**Testing:**

code:
```python
import netmiko
import logging
from getpass import getpass

logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')


password = getpass()
with netmiko.ConnectHandler(
    device_type="cisco_ios",
    host="cisco1.askbow.net",
    username="cisco_test",
    password=password,
    secret=password,
) as nc:
    nc.enable()
```

output:
```
//snip
netmiko DEBUG Pattern found: (enable)
ip-172-31-46-176>
ip-172-31-46-176>enable
netmiko DEBUG read_channel:
netmiko DEBUG Pattern found: ((?:ip\-172\-31\-46\-176|ssword))
Password
netmiko DEBUG write_channel: b'********\n'                                              // <= * instead of the pasword
netmiko DEBUG read_channel:
netmiko DEBUG read_channel:
//snip
```