### PR TITLE
Changed Huawei VRPv8 SSH send_config_set behaviour to not exit configuration

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Optional, Any, Union, Sequence, TextIO
 import time
 import re
 import warnings
@@ -192,6 +192,17 @@ class HuaweiTelnet(HuaweiBase):
 
 
 class HuaweiVrpv8SSH(HuaweiSSH):
+    def send_config_set(
+        self,
+        config_commands: Union[str, Sequence[str], TextIO, None] = None,
+        exit_config_mode: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """Huawei VRPv8 requires you not exit from configuration mode."""
+        return super().send_config_set(
+            config_commands=config_commands, exit_config_mode=exit_config_mode, **kwargs
+        )
+
     def commit(
         self,
         comment: str = "",


### PR DESCRIPTION
This pull request is to override send_config_set method for [HuaweiVrpv8SSH class](https://github.com/ktbyers/netmiko/blob/4c3732346eea1a4a608abd9e09d65eeb2f577810/netmiko/huawei/huawei.py#L200) similar how its done for [cisco_xr driver](https://github.com/ktbyers/netmiko/blob/4c3732346eea1a4a608abd9e09d65eeb2f577810/netmiko/cisco/cisco_xr.py#L23) and set exit_config_mode to False.

#2625 