### PR TITLE
Mikrotik strip command

### DIFF
--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -1,4 +1,5 @@
 from typing import Any, Union, List, Dict, Optional
+import re
 from netmiko.no_enable import NoEnable
 from netmiko.cisco_base_connection import CiscoSSHConnection
 
@@ -76,6 +77,20 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         else:
             # Unexpected just return the original string
             return a_string
+
+    def strip_command(self, command_string: str, output: str) -> str:
+        """
+        Supercharge strip_command to remove potential additional command printed
+        """
+        output = super().strip_command(command_string, output)
+        cmd = command_string.strip()
+        if re.match(rf"^(\[\S+\] > )?{re.escape(cmd)}", output):
+            output_lines = output.split(self.RESPONSE_RETURN)
+            new_output = output_lines[1:]
+            return self.RESPONSE_RETURN.join(new_output)
+        else:
+            # command_string isn't there; do nothing
+            return output
 
     def set_base_prompt(
         self,


### PR DESCRIPTION
Hello,

We noticed an issue with mikrotik having the command not stripped from output. It was then messing up the ntc template.
Half fixing #2669 

Before:

```
>>> print(net_connect.send_command("system routerboard print"))
[admin@MikroTik] > system routerboard print

       routerboard: yes
        board-name: hEX
             model: RB750Gr3
          revision: r4
     serial-number: CC210E592C82
     firmware-type: mt7621L
  factory-firmware: 6.48
  current-firmware: 6.49
  upgrade-firmware: 6.49
```

After:
```
 >>> print(net_connect.send_command("system routerboard print"))
routerboard: yes
        board-name: hEX
             model: RB750Gr3
          revision: r4
     serial-number: CC210E592C82
     firmware-type: mt7621L
  factory-firmware: 6.48
  current-firmware: 6.49
  upgrade-firmware: 6.49
```

