### PR TITLE
Develop adva new driver

### DIFF
--- a/netmiko/adva/__init__.py
+++ b/netmiko/adva/__init__.py
@@ -1,0 +1,10 @@
+"""Adva Device Drivers
+"""
+from __future__ import unicode_literals
+from netmiko.adva.adva_aos_fsp_150_f2 import AdvaAosFsp150f2SSH
+from netmiko.adva.adva_aos_fsp_150_f3 import AdvaAosFsp150f3SSH
+
+__all__ = [
+    "AdvaAosFsp150f2SSH",
+    "AdvaAosFsp150f3SSH",
+]

--- a/netmiko/adva/adva_aos_fsp_150_f2.py
+++ b/netmiko/adva/adva_aos_fsp_150_f2.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import re
 import time
+from typing import Any
 from netmiko.no_enable import NoEnable
 from netmiko.no_config import NoConfig
 from netmiko.cisco_base_connection import CiscoSSHConnection
@@ -36,7 +37,7 @@ class AdvaAosFsp150f2SSH(NoEnable, NoConfig, CiscoSSHConnection):
         NoConfig (class): Netmiko NoConfig Class
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """
         Adva F2 Device Instantiation
         \n for default enter causes some issues with the Adva
@@ -47,7 +48,7 @@ class AdvaAosFsp150f2SSH(NoEnable, NoConfig, CiscoSSHConnection):
 
         super().__init__(**kwargs)
 
-    def session_preparation(self):
+    def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
         Handles devices with security prompt enabled
@@ -68,7 +69,7 @@ class AdvaAosFsp150f2SSH(NoEnable, NoConfig, CiscoSSHConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def set_base_prompt(self):
+    def set_base_prompt(self) -> str:
         """
         Remove :--> for regular mode, and all instances of :config:txt:--> when config being applied
         Used as delimiter for stripping of trailing prompt in output

--- a/netmiko/adva/adva_aos_fsp_150_f2.py
+++ b/netmiko/adva/adva_aos_fsp_150_f2.py
@@ -92,8 +92,8 @@ class AdvaAosFsp150f2SSH(NoEnable, NoConfig, CiscoSSHConnection):
         :param pattern: Regular expression pattern to search for in find_prompt() call
         """
         prompt = self.find_prompt()
-        if not (match := re.search(r"(^.+?)([:].*)-->$", prompt)):
+        match = re.search(r"(^.+?)([:].*)-->$", prompt)
+        if not match:
             raise ValueError("Router prompt not found: {0}".format(repr(prompt)))
-            # Strip everything after first ':' from prompt
         self.base_prompt = match[1]
         return self.base_prompt

--- a/netmiko/adva/adva_aos_fsp_150_f2.py
+++ b/netmiko/adva/adva_aos_fsp_150_f2.py
@@ -1,0 +1,87 @@
+"""Adva support."""
+# pylint: disable=line-too-long
+# pylint: disable=consider-using-f-string
+# pylint: disable=abstract-method
+# pylint: disable=arguments-differ
+from __future__ import print_function
+from __future__ import unicode_literals
+import re
+import time
+from netmiko.no_enable import NoEnable
+from netmiko.no_config import NoConfig
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class AdvaAosFsp150f2SSH(NoEnable, NoConfig, CiscoSSHConnection):
+    """Adva AOS FSP 15P F2 SSH Base Class
+       F2 AOS applies for the following FSP150 device types
+       FSP150CC-825
+       These devices don't have a Enable Mode or Config Mode
+       Configuration Should be applied via the configuration context
+        home
+        configure snmp
+        add v3user guytest noauth-nopriv
+        home
+
+        configure system
+        home
+
+        Use of home to return to CLI root context, home cannot be used from root
+        LAB-R2-825-1:--> home
+        Unrecognized command
+
+    Args:
+        CiscoSSHConnection (class): Netmiko Cisco SSH Connection Class
+        NoEnable (class): Netmiko NoEnable Class
+        NoConfig (class): Netmiko NoConfig Class
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Adva F2 Device Instantiation
+        \n for default enter causes some issues with the Adva
+        so setting to \r
+        """
+        if kwargs.get("default_enter") is None:
+            kwargs["default_enter"] = "\r"
+
+        super().__init__(**kwargs)
+
+    def session_preparation(self):
+        """
+        Prepare the session after the connection has been established.
+        Handles devices with security prompt enabled
+        """
+        delay_factor = self.select_delay_factor(delay_factor=0)
+        output = ""
+        while True:
+            output += self.read_channel()
+            if "Do you wish to continue" in output:
+                self.write_channel(f"y{self.RETURN}")
+                break
+            if "-->" in output:
+                break
+            time.sleep(0.33 * delay_factor)
+        self._test_channel_read(pattern=r"-->")
+        self.set_base_prompt()
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def set_base_prompt(self):
+        """
+        Remove :--> for regular mode, and all instances of :config:txt:--> when config being applied
+        Used as delimiter for stripping of trailing prompt in output
+
+        Raises:
+            ValueError: Raises Value Error Router Prompt Not Found
+
+        Returns:
+            str: Device Prompt
+        """
+        prompt = self.find_prompt()
+        if not (match := re.search(r"(^.+?)([:].*)-->$", prompt)):
+            raise ValueError("Router prompt not found: {0}".format(repr(prompt)))
+            # Strip everything after first ':' from prompt
+        self.base_prompt = match[1]
+        return self.base_prompt

--- a/netmiko/adva/adva_aos_fsp_150_f3.py
+++ b/netmiko/adva/adva_aos_fsp_150_f3.py
@@ -1,0 +1,196 @@
+"""Adva F3 Device Support"""
+# pylint: disable=line-too-long
+# pylint: disable=consider-using-f-string
+# pylint: disable=abstract-method
+# pylint: disable=arguments-differ
+from __future__ import print_function
+from __future__ import unicode_literals
+import re
+import time
+from typing import (
+    Optional,
+    Sequence,
+    TextIO,
+    Union,
+)
+
+from netmiko.no_enable import NoEnable
+from netmiko.no_config import NoConfig
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class AdvaAosFsp150f3SSH(NoEnable, NoConfig, CiscoSSHConnection):
+    """
+       Adva AOS FSP 15P F3 SSH Base Class
+       F3 AOS applies for the following FSP150 device types
+       FSP150CC-XG21x
+       FSP150CC-GE11x
+       FSP150CC-GE20x
+       These devices don't have a Enable Mode or Config Mode
+       Configuration Should be applied via the configuration context
+        home
+        configure communication
+        add ip-route nexthop xxxxxxx
+
+        #
+        #CLI:PORT N2A SHAPER-1-1-1-3-0  Create
+        #
+        home
+        network-element ne-1
+
+        Use of home to return to CLI root context
+
+    Args:
+        CiscoSSHConnection (class): Netmiko Cisco SSH Connection Class
+        NoEnable (class): Netmiko NoEnable Class
+        NoConfig (class): Netmiko NoConfig Class
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Adva F3 Device Instantiation
+        \n for default enter causes some issues with the Adva
+        so setting to \r
+        """
+        if kwargs.get("default_enter") is None:
+            kwargs["default_enter"] = "\r"
+
+        super().__init__(**kwargs)
+
+    def session_preparation(self):
+        """
+        Prepare the session after the connection has been established.
+        Handles devices with security prompt enabled
+        """
+        delay_factor = self.select_delay_factor(delay_factor=0)
+        output = ""
+        while True:
+            output += self.read_channel()
+            if "Do you wish to continue" in output:
+                self.write_channel(f"y{self.RETURN}")
+                break
+            if "-->" in output:
+                break
+            time.sleep(0.33 * delay_factor)
+        self._test_channel_read(pattern=r"-->")
+        self.set_base_prompt()
+        # CMD Verify False used to allow multline paging command
+        self.disable_paging(cmd_verify=False)
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def disable_paging(
+        self,
+        command: str = "terminal length 0",
+        delay_factor: Optional[float] = None,
+        cmd_verify: bool = True,
+        pattern: Optional[str] = None,
+    ) -> str:
+        """
+        Method to disable paging on the Adva, multi-line configuration command required
+
+        Args:
+            command (str, optional): Command to Disable Paging. Defaults to "terminal length 0".
+            delay_factor (Optional[float], optional): Deprecated in Netmiko 4.x. Will be eliminated in Netmiko 5. Defaults to None.
+            cmd_verify (bool, optional): Verify command echo before proceeding. Defaults to True.
+            pattern (Optional[str], optional): Regular expression pattern used to identify that reading is done. Defaults to None.
+
+        Returns:
+            str: SSH Channel Output
+        """
+        # Multiline Command Below is used for paging
+        command = (
+            "configure user-security"
+            + self.TELNET_RETURN
+            + "config-user "
+            + self.username
+            + " cli-paging disabled"
+            + self.TELNET_RETURN
+            + "home"
+            + self.TELNET_RETURN
+        )
+        return super().disable_paging(
+            command=command,
+            delay_factor=delay_factor,
+            cmd_verify=cmd_verify,
+            pattern=pattern,
+        )
+
+    def set_base_prompt(self):
+        """
+        Remove --> for regular mode, and all instances of :config:txt:--> when config being applied
+        Used as delimiter for stripping of trailing prompt in output
+
+        Raises:
+            ValueError: Raises Value Error Router Prompt Not Found
+
+        Returns:
+            str: Device Prompt
+        """
+        prompt = self.find_prompt()
+        if not (match := re.search(r"(^.+?)-->$", prompt)):
+            raise ValueError("Router prompt not found: {0}".format(repr(prompt)))
+            # Strip everything before '-->' from prompt
+        self.base_prompt = match[1]
+        return self.base_prompt
+
+    def send_config_set(
+        self,
+        config_commands: Union[str, Sequence[str], TextIO, None] = None,
+        *,
+        exit_config_mode: bool = True,
+        read_timeout: Optional[float] = 2.0,
+        delay_factor: Optional[float] = None,
+        max_loops: Optional[int] = None,
+        strip_prompt: bool = False,
+        strip_command: bool = False,
+        config_mode_command: Optional[str] = None,
+        cmd_verify: bool = True,
+        enter_config_mode: bool = True,
+        error_pattern: str = "",
+        terminator: str = r"#",
+        bypass_commands: Optional[
+            str
+        ] = r"(add\s+\w+\s+[A-Za-z0-9#\?!@\$%\^&\*-]*\s+[A-Za-z0-9#\?!@\$%\^&\*-]*\s+(superuser|crypto|maintenance|provisioning|retrieve|test-user)|secret.*)",
+    ) -> str:
+        """
+        Send configuration commands down the SSH channel.
+
+        config_commands is an iterable containing all of the configuration commands.
+        The commands will be executed one after the other.
+
+        Automatically exits/enters configuration mode.
+
+        Args:
+            config_commands (Union[str, Sequence[str], TextIO, None], optional): Multiple configuration commands to be sent to the device Defaults to None.
+            exit_config_mode (bool, optional): Determines whether or not to exit config mode after complete Defaults to True.
+            read_timeout (Optional[float], optional): Absolute timer to send to read_channel_timing. Should be rarely needed. Defaults to 2.0.
+            delay_factor (Optional[float], optional): Deprecated in Netmiko 4.x. Will be eliminated in Netmiko 5. Defaults to None.
+            max_loops (Optional[int], optional): Deprecated in Netmiko 4.x. Will be eliminated in Netmiko 5. Defaults to None.
+            strip_prompt (bool, optional): Determines whether or not to strip the prompt Defaults to False.
+            strip_command (bool, optional): Determines whether or not to strip the command Defaults to False.
+            config_mode_command (Optional[str], optional): The command to enter into config mode Defaults to None.
+            cmd_verify (bool, optional): Whether or not to verify command echo for each command in config_set Defaults to True.
+            enter_config_mode (bool, optional): Do you enter config mode before sending config commands Defaults to True.
+            error_pattern (str, optional): egular expression pattern to detect config errors in the output. Defaults to "".
+            terminator (str, optional): Regular expression pattern to use as an alternate terminator in certain situations. Defaults to r"#".
+            bypass_commands (Optional[str], optional): _description_. Defaults to r"(add.*|secret.*)".
+
+        Returns:
+            str: SSH Channel Output
+        """
+        return super().send_config_set(
+            config_commands=config_commands,
+            exit_config_mode=exit_config_mode,
+            read_timeout=read_timeout,
+            delay_factor=delay_factor,
+            max_loops=max_loops,
+            strip_prompt=strip_prompt,
+            strip_command=strip_command,
+            config_mode_command=config_mode_command,
+            cmd_verify=cmd_verify,
+            enter_config_mode=enter_config_mode,
+            error_pattern=error_pattern,
+            terminator=terminator,
+            bypass_commands=bypass_commands,
+        )

--- a/netmiko/adva/adva_aos_fsp_150_f3.py
+++ b/netmiko/adva/adva_aos_fsp_150_f3.py
@@ -162,7 +162,7 @@ class AdvaAosFsp150f3SSH(NoEnable, NoConfig, CiscoSSHConnection):
         terminator: str = r"#",
         bypass_commands: Optional[
             str
-        ] = r"(add\s+\w+\s+[A-Za-z0-9#\?!@\$%\^&\*-]*\s+[A-Za-z0-9#\?!@\$%\^&\*-]*\s+(superuser|crypto|maintenance|provisioning|retrieve|test-user)|secret.*)",
+        ] = r"?:add\s+\S+\s+\S+\s+\S+\s+(?:superuser|crypto|maintenance|provisioning|retrieve|test-user)|secret.*)",
     ) -> str:
         """
         Send configuration commands down the SSH channel.

--- a/netmiko/adva/adva_aos_fsp_150_f3.py
+++ b/netmiko/adva/adva_aos_fsp_150_f3.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import re
 import time
 from typing import (
+    Any,
     Optional,
     Sequence,
     TextIO,
@@ -46,7 +47,7 @@ class AdvaAosFsp150f3SSH(NoEnable, NoConfig, CiscoSSHConnection):
         NoConfig (class): Netmiko NoConfig Class
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """
         Adva F3 Device Instantiation
         \n for default enter causes some issues with the Adva
@@ -57,7 +58,7 @@ class AdvaAosFsp150f3SSH(NoEnable, NoConfig, CiscoSSHConnection):
 
         super().__init__(**kwargs)
 
-    def session_preparation(self):
+    def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
         Handles devices with security prompt enabled
@@ -116,7 +117,7 @@ class AdvaAosFsp150f3SSH(NoEnable, NoConfig, CiscoSSHConnection):
             pattern=pattern,
         )
 
-    def set_base_prompt(self):
+    def set_base_prompt(self) -> str:
         """
         Remove --> for regular mode, and all instances of :config:txt:--> when config being applied
         Used as delimiter for stripping of trailing prompt in output

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -13,6 +13,14 @@ from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
+from netmiko.audiocode import (
+    Audiocode72SSH,
+    Audiocode66SSH,
+    AudiocodeShellSSH,
+    Audiocode72Telnet,
+    Audiocode66Telnet,
+    AudiocodeShellTelnet,
+)
 from netmiko.brocade import BrocadeFOSSSH
 from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
@@ -72,13 +80,18 @@ from netmiko.juniper import JuniperSSH, JuniperTelnet, JuniperScreenOsSSH
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.keymile import KeymileSSH, KeymileNOSSSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
-from netmiko.mikrotik import MikrotikRouterOsSSH
+from netmiko.mikrotik import MikrotikRouterOsSSH, MikrotikRouterOsFileTransfer
 from netmiko.mikrotik import MikrotikSwitchOsSSH
 from netmiko.mellanox import MellanoxMlnxosSSH
 from netmiko.mrv import MrvLxSSH
 from netmiko.mrv import MrvOptiswitchSSH
 from netmiko.netapp import NetAppcDotSSH
-from netmiko.nokia import NokiaSrosSSH, NokiaSrosFileTransfer, NokiaSrosTelnet
+from netmiko.nokia import (
+    NokiaSrosSSH,
+    NokiaSrosFileTransfer,
+    NokiaSrosTelnet,
+    NokiaSrlSSH,
+)
 from netmiko.netgear import NetgearProSafeSSH
 from netmiko.oneaccess import OneaccessOneOSTelnet, OneaccessOneOSSSH
 from netmiko.ovs import OvsLinuxSSH
@@ -133,6 +146,9 @@ CLASS_MAPPER_BASE = {
     "aruba_os": ArubaSSH,
     "aruba_osswitch": HPProcurveSSH,
     "aruba_procurve": HPProcurveSSH,
+    "audiocode_72": Audiocode72SSH,
+    "audiocode_66": Audiocode66SSH,
+    "audiocode_shell": AudiocodeShellSSH,
     "avaya_ers": ExtremeErsSSH,
     "avaya_vsp": ExtremeVspSSH,
     "broadcom_icos": BroadcomIcosSSH,
@@ -213,6 +229,7 @@ CLASS_MAPPER_BASE = {
     "netgear_prosafe": NetgearProSafeSSH,
     "netscaler": NetscalerSSH,
     "nokia_sros": NokiaSrosSSH,
+    "nokia_srl": NokiaSrlSSH,
     "oneaccess_oneos": OneaccessOneOSSSH,
     "ovs_linux": OvsLinuxSSH,
     "paloalto_panos": PaloAltoPanosSSH,
@@ -251,6 +268,7 @@ FILE_TRANSFER_MAP = {
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,
     "nokia_sros": NokiaSrosFileTransfer,
+    "mikrotik_routeros": MikrotikRouterOsFileTransfer,
 }
 
 # Also support keys that end in _ssh
@@ -273,6 +291,9 @@ CLASS_MAPPER["adtran_os_telnet"] = AdtranOSTelnet
 CLASS_MAPPER["apresia_aeos_telnet"] = ApresiaAeosTelnet
 CLASS_MAPPER["arista_eos_telnet"] = AristaTelnet
 CLASS_MAPPER["aruba_procurve_telnet"] = HPProcurveTelnet
+CLASS_MAPPER["audiocode_72_telnet"] = Audiocode72Telnet
+CLASS_MAPPER["audiocode_66_telnet"] = Audiocode66Telnet
+CLASS_MAPPER["audiocode_shell_telnet"] = AudiocodeShellTelnet
 CLASS_MAPPER["brocade_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["brocade_netiron_telnet"] = ExtremeNetironTelnet
 CLASS_MAPPER["calix_b6_telnet"] = CalixB6Telnet

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -6,20 +6,13 @@ from netmiko.exceptions import NetmikoTimeoutException, NetmikoAuthenticationExc
 from netmiko.a10 import A10SSH
 from netmiko.accedian import AccedianSSH
 from netmiko.adtran import AdtranOSSSH, AdtranOSTelnet
+from netmiko.adva import AdvaAosFsp150f3SSH, AdvaAosFsp150f2SSH
 from netmiko.alcatel import AlcatelAosSSH
 from netmiko.allied_telesis import AlliedTelesisAwplusSSH
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
-from netmiko.audiocode import (
-    Audiocode72SSH,
-    Audiocode66SSH,
-    AudiocodeShellSSH,
-    Audiocode72Telnet,
-    Audiocode66Telnet,
-    AudiocodeShellTelnet,
-)
 from netmiko.brocade import BrocadeFOSSSH
 from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
@@ -79,18 +72,13 @@ from netmiko.juniper import JuniperSSH, JuniperTelnet, JuniperScreenOsSSH
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.keymile import KeymileSSH, KeymileNOSSSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
-from netmiko.mikrotik import MikrotikRouterOsSSH, MikrotikRouterOsFileTransfer
+from netmiko.mikrotik import MikrotikRouterOsSSH
 from netmiko.mikrotik import MikrotikSwitchOsSSH
 from netmiko.mellanox import MellanoxMlnxosSSH
 from netmiko.mrv import MrvLxSSH
 from netmiko.mrv import MrvOptiswitchSSH
 from netmiko.netapp import NetAppcDotSSH
-from netmiko.nokia import (
-    NokiaSrosSSH,
-    NokiaSrosFileTransfer,
-    NokiaSrosTelnet,
-    NokiaSrlSSH,
-)
+from netmiko.nokia import NokiaSrosSSH, NokiaSrosFileTransfer, NokiaSrosTelnet
 from netmiko.netgear import NetgearProSafeSSH
 from netmiko.oneaccess import OneaccessOneOSTelnet, OneaccessOneOSSSH
 from netmiko.ovs import OvsLinuxSSH
@@ -135,6 +123,8 @@ CLASS_MAPPER_BASE = {
     "a10": A10SSH,
     "accedian": AccedianSSH,
     "adtran_os": AdtranOSSSH,
+    "adva_aos_fsp150_f3": AdvaAosFsp150f3SSH,
+    "adva_aos_fsp150_f2": AdvaAosFsp150f2SSH,
     "alcatel_aos": AlcatelAosSSH,
     "alcatel_sros": NokiaSrosSSH,
     "allied_telesis_awplus": AlliedTelesisAwplusSSH,
@@ -143,9 +133,6 @@ CLASS_MAPPER_BASE = {
     "aruba_os": ArubaSSH,
     "aruba_osswitch": HPProcurveSSH,
     "aruba_procurve": HPProcurveSSH,
-    "audiocode_72": Audiocode72SSH,
-    "audiocode_66": Audiocode66SSH,
-    "audiocode_shell": AudiocodeShellSSH,
     "avaya_ers": ExtremeErsSSH,
     "avaya_vsp": ExtremeVspSSH,
     "broadcom_icos": BroadcomIcosSSH,
@@ -226,7 +213,6 @@ CLASS_MAPPER_BASE = {
     "netgear_prosafe": NetgearProSafeSSH,
     "netscaler": NetscalerSSH,
     "nokia_sros": NokiaSrosSSH,
-    "nokia_srl": NokiaSrlSSH,
     "oneaccess_oneos": OneaccessOneOSSSH,
     "ovs_linux": OvsLinuxSSH,
     "paloalto_panos": PaloAltoPanosSSH,
@@ -265,7 +251,6 @@ FILE_TRANSFER_MAP = {
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,
     "nokia_sros": NokiaSrosFileTransfer,
-    "mikrotik_routeros": MikrotikRouterOsFileTransfer,
 }
 
 # Also support keys that end in _ssh
@@ -288,9 +273,6 @@ CLASS_MAPPER["adtran_os_telnet"] = AdtranOSTelnet
 CLASS_MAPPER["apresia_aeos_telnet"] = ApresiaAeosTelnet
 CLASS_MAPPER["arista_eos_telnet"] = AristaTelnet
 CLASS_MAPPER["aruba_procurve_telnet"] = HPProcurveTelnet
-CLASS_MAPPER["audiocode_72_telnet"] = Audiocode72Telnet
-CLASS_MAPPER["audiocode_66_telnet"] = Audiocode66Telnet
-CLASS_MAPPER["audiocode_shell_telnet"] = AudiocodeShellTelnet
 CLASS_MAPPER["brocade_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["brocade_netiron_telnet"] = ExtremeNetironTelnet
 CLASS_MAPPER["calix_b6_telnet"] = CalixB6Telnet

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -138,6 +138,8 @@ CLASS_MAPPER_BASE = {
     "adtran_os": AdtranOSSSH,
     "adva_aos_fsp150_f3": AdvaAosFsp150f3SSH,
     "adva_aos_fsp150_f2": AdvaAosFsp150f2SSH,
+    "adva": AdvaAosFsp150f2SSH,
+    "adva_ge114": AdvaAosFsp150f3SSH, 
     "alcatel_aos": AlcatelAosSSH,
     "alcatel_sros": NokiaSrosSSH,
     "allied_telesis_awplus": AlliedTelesisAwplusSSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -138,8 +138,6 @@ CLASS_MAPPER_BASE = {
     "adtran_os": AdtranOSSSH,
     "adva_aos_fsp150_f3": AdvaAosFsp150f3SSH,
     "adva_aos_fsp150_f2": AdvaAosFsp150f2SSH,
-    "adva": AdvaAosFsp150f2SSH,
-    "adva_ge114": AdvaAosFsp150f3SSH, 
     "alcatel_aos": AlcatelAosSSH,
     "alcatel_sros": NokiaSrosSSH,
     "allied_telesis_awplus": AlliedTelesisAwplusSSH,

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def find_version(*file_paths):
 
 
 setup(
-    name="netmiko",
+    name="netmiko-bti-4-1-1",
     version=find_version("netmiko", "__init__.py"),
-    description="Multi-vendor library to simplify legacy CLI connections to network devices",
+    description="Multi-vendor library to simplify legacy CLI connections to network devices (BT Ireland Customised)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ktbyers/netmiko",

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def find_version(*file_paths):
 
 
 setup(
-    name="netmiko-bti-4-1-1",
+    name="netmiko",
     version=find_version("netmiko", "__init__.py"),
-    description="Multi-vendor library to simplify legacy CLI connections to network devices (BT Ireland Customised)",
+    description="Multi-vendor library to simplify legacy CLI connections to network devices",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ktbyers/netmiko",


### PR DESCRIPTION
Opening a pull request to add Driver support for the Adva F3 and Adva F2 devices.

Test configuration not included in the branch, but output of test results below. Added some specific Adva tests. Can update the branch with the test information if required.

If you need anything else let me know.

Cheers,

Guy

(netmiko_test) [guych@spiderbaby test_adva]$ ./adva_tests.sh
Starting tests...good luck:
Adva F3
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/guych/virt_envs/netmiko_test/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/guych/projects_python/netmiko-bti-4-1-0, configfile: setup.cfg
plugins: pylama-7.7.1
collected 32 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_terminal_width PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED
test_netmiko_show.py::test_send_command PASSED
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)
test_netmiko_show.py::test_send_multiline_timing SKIPPED
test_netmiko_show.py::test_send_multiline_timing_adva_f3 PASSED
test_netmiko_show.py::test_send_multiline_adva_f3 PASSED
test_netmiko_show.py::test_send_multiline_prompt_adva_f3 PASSED
test_netmiko_show.py::test_send_multiline_simple_adva_f3 PASSED
test_netmiko_show.py::test_send_multiline_timing_adva_f2 SKIPPED
test_netmiko_show.py::test_send_multiline_adva_f2 SKIPPED
test_netmiko_show.py::test_send_multiline_prompt_adva_f2 SKIPPED
test_netmiko_show.py::test_send_multiline_simple_adva_f2 SKIPPED
test_netmiko_show.py::test_send_multiline SKIPPED
test_netmiko_show.py::test_send_multiline_prompt SKIPPED
test_netmiko_show.py::test_send_multiline_simple SKIPPED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED
test_netmiko_show.py::test_disconnect_no_enable SKIPPED

=============================================================================== short test summary info ================================================================================
SKIPPED [1] test_netmiko_show.py:70: Skipped
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:110: Skipped
SKIPPED [1] test_netmiko_show.py:131: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:153: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:193: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:213: Skipped
SKIPPED [1] test_netmiko_show.py:301: Skipped
SKIPPED [1] test_netmiko_show.py:316: Skipped
SKIPPED [1] test_netmiko_show.py:332: Skipped
SKIPPED [1] test_netmiko_show.py:352: Skipped
SKIPPED [1] test_netmiko_show.py:374: Skipped
SKIPPED [1] test_netmiko_show.py:399: Skipped
SKIPPED [1] test_netmiko_show.py:423: Skipped
SKIPPED [1] test_netmiko_show.py:525: Skipped
=========================================================================== 17 passed, 15 skipped in 50.66s ============================================================================
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/guych/virt_envs/netmiko_test/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/guych/projects_python/netmiko-bti-4-1-0, configfile: setup.cfg
plugins: pylama-7.7.1
collected 12 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode SKIPPED (Platform doesn't support config mode.)
test_netmiko_config.py::test_exit_config_mode SKIPPED (Platform doesn't support config mode.)
test_netmiko_config.py::test_config_set PASSED
test_netmiko_config.py::test_config_set_longcommand PASSED
test_netmiko_config.py::test_config_hostname PASSED
test_netmiko_config.py::test_config_from_file PASSED
test_netmiko_config.py::test_config_error_pattern PASSED
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)
test_netmiko_config.py::test_disconnect PASSED

=============================================================================== short test summary info ================================================================================
SKIPPED [1] test_netmiko_config.py:39: Platform doesn't support config mode.
SKIPPED [1] test_netmiko_config.py:48: Platform doesn't support config mode.
SKIPPED [1] test_netmiko_config.py:164: No banner defined.
SKIPPED [1] test_netmiko_config.py:197: No banner defined.
============================================================================ 8 passed, 4 skipped in 45.17s =============================================================================
Adva F2
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/guych/virt_envs/netmiko_test/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/guych/projects_python/netmiko-bti-4-1-0, configfile: setup.cfg
plugins: pylama-7.7.1
collected 32 items

test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_terminal_width PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED
test_netmiko_show.py::test_send_command PASSED
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)
test_netmiko_show.py::test_send_multiline_timing SKIPPED
test_netmiko_show.py::test_send_multiline_timing_adva_f3 SKIPPED
test_netmiko_show.py::test_send_multiline_adva_f3 SKIPPED
test_netmiko_show.py::test_send_multiline_prompt_adva_f3 SKIPPED
test_netmiko_show.py::test_send_multiline_simple_adva_f3 SKIPPED
test_netmiko_show.py::test_send_multiline_timing_adva_f2 PASSED
test_netmiko_show.py::test_send_multiline_adva_f2 PASSED
test_netmiko_show.py::test_send_multiline_prompt_adva_f2 PASSED
test_netmiko_show.py::test_send_multiline_simple_adva_f2 PASSED
test_netmiko_show.py::test_send_multiline SKIPPED
test_netmiko_show.py::test_send_multiline_prompt SKIPPED
test_netmiko_show.py::test_send_multiline_simple SKIPPED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED
test_netmiko_show.py::test_disconnect_no_enable SKIPPED

=============================================================================== short test summary info ================================================================================
SKIPPED [1] test_netmiko_show.py:70: Skipped
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:110: Skipped
SKIPPED [1] test_netmiko_show.py:131: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:153: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:193: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:213: Skipped
SKIPPED [1] test_netmiko_show.py:226: Skipped
SKIPPED [1] test_netmiko_show.py:245: Skipped
SKIPPED [1] test_netmiko_show.py:262: Skipped
SKIPPED [1] test_netmiko_show.py:282: Skipped
SKIPPED [1] test_netmiko_show.py:374: Skipped
SKIPPED [1] test_netmiko_show.py:399: Skipped
SKIPPED [1] test_netmiko_show.py:423: Skipped
SKIPPED [1] test_netmiko_show.py:525: Skipped
=========================================================================== 17 passed, 15 skipped in 30.45s ============================================================================
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/guych/virt_envs/netmiko_test/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/guych/projects_python/netmiko-bti-4-1-0, configfile: setup.cfg
plugins: pylama-7.7.1
collected 12 items

test_netmiko_config.py::test_ssh_connect PASSED
test_netmiko_config.py::test_enable_mode PASSED
test_netmiko_config.py::test_config_mode SKIPPED (Platform doesn't support config mode.)
test_netmiko_config.py::test_exit_config_mode SKIPPED (Platform doesn't support config mode.)
test_netmiko_config.py::test_config_set PASSED
test_netmiko_config.py::test_config_set_longcommand PASSED
test_netmiko_config.py::test_config_hostname PASSED
test_netmiko_config.py::test_config_from_file PASSED
test_netmiko_config.py::test_config_error_pattern PASSED
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)
test_netmiko_config.py::test_disconnect PASSED

=============================================================================== short test summary info ================================================================================
SKIPPED [1] test_netmiko_config.py:39: Platform doesn't support config mode.
SKIPPED [1] test_netmiko_config.py:48: Platform doesn't support config mode.
SKIPPED [1] test_netmiko_config.py:164: No banner defined.
SKIPPED [1] test_netmiko_config.py:197: No banner defined.
============================================================================ 8 passed, 4 skipped in 19.02s ============================================================================
