### PR TITLE
Update ssh_autodetect.py

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -243,7 +243,7 @@ SSH_MAPPER_DICT = {
     "cisco_wlc_85": {
         "cmd": "show inventory",
         "dispatch": "_autodetect_std",
-        "search_patterns": [r"Cisco.*Wireless Controller"],
+        "search_patterns": [r"Cisco.*Wireless.*Controller"],
         "priority": 99,
     },
     "mellanox_mlnxos": {


### PR DESCRIPTION
Newer IOS versions will display "Wireless LAN Controller" instead of "Wireless Controller". Example: 
(WLC) >show inventory
Burned-in MAC Address............................ REMOVED Maximum number of APs supported.................. 150
NAME: "Chassis"    , DESCR: "Cisco 3500 Series Wireless LAN Controller"
PID: AIR-CT3504-K9,  VID: V02,  SN: REMOVED