### PR TITLE
Add FortiAnalyzer compatibility

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -27,7 +27,7 @@ class FortinetSSH(NoConfig, CiscoSSHConnection):
             self.write_channel("a\r")
             self._test_channel_read(pattern=r"[#$]")
 
-        self.set_base_prompt(alt_prompt_terminator="$")
+        self.set_base_prompt(alt_prompt_terminator="$", alt_prompt_terminator2=">")
         self.disable_paging()
 
     def disable_paging(

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -20,14 +20,14 @@ class FortinetSSH(NoConfig, CiscoSSHConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
 
-        data = self._test_channel_read(pattern="to accept|[#$]")
+        data = self._test_channel_read(pattern="to accept|[>#$]")
         # If "set post-login-banner enable" is set it will require you to press 'a'
         # to accept the banner before you login. This will accept if it occurs
         if "to accept" in data:
             self.write_channel("a\r")
-            self._test_channel_read(pattern=r"[#$]")
+            self._test_channel_read(pattern=r"[>#$]")
 
-        self.set_base_prompt(alt_prompt_terminator="$", alt_prompt_terminator2=">")
+        self.set_base_prompt()
         self.disable_paging()
 
     def disable_paging(


### PR DESCRIPTION
FortiAnalyzer CLI use '>' as prompt, but actual pattern doesn't read it.

Example of FortiAnalyzer CLI : 
```
> get system status
System:
        Version:              FACVM v6.2.1-build0552,201030 (GA)
        Branch point:         0552
        Architecture:         64-bit
        Serial number:        FAC-VMTM21006510
        System time:          Thu Aug 11 18:29:39 2022 up 169 days,  2:14
        Disk Usage:           0 GB
        Disk Size:            57 GB

HA Status:
        Enabled:              No
        Node Type:
        Role:                 Disabled
        Status:               Disabled
        Cluster size:
        Heartbeat interface:
        Priority:
        Node-Specific Gateway:
        Peer:
>
```