### PR TITLE
Huawei - allow vrp versions < 8

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -212,6 +212,7 @@ CLASS_MAPPER_BASE = {
     "huawei": HuaweiSSH,
     "huawei_smartax": HuaweiSmartAXSSH,
     "huawei_olt": HuaweiSmartAXSSH,
+    "huawei_vrp": HuaweiSSH,
     "huawei_vrpv8": HuaweiVrpv8SSH,
     "ipinfusion_ocnos": IpInfusionOcNOSSSH,
     "juniper": JuniperSSH,


### PR DESCRIPTION
Hi @ktbyers 

Not sure how best you want to handle this case.
We are working with a huawei vrp V5. If we reference just `huawei` as the `device_type`, we obtain the right netmiko connection class. However no NTC templates parsing will be done as NTC expect `huawei_vrp`. 
If we use `huawei_vrpv8`, we obtain the parsing we want from NTC, however the netmiko connection class is wrong. There are some pretty big differences like in the send_config_set: there is a `save` but there are no `commit` (like in the HuaweiSSH class).

So here a suggestion of fix that would not involve a breaking change. 