### PR TITLE
set self.global_cmd_verify=False only if None for Classic CLI in Nokia SROS

### DIFF
--- a/netmiko/nokia/nokia_sros.py
+++ b/netmiko/nokia/nokia_sros.py
@@ -53,7 +53,9 @@ class NokiaSros(BaseConnection):
         else:
             # Classical CLI has no method to set the terminal width nor to disable command
             # complete on space; consequently, cmd_verify needs disabled.
-            self.global_cmd_verify = False
+            # Only disabled if not set under the ConnectHandler.
+            if self.global_cmd_verify is None:
+                self.global_cmd_verify = False
             self.disable_paging(command="environment no more", pattern="environment")
 
         # Clear the read buffer


### PR DESCRIPTION
We want to honor the cmd_verify definition under the Connecthandler. Only set to False, if unset.