### PR TITLE
Enable ANSI code handling for zyxel_os devices

### DIFF
--- a/netmiko/zyxel/zyxel_ssh.py
+++ b/netmiko/zyxel/zyxel_ssh.py
@@ -23,3 +23,8 @@ class ZyxelSSH(NoEnable, NoConfig, CiscoSSHConnection):
             enter_config_mode=enter_config_mode,
             **kwargs
         )
+
+    def session_preparation(self) -> None:
+        # Zyxel switches output ansi codes
+        self.ansi_escape_codes = True
+


### PR DESCRIPTION
ZyNOS generates ANSI escape codes in output.  This change enables ANSI escape code handling.