### PR TITLE
Huawei - Manage prompt for secure the configuration

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -151,6 +151,16 @@ class HuaweiSSH(HuaweiBase):
             self.write_channel("N" + self.RETURN)
             self.read_until_pattern(pattern=self.prompt_pattern)
 
+        # Huawei prompts for secure the configuration before displaying the initial base prompt.
+        if re.search(
+            r"security\srisks\sin\sthe\sconfiguration\sfile.*\?\s*\[[Yy]\/[nN]\]", data
+        ):
+            self.send_command("Y", expect_string=r"continue\?\s*\[[Yy]\/[nN]\]")
+            self.send_command(
+                "Y", expect_string=r"saved\ssuccessfully", read_timeout=60
+            )
+            self.read_until_pattern(pattern=self.prompt_pattern)
+
 
 class HuaweiTelnet(HuaweiBase):
     """Huawei Telnet driver."""


### PR DESCRIPTION
Huawei - Allow to secure the current configuration after loggin


Example of router result:
```
 Warning: There are security risks in the configuration file. You are advised to save the configuration immediately. If you choose to save, the current configuration file will be unavailable after version downgrade. Are you sure to save now?[Y/N]: Y
 Warning: The current configuration will be written to the device. 
 Are you sure to continue?[Y/N]: Y
  It will take several minutes to save configuration file, please wait...........
  Configuration file had been saved successfully
  Note: The configuration file will take effect after being activated
<Huawei>
```