### PR TITLE
Update utilities.py

### DIFF
--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -20,7 +20,7 @@ import os
 from pathlib import Path
 import functools
 from datetime import datetime
-import importlib.resources as pkg_resources
+import importlib_resources as pkg_resources
 from textfsm import clitable
 from textfsm.clitable import CliTableError
 from netmiko import log


### PR DESCRIPTION
To resolve Bug:
    from netmiko import CNTL_SHIFT_6
  File "/usr/local/lib/python3.6/site-packages/netmiko/__init__.py", line 7, in <module>
    from netmiko.ssh_dispatcher import ConnectHandler
  File "/usr/local/lib/python3.6/site-packages/netmiko/ssh_dispatcher.py", line 6, in <module>
    from netmiko.a10 import A10SSH
  File "/usr/local/lib/python3.6/site-packages/netmiko/a10/__init__.py", line 1, in <module>
    from netmiko.a10.a10_ssh import A10SSH
  File "/usr/local/lib/python3.6/site-packages/netmiko/a10/a10_ssh.py", line 2, in <module>
    from netmiko.cisco_base_connection import CiscoSSHConnection
  File "/usr/local/lib/python3.6/site-packages/netmiko/cisco_base_connection.py", line 5, in <module>
    from netmiko.base_connection import BaseConnection
  File "/usr/local/lib/python3.6/site-packages/netmiko/base_connection.py", line 51, in <module>
    from netmiko.channel import Channel, SSHChannel, TelnetChannel, SerialChannel
  File "/usr/local/lib/python3.6/site-packages/netmiko/channel.py", line 7, in <module>
    from netmiko.utilities import write_bytes
  File "/usr/local/lib/python3.6/site-packages/netmiko/utilities.py", line 23, in <module>
    import importlib.resources as pkg_resources
ModuleNotFoundError: No module named 'importlib.resources'