### PR TITLE
Add support for VyOS operator users in prompt detection

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1252,6 +1252,7 @@ Device settings: {self.device_type} {self.host}:{self.port}
         pri_prompt_terminator: str = "#",
         alt_prompt_terminator: str = ">",
         delay_factor: float = 1.0,
+        additional_terminators: List[str] = [],
     ) -> str:
         """Sets self.base_prompt
 
@@ -1268,9 +1269,13 @@ Device settings: {self.device_type} {self.host}:{self.port}
         :param alt_prompt_terminator: Alternate trailing delimiter for identifying a device prompt
 
         :param delay_factor: See __init__: global_delay_factor
+
+        :param additional_terminators: Additional trailing delimiter(s) for identifying a device prompt
         """
         prompt = self.find_prompt(delay_factor=delay_factor)
-        if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
+        terminators = set([pri_prompt_terminator, alt_prompt_terminator])
+        terminators.update(additional_terminators)
+        if not prompt[-1] in terminators:
             raise ValueError(f"Router prompt not found: {repr(prompt)}")
         # Strip off trailing terminator
         self.base_prompt = prompt[:-1]

--- a/netmiko/vyos/vyos_ssh.py
+++ b/netmiko/vyos/vyos_ssh.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence, TextIO, Any
+from typing import Optional, Union, Sequence, TextIO, Any, List
 import time
 import warnings
 from netmiko.no_enable import NoEnable
@@ -97,12 +97,14 @@ class VyOSSSH(NoEnable, CiscoSSHConnection):
         pri_prompt_terminator: str = "$",
         alt_prompt_terminator: str = "#",
         delay_factor: float = 1.0,
+        additional_terminators: List[str] = [">"],
     ) -> str:
         """Sets self.base_prompt: used as delimiter for stripping of trailing prompt in output."""
         prompt = super().set_base_prompt(
             pri_prompt_terminator=pri_prompt_terminator,
             alt_prompt_terminator=alt_prompt_terminator,
             delay_factor=delay_factor,
+            additional_terminators=additional_terminators,
         )
         # Set prompt to user@hostname (remove two additional characters)
         self.base_prompt = prompt[:-2].strip()


### PR DESCRIPTION
Fixes #1591

I just ran into this bug today, and this is a minimal fix to address the need for a 3rd prompt terminator for VyOS when using an "operator" user instead of an "admin" user.   It should be generic and apply for 3+ terminators (adds a list as a defaulted keyword argument) should future routers also need this functionality.