### PR TITLE
Fix missing colon on commands.yml.example

### DIFF
--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -452,7 +452,7 @@ sophos_sfos:
   basic: "system diagnostics utilities route lookup 172.16.16.16"
   extended_output: "system diagnostics show version-info"
 
-adtran_os
+adtran_os:
   version: "show version"
   basic: "show system-management-evc"
   extended_output: "show version"


### PR DESCRIPTION
Colon was missing for adtran_os. 
Tests were failing because of it.