### PR TITLE
added Driver Cisco UCM SSH

### DIFF
--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -15,6 +15,7 @@ from netmiko.cisco.cisco_s300 import CiscoS300SSH
 from netmiko.cisco.cisco_s300 import CiscoS300Telnet
 from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
 from netmiko.cisco.cisco_viptela import CiscoViptelaSSH
+from netmiko.cisco.cisco_ucm_ssh import CiscoUCMSSH
 
 __all__ = [
     "CiscoIosSSH",
@@ -36,4 +37,5 @@ __all__ = [
     "CiscoNxosFileTransfer",
     "CiscoIosSerial",
     "CiscoXrFileTransfer",
+    "CiscoUCMSSH"
 ]

--- a/netmiko/cisco/cisco_ucm_ssh.py
+++ b/netmiko/cisco/cisco_ucm_ssh.py
@@ -1,0 +1,49 @@
+from typing import Optional
+from paramiko import SSHClient
+import time
+from os import path
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+class CiscoUCMSSH(CiscoBaseConnection):
+    """
+    Implements methods for communicating with Cisco Unified Call Manager.
+    """
+
+    # def session_preparation(self) -> None:
+    #     """
+    #     Prepare the session after the connection has been established.
+    #     """
+    #     delay_factor = self.select_delay_factor(delay_factor=0)
+    #     time.sleep(0.3 * delay_factor)
+    #     self.clear_buffer()
+    #     self._test_channel_read(pattern=r"admin:")
+    #     self.set_base_prompt()
+    #     self.enable()
+    #     self.disable_paging()
+    #     # Clear the read buffer
+    #     time.sleep(0.3 * self.global_delay_factor)
+    #     self.clear_buffer()
+        
+    def set_base_prompt(
+        self,
+        pri_prompt_terminator: str = ":",
+        alt_prompt_terminator: str = ":",
+        delay_factor: float = 1.0,
+        pattern: Optional[str] = None,
+    ) -> str:
+        """
+        Sets self.base_prompt
+
+        Used as delimiter for stripping of trailing prompt in output.
+
+        Should be set to something that is general and applies in multiple
+        contexts. For Cisco Unified Call Manager prompt with ':'.
+
+        """
+        return super().set_base_prompt(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            delay_factor=delay_factor,
+            pattern=pattern
+            )
+        

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -30,8 +30,10 @@ from netmiko.cisco import (
 from netmiko.cisco import CiscoNxosSSH, CiscoNxosFileTransfer
 from netmiko.cisco import CiscoS300SSH, CiscoS300Telnet
 from netmiko.cisco import CiscoTpTcCeSSH
+from netmiko.cisco import CiscoUCMSSH
 from netmiko.cisco import CiscoViptelaSSH
 from netmiko.cisco import CiscoWlcSSH
+from netmiko.cisco import CiscoCUCMSSH
 from netmiko.cisco import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer
 from netmiko.citrix import NetscalerSSH
 from netmiko.cloudgenix import CloudGenixIonSSH
@@ -151,6 +153,7 @@ CLASS_MAPPER_BASE = {
     "cisco_s300": CiscoS300SSH,
     "cisco_tp": CiscoTpTcCeSSH,
     "cisco_viptela": CiscoViptelaSSH,
+    "cisco_ucm": CiscoUCMSSH,
     "cisco_wlc": CiscoWlcSSH,
     "cisco_xe": CiscoIosSSH,
     "cisco_xr": CiscoXrSSH,


### PR DESCRIPTION
This is a driver to have Netmiko connect to Cisco UCM servers.  Current Netmiko fails because of the base prompt does not find 'admin:'.   This has been tested with send_command method.  