### PR TITLE
Added sleep to wait for session closure on old wlc

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -197,6 +197,8 @@ output:
                 self._session_log_fin = True
                 self.write_channel("n" + self.RETURN)
 
+            time.sleep(0.5)
+
             try:
                 self.write_channel(self.RETURN)
             except socket.error:


### PR DESCRIPTION
This fix solving issue with Netmiko, where Paramiko thread is not closed for WLCs with older software version.

More details here:
https://github.com/ktbyers/netmiko/issues/2084

