### PR TITLE
Added support for Arris CER and Casa CMTS platforms.

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -65,8 +65,10 @@
 - Accedian
 - Allied Telesis AlliedWare Plus
 - Aruba
+- Arris CER
 - Brocade Fabric OS
 - C-DOT CROS
+- Casa CMTS
 - Ciena SAOS
 - Citrix Netscaler
 - Cisco Telepresence
@@ -108,6 +110,7 @@
 - allied_telesis_awplus
 - apresia_aeos
 - arista_eos
+- arris_cer
 - aruba_os
 - aruba_osswitch
 - aruba_procurve
@@ -121,6 +124,7 @@
 - brocade_vdx
 - brocade_vyos
 - calix_b6
+- casa_cmts
 - cdot_cros
 - centec_os
 - checkpoint_gaia

--- a/netmiko/arris/__init__.py
+++ b/netmiko/arris/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.arris.arris_cer import ArrisCERBase, ArrisCERSSH
+
+__all__ = ["ArrisCERBase", "ArrisCERSSH"]

--- a/netmiko/arris/arris_cer.py
+++ b/netmiko/arris/arris_cer.py
@@ -1,0 +1,39 @@
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class ArrisCERBase(CiscoSSHConnection):
+    """
+    Arris CER Support.
+
+    Implements methods for interacting with Arris CER platforms.
+    """
+
+    def config_mode(
+        self,
+        config_command: str = "configure",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        """Enters configuration mode."""
+        return super().config_mode(
+            config_command=config_command,
+            pattern=pattern,
+            re_flags=re_flags,
+        )
+
+    def save_config(
+        self,
+        cmd: str = "write memory",
+        confirm: bool = False,
+        confirm_response: str = "",
+    ) -> str:
+        """Saves the running configuration to NVRAM."""
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+
+class ArrisCERSSH(ArrisCERBase):
+    """Arris CER SSH Driver."""
+
+    pass

--- a/netmiko/casa/__init__.py
+++ b/netmiko/casa/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.casa.casa_cmts import CasaCMTSBase, CasaCMTSSSH
+
+__all__ = ["CasaCMTSBase", "CasaCMTSSSH"]

--- a/netmiko/casa/casa_cmts.py
+++ b/netmiko/casa/casa_cmts.py
@@ -1,0 +1,45 @@
+from typing import Optional
+from netmiko.cisco_base_connection import CiscoSSHConnection
+from netmiko.no_enable import NoEnable
+
+
+class CasaCMTSBase(NoEnable, CiscoSSHConnection):
+    """
+    Casa CMTS support.
+
+    Implements methods for interacting with Casa CMTS platforms.
+    """
+
+    def disable_paging(
+        self,
+        command: str = "page-off",
+        delay_factor: Optional[float] = None,
+        cmd_verify: bool = True,
+        pattern: Optional[str] = None,
+    ) -> str:
+        """Disables paging."""
+        return super().disable_paging(
+            command=command,
+            delay_factor=delay_factor,
+            cmd_verify=cmd_verify,
+            pattern=pattern,
+        )
+
+    def config_mode(
+        self,
+        config_command: str = "config",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        """Enters configuration mode."""
+        return super().config_mode(
+            config_command=config_command,
+            pattern=pattern,
+            re_flags=re_flags,
+        )
+
+
+class CasaCMTSSSH(CasaCMTSBase):
+    """Casa CMTS SSH Driver."""
+
+    pass

--- a/netmiko/casa/casa_cmts.py
+++ b/netmiko/casa/casa_cmts.py
@@ -38,6 +38,28 @@ class CasaCMTSBase(NoEnable, CiscoSSHConnection):
             re_flags=re_flags,
         )
 
+    def exit_config_mode(
+        self, exit_config: str = chr(26), pattern: str = r"#.*"
+    ) -> str:
+        """
+        Exits configuration mode.
+
+        Must use CTRL-Z (ASCII 26) to reliably exit from any
+        tier in the configuration hierarchy.
+
+        Since CTRL-Z is a non-printable character, we must temporarily disable
+        global_cmd_verify to prevent an exception trying to read the
+        echoed input.
+        """
+        if self.global_cmd_verify is not False and exit_config == chr(26):
+            global_cmd_verify_tmp = self.global_cmd_verify
+            self.global_cmd_verify = False
+            output = super().exit_config_mode(exit_config, pattern)
+            self.global_cmd_verify = global_cmd_verify_tmp
+        else:
+            output = super().exit_config_mode(exit_config, pattern)
+        return output
+
 
 class CasaCMTSSSH(CasaCMTSBase):
     """Casa CMTS SSH Driver."""

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -76,6 +76,18 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "arris_cer": {
+        "cmd": "show version",
+        "search_patterns": [r"CER"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "casa_cmts": {
+        "cmd": "show version",
+        "search_patterns": [r"Casa"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "ciena_saos": {
         "cmd": "software show",
         "search_patterns": [r"saos"],

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -10,6 +10,7 @@ from netmiko.alcatel import AlcatelAosSSH
 from netmiko.allied_telesis import AlliedTelesisAwplusSSH
 from netmiko.arista import AristaSSH, AristaTelnet
 from netmiko.arista import AristaFileTransfer
+from netmiko.arris import ArrisCERSSH
 from netmiko.apresia import ApresiaAeosSSH, ApresiaAeosTelnet
 from netmiko.aruba import ArubaSSH
 from netmiko.audiocode import (
@@ -23,6 +24,7 @@ from netmiko.audiocode import (
 from netmiko.brocade import BrocadeFOSSSH
 from netmiko.broadcom import BroadcomIcosSSH
 from netmiko.calix import CalixB6SSH, CalixB6Telnet
+from netmiko.casa import CasaCMTSSSH
 from netmiko.cdot import CdotCrosSSH
 from netmiko.centec import CentecOSSSH, CentecOSTelnet
 from netmiko.checkpoint import CheckPointGaiaSSH
@@ -140,6 +142,7 @@ CLASS_MAPPER_BASE = {
     "allied_telesis_awplus": AlliedTelesisAwplusSSH,
     "apresia_aeos": ApresiaAeosSSH,
     "arista_eos": AristaSSH,
+    "arris_cer": ArrisCERSSH,
     "aruba_os": ArubaSSH,
     "aruba_osswitch": HPProcurveSSH,
     "aruba_procurve": HPProcurveSSH,
@@ -157,6 +160,7 @@ CLASS_MAPPER_BASE = {
     "brocade_vyos": VyOSSSH,
     "checkpoint_gaia": CheckPointGaiaSSH,
     "calix_b6": CalixB6SSH,
+    "casa_cmts": CasaCMTSSSH,
     "cdot_cros": CdotCrosSSH,
     "centec_os": CentecOSSSH,
     "ciena_saos": CienaSaosSSH,


### PR DESCRIPTION
Greetings, 

Looking to add support for Arris and Casa CMTS platforms. Please let me know if you have any feedback. 

Test results (arris_cer):
`(venv) PS C:\Users\VangesselD\PycharmProjects\netmiko\tests> py.test -v test_netmiko_show.py --test_device arris_cer
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- C:\Users\VangesselD\PycharmProjects\netmiko\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\VangesselD\PycharmProjects\netmiko, configfile: setup.cfg
plugins: pylama-8.3.8
collected 25 items

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                                                                               [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                                                 [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                                                 [ 12%] 
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                                                    [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                                                 [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                                            [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                                                                             [ 28%] 
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                                                   [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                                                                                    [ 36%] 
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                                                    [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                                                                                   [ 44%] 
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                                                                                [ 48%] 
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                                                                                     [ 52%] 
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                                                                                         [ 56%] 
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                                                                                [ 60%] 
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                                                                                         [ 64%] 
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                                                                                         [ 68%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                                                    [ 72%] 
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                                                   [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                                                  [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                                            [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                                                   [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                                                    [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                                                     [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                                                                                          [100%]

======================================================================================================= short test summary info ======================================================================================================= 
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
=================================================================================================== 13 passed, 12 skipped in 35.10s =================================================================================================== 
(venv) PS C:\Users\VangesselD\PycharmProjects\netmiko\tests> py.test -v test_netmiko_config.py --test_device arris_cer
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- C:\Users\VangesselD\PycharmProjects\netmiko\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\VangesselD\PycharmProjects\netmiko, configfile: setup.cfg
plugins: pylama-8.3.8
collected 13 items

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                                                  [  7%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                                                  [ 15%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                                                  [ 23%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                                             [ 30%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                                                   [ 38%]
test_netmiko_config.py::test_config_set_generator PASSED                                                                                                                                                                         [ 46%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                                                       [ 53%] 
test_netmiko_config.py::test_config_from_file SKIPPED                                                                                                                                                                            [ 69%] 
test_netmiko_config.py::test_config_error_pattern SKIPPED (No error_pattern defined.)                                                                                                                                            [ 76%] 
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)                                                                                                                                                                 [ 84%] 
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)                                                                                                                                                      [ 92%] 
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                                                   [100%] 

======================================================================================================= short test summary info ======================================================================================================= 
SKIPPED [1] test_netmiko_config.py:163: Skipped
SKIPPED [1] test_netmiko_config.py:175: No error_pattern defined.
SKIPPED [1] test_netmiko_config.py:209: No banner defined.
SKIPPED [1] test_netmiko_config.py:242: No banner defined.
==================================================================================================== 9 passed, 4 skipped in 56.38s ==================================================================================================== `

Test results (casa_cmts):
`(venv) PS C:\Users\VangesselD\PycharmProjects\netmiko\tests> py.test -v test_netmiko_show.py --test_device casa_cmts
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- C:\Users\VangesselD\PycharmProjects\netmiko\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\VangesselD\PycharmProjects\netmiko, configfile: setup.cfg
plugins: pylama-8.3.8
collected 25 items

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                                                                               [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                                                 [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                                                 [ 12%] 
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                                                    [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                                                 [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                                            [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                                                                             [ 28%] 
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                                                   [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                                                                                    [ 36%] 
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                                                    [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                                                                                   [ 44%] 
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                                                                                [ 48%] 
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                                                                                     [ 52%] 
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                                                                                         [ 56%] 
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                                                                                [ 60%] 
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                                                                                         [ 64%] 
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                                                                                         [ 68%] 
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                                                    [ 72%] 
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                                                   [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                                                  [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                                            [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                                                   [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                                                    [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                                                     [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                                                                                          [100%]

======================================================================================================= short test summary info ======================================================================================================= 
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
=================================================================================================== 13 passed, 12 skipped in 46.15s =================================================================================================== 
(venv) PS C:\Users\VangesselD\PycharmProjects\netmiko\tests> py.test -v test_netmiko_config.py --test_device casa_cmts
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- C:\Users\VangesselD\PycharmProjects\netmiko\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\VangesselD\PycharmProjects\netmiko, configfile: setup.cfg
plugins: pylama-8.3.8
collected 13 items                                                                                                                                                                                                                      

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                                                  [  7%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                                                  [ 15%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                                                  [ 23%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                                             [ 30%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                                                   [ 38%]
test_netmiko_config.py::test_config_set_generator PASSED                                                                                                                                                                         [ 46%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                                                       [ 53%] 
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                                                                              [ 61%] 
test_netmiko_config.py::test_config_from_file SKIPPED                                                                                                                                                                            [ 69%] 
test_netmiko_config.py::test_config_error_pattern SKIPPED (No error_pattern defined.)                                                                                                                                            [ 76%] 
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)                                                                                                                                                                 [ 84%] 
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)                                                                                                                                                      [ 92%] 
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                                                   [100%]

======================================================================================================= short test summary info ======================================================================================================= 
SKIPPED [1] test_netmiko_config.py:163: Skipped
SKIPPED [1] test_netmiko_config.py:175: No error_pattern defined.
SKIPPED [1] test_netmiko_config.py:209: No banner defined.
SKIPPED [1] test_netmiko_config.py:242: No banner defined.
==================================================================================================== 9 passed, 4 skipped in 59.90s ==================================================================================================== `

Thank you!