### PR TITLE
Fix Mikrotik endless loop with send_command_timing

### DIFF
--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -102,7 +102,7 @@ class MikrotikBase(NoEnable, CiscoSSHConnection):
         **kwargs: Any,
     ) -> Union[str, List[Any], Dict[str, Any]]:
         """Force cmd_verify to be True due to all of the line repainting"""
-        return super()._send_command_timing_str(
+        return super().send_command_timing(
             command_string=command_string, cmd_verify=cmd_verify, **kwargs
         )
 


### PR DESCRIPTION
Which was kind of sad because send_command_timing is really useful with Mikrotik overprinting commands