### PR TITLE
Added Versa FlexVNF platform to SSH autodetect

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -252,6 +252,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "flexvnf": {
+        "cmd": "show system package-info",
+        "search_patterns": [r"Versa FlexVNF"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
 }
 
 # Sort SSH_MAPPER_DICT such that the most common commands are first


### PR DESCRIPTION
Versa FlexVNF support were missing from SSH auto-detect, so I've added to the SSH_MAPPER_DICT dictionary:

```
    "flexvnf": {
        "cmd": "show system package-info",
        "search_patterns": [r"Versa FlexVNF"],
        "priority": 99,
        "dispatch": "_autodetect_std",
    },
```

Real output from a Versa FlexVNF device:
```
Administrator@Hostname-cli> show system package-info

  Package             Versa FlexVNF software
  Release             21.1.1
  Spack api version   11
  Spack lib version   5
  Release Type        GA
  Release date        20201007
  Package id          5d1edd2
  Package name        versa-flexvnf-20201007-172235-5d1edd2-21.1.1-wsm
  Branch              CUSTOM
  Creator             jenkins
```
