### PR TITLE
Replace deprecated threading.currentThread with threading.current_thread

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -3,6 +3,7 @@ name: build
 on: [push, pull_request]
 env:
   environment: gh_actions
+  FORCE_COLOR: 1
 jobs:
   std_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Run Tests
         run: |
-          py.test -v -s tests/test_import_netmiko.py
-          py.test -v -s tests/unit/test_base_connection.py
-          py.test -v -s tests/unit/test_utilities.py
-          py.test -v -s tests/unit/test_ssh_autodetect.py
-          py.test -v -s tests/unit/test_connection.py
+          pytest -v -s tests/test_import_netmiko.py
+          pytest -v -s tests/unit/test_base_connection.py
+          pytest -v -s tests/unit/test_utilities.py
+          pytest -v -s tests/unit/test_ssh_autodetect.py
+          pytest -v -s tests/unit/test_connection.py

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/docs/netmiko/cli_tools/netmiko_cfg.html
+++ b/docs/netmiko/cli_tools/netmiko_cfg.html
@@ -218,7 +218,7 @@ def main(args):
         )
         my_thread.start()
     # Make sure all threads have finished
-    main_thread = threading.currentThread()
+    main_thread = threading.current_thread()
     for some_thread in threading.enumerate():
         if some_thread != main_thread:
             some_thread.join()
@@ -369,7 +369,7 @@ if __name__ == &#34;__main__&#34;:
         )
         my_thread.start()
     # Make sure all threads have finished
-    main_thread = threading.currentThread()
+    main_thread = threading.current_thread()
     for some_thread in threading.enumerate():
         if some_thread != main_thread:
             some_thread.join()

--- a/docs/netmiko/cli_tools/netmiko_grep.html
+++ b/docs/netmiko/cli_tools/netmiko_grep.html
@@ -197,7 +197,7 @@ def main(args):
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()
@@ -352,7 +352,7 @@ if __name__ == &#34;__main__&#34;:
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()

--- a/docs/netmiko/cli_tools/netmiko_show.html
+++ b/docs/netmiko/cli_tools/netmiko_show.html
@@ -196,7 +196,7 @@ def main(args):
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()
@@ -351,7 +351,7 @@ if __name__ == &#34;__main__&#34;:
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()

--- a/examples_old/case16_concurrency/threads_netmiko.py
+++ b/examples_old/case16_concurrency/threads_netmiko.py
@@ -26,7 +26,7 @@ def main():
         my_thread = threading.Thread(target=show_version, args=(a_device,))
         my_thread.start()
 
-    main_thread = threading.currentThread()
+    main_thread = threading.current_thread()
     for some_thread in threading.enumerate():
         if some_thread != main_thread:
             print(some_thread)

--- a/netmiko/cli_tools/netmiko_cfg.py
+++ b/netmiko/cli_tools/netmiko_cfg.py
@@ -193,7 +193,7 @@ def main(args):
         )
         my_thread.start()
     # Make sure all threads have finished
-    main_thread = threading.currentThread()
+    main_thread = threading.current_thread()
     for some_thread in threading.enumerate():
         if some_thread != main_thread:
             some_thread.join()

--- a/netmiko/cli_tools/netmiko_grep.py
+++ b/netmiko/cli_tools/netmiko_grep.py
@@ -172,7 +172,7 @@ def main(args):
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()

--- a/netmiko/cli_tools/netmiko_show.py
+++ b/netmiko/cli_tools/netmiko_show.py
@@ -171,7 +171,7 @@ def main(args):
             )
             my_thread.start()
         # Make sure all threads have finished
-        main_thread = threading.currentThread()
+        main_thread = threading.current_thread()
         for some_thread in threading.enumerate():
             if some_thread != main_thread:
                 some_thread.join()


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174

Also:

* Test latest Python 3.10 (currently 3.10.5) instead of 3.10.0
* Test [Python 3.11 beta](https://dev.to/hugovk/help-test-python-311-4gn0)
* Add colour to CI output
* Drop the dot in pytest https://twitter.com/pytestdotorg/status/753767547866972160