### PR TITLE
 IPV6 support for SNMPDetect(#3027) 

### DIFF
--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -20,6 +20,7 @@ SNMPDetect class defaults to SNMPv3
 Note, pysnmp is a required dependency for SNMPDetect and is intentionally not included in
 netmiko requirements. So installation of pysnmp might be required.
 """
+import ipaddress
 from typing import Optional, Dict
 from typing.re import Pattern
 import re
@@ -237,6 +238,12 @@ class SNMPDetect(object):
         self.auth_proto = self._snmp_v3_authentication[auth_proto]
         self.encryp_proto = self._snmp_v3_encryption[encrypt_proto]
         self._response_cache: Dict[str, str] = {}
+        self.snmp_target = (self.hostname, self.snmp_port)
+
+        if ipaddress.ip_address(self.hostname).version == 6:
+            self.udp_transport_target=cmdgen.Udp6TransportTarget(self.snmp_target, timeout=1.5, retries=2)
+        else:
+            self.udp_transport_target=cmdgen.UdpTransportTarget(self.snmp_target, timeout=1.5, retries=2)
 
     def _get_snmpv3(self, oid: str) -> str:
         """
@@ -252,7 +259,6 @@ class SNMPDetect(object):
         string : str
             The string as part of the value from the OID you are trying to retrieve.
         """
-        snmp_target = (self.hostname, self.snmp_port)
         cmd_gen = cmdgen.CommandGenerator()
 
         (error_detected, error_status, error_index, snmp_data) = cmd_gen.getCmd(
@@ -263,7 +269,7 @@ class SNMPDetect(object):
                 authProtocol=self.auth_proto,
                 privProtocol=self.encryp_proto,
             ),
-            cmdgen.UdpTransportTarget(snmp_target, timeout=1.5, retries=2),
+            self.udp_transport_target,
             oid,
             lookupNames=True,
             lookupValues=True,
@@ -287,12 +293,11 @@ class SNMPDetect(object):
         string : str
             The string as part of the value from the OID you are trying to retrieve.
         """
-        snmp_target = (self.hostname, self.snmp_port)
         cmd_gen = cmdgen.CommandGenerator()
 
         (error_detected, error_status, error_index, snmp_data) = cmd_gen.getCmd(
             cmdgen.CommunityData(self.community),
-            cmdgen.UdpTransportTarget(snmp_target, timeout=1.5, retries=2),
+            self.udp_transport_target,
             oid,
             lookupNames=True,
             lookupValues=True,

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -241,9 +241,13 @@ class SNMPDetect(object):
         self.snmp_target = (self.hostname, self.snmp_port)
 
         if ipaddress.ip_address(self.hostname).version == 6:
-            self.udp_transport_target=cmdgen.Udp6TransportTarget(self.snmp_target, timeout=1.5, retries=2)
+            self.udp_transport_target = cmdgen.Udp6TransportTarget(
+                self.snmp_target, timeout=1.5, retries=2
+            )
         else:
-            self.udp_transport_target=cmdgen.UdpTransportTarget(self.snmp_target, timeout=1.5, retries=2)
+            self.udp_transport_target = cmdgen.UdpTransportTarget(
+                self.snmp_target, timeout=1.5, retries=2
+            )
 
     def _get_snmpv3(self, oid: str) -> str:
         """


### PR DESCRIPTION
Hi Team!
Adding usage of Udp6TransportTarget when the device hostname is IPv6 as mentioned in issue #3027.
It felt cleaner to do it in the init rather than in the _get_snmpv2c and _get_snmpv3 functions.
Tested on a few hundred of devices without issue.
I don't see any test for SNMPDetect, should I prepare any?
Kindly,