### PR TITLE
Remove PY3.6 support; add PyYAML as direct dependency

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+        python-version: [3.7, 3.8, 3.9, 3.10.0]
 
     steps:
       - name: Checkout repository

--- a/license-dependencies.txt
+++ b/license-dependencies.txt
@@ -13,6 +13,7 @@ scp            0.14.4   GNU Library or Lesser General Public License (LGPL)
 tenacity       8.0.1    Apache Software License                             
 ntc-templates  3.0.0    Apache Software License                             
 pyserial       3.5      BSD License
+PyYAML         6.0      MIT License                                         
 
 ##### Child dependencies
 Name                 Version  License
@@ -25,5 +26,5 @@ pycparser            2.21     BSD License
 cffi                 1.15.0   MIT License                                         
 future               0.18.2   MIT License                                         
 six                  1.16.0   MIT License                                         
-importlib-resources  5.4.0    Apache Software License                             
-zipp                 3.6.0    MIT License                                         
+
+With assistance from `pip-licenses -o license`

--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import functools
 from datetime import datetime
+import importlib.resources as pkg_resources
 from textfsm import clitable
 from textfsm.clitable import CliTableError
 from netmiko import log
@@ -47,12 +48,6 @@ try:
     GENIE_INSTALLED = True
 except ImportError:
     GENIE_INSTALLED = False
-
-# If we are on python < 3.7, we need to force the import of importlib.resources backport
-if sys.version_info[:2] >= (3, 7):
-    import importlib.resources as pkg_resources
-else:
-    import importlib_resources as pkg_resources
 
 try:
     import serial.tools.list_ports
@@ -302,7 +297,7 @@ Alternatively, `pip install ntc-templates` (if using ntc-templates).
     else:
         # Try 'pip installed' ntc-templates
         try:
-            with pkg_resources.path(
+            with pkg_resources.path(  # type: ignore
                 package="ntc_templates", resource="parse.py"
             ) as posix_path:
                 # Example: /opt/venv/netmiko/lib/python3.8/site-packages/ntc_templates/templates

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -49,13 +48,13 @@ setup(
     packages=find_packages(exclude=("test*",)),
     install_requires=[
         "setuptools>=38.4.0",
-        "paramiko>=2.6.0",
-        "scp>=0.13.2",
+        "paramiko>=2.7.2",
+        "scp>=0.13.3",
         "tenacity",
+        "pyyaml>=5.3",
         "textfsm>=1.1.2",
         "ntc-templates>=2.0.0",
         "pyserial",
-        "importlib_resources ; python_version<'3.7'",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Remove PY3.6 support (EOL)

Add PyYAML as direct dependency for netmiko tools.