### PR TITLE
Replace typing.re import

### DIFF
--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -333,7 +333,7 @@ class SNMPDetect(object):
         for entry in snmp_mapper_list:
             for device_type, v in entry.items():
                 oid: str = v["oid"]  # type: ignore
-                regex: Pattern = v["expr"]
+                regex: Pattern[str] = v["expr"]
 
                 # Used cache data if we already queryied this OID
                 if self._response_cache.get(oid):

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -20,8 +20,7 @@ SNMPDetect class defaults to SNMPv3
 Note, pysnmp is a required dependency for SNMPDetect and is intentionally not included in
 netmiko requirements. So installation of pysnmp might be required.
 """
-from typing import Optional, Dict
-from typing.re import Pattern
+from typing import Optional, Dict, Pattern
 import re
 
 try:

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -333,7 +333,7 @@ class SNMPDetect(object):
         for entry in snmp_mapper_list:
             for device_type, v in entry.items():
                 oid: str = v["oid"]  # type: ignore
-                regex: Pattern[str] = v["expr"]
+                regex: Pattern[str] = v["expr"]  # type: ignore
 
                 # Used cache data if we already queryied this OID
                 if self._response_cache.get(oid):


### PR DESCRIPTION
`typing.re` has been deprecated since Python 3.8 and will be removed in Python 3.12.
`Pattern` is also available in the top-level `typing` namespace.