### PR TITLE
Improve junos check_config_mode to handle commit-confirm message

### DIFF
--- a/netmiko/juniper/juniper.py
+++ b/netmiko/juniper/juniper.py
@@ -68,9 +68,17 @@ class JuniperBase(NoEnable, BaseConnection):
         return
 
     def check_config_mode(
-        self, check_string: str = "]", pattern: str = r"[>#]"
+        self, check_string: str = "]", pattern: str = r"(?m)[>#] $"
     ) -> bool:
-        """Checks if the device is in configuration mode or not."""
+        """
+        Checks if the device is in configuration mode or not.
+
+        (?m) = Use multiline matching
+
+        Juniper unfortunately will use # as a message indicator when not in config mode
+        For example, with commit confirmed.
+
+        """
         return super().check_config_mode(check_string=check_string, pattern=pattern)
 
     def config_mode(

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -377,4 +377,4 @@ def test_disconnect_no_enable(net_connect_newconn, commands, expected_responses)
         assert net_connect.remote_conn is None
         assert time_delta.total_seconds() < 5
     else:
-        assert True
+        assert pytest.skip()


### PR DESCRIPTION
that appears in and out of config mode with a "#"