### PR TITLE
Fix Huawei telnet ReadException: Unable to successfully split output based on pattern

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -128,7 +128,7 @@ class HuaweiTelnet(HuaweiBase):
         """Telnet login for Huawei Devices"""
 
         delay_factor = self.select_delay_factor(delay_factor)
-        password_change_prompt = r"(Change now|Please choose 'YES' or 'NO').+"
+        password_change_prompt = r"(?:Change now|Please choose 'YES' or 'NO').+"
         combined_pattern = r"({}|{}|{})".format(
             pri_prompt_terminator, alt_prompt_terminator, password_change_prompt
         )


### PR DESCRIPTION
This PR fixes #2711

#### Root cause:
Unexpected nested group in regex pattern "combined_pattern".
For details please see: https://github.com/ktbyers/netmiko/issues/2711#issuecomment-1231032715.
#### Solution:
Change `password_change_prompt` regex group to non-capturing group. This change avoids nested group in `combined_pattern`, that solves the root cause. Actually nested group still presents in `combined_pattern`, but since this group is a non-capturing group, this solves the issue.
#### Side effects (not detected):
 - Below in code, `password_change_prompt` used in `re.search(password_change_prompt, output)` statement. I've tested that changing group to non-capturing group do not affect the `re.search` statement.
 - Suppose `password_change_prompt` will need to be passed inside the `read_until_pattern` method in future. In this case it also will not be a problem, because non-capturing group will be wrapped with parentheses which will change non-capturing group back to regular group, see line `pattern = f"({pattern})"`:
```python
                # The string matched by pattern must be retained in the output string.
                # re.split will do this if capturing parenthesis are used.
                if len(results) == 2:
                    # no capturing parenthesis, convert and try again.
                    pattern = f"({pattern})"
                    results = re.split(pattern, output, maxsplit=1, flags=re_flags)
```
 - I've tested changes on about 1000 different huawei devices - it works good.

P.S. @ktbyers thank you for non-capturing group idea :+1: 