### PR TITLE
Update ssh_autodetect.py

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -204,6 +204,18 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "extreme_voss": {
+        "cmd": "show sys-info",
+        "search_patterns": [r"VSP|vsp"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "extreme_boss": {
+        "cmd": "show system",
+        "search_patterns": [r"Ethernet Routing Switch"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "ubiquiti_edgeswitch": {
         "cmd": "show version",
         "search_patterns": [r"EdgeSwitch"],


### PR DESCRIPTION
added extreme boss and voss switching platform for autodetect ssh. Updated in the SSH_MAPPER_DICT.