### PR TITLE
Snmpdetect fix cisco_ios detection and add routeros

### DIFF
--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -56,7 +56,7 @@ SNMP_MAPPER_BASE = {
     },
     "cisco_ios": {
         "oid": ".1.3.6.1.2.1.1.1.0",
-        "expr": re.compile(r".*Cisco IOS Software,.*", re.IGNORECASE),
+        "expr": re.compile(r".*Cisco IOS Software.*,.*", re.IGNORECASE),
         "priority": 60,
     },
     "cisco_xe": {

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -116,7 +116,7 @@ SNMP_MAPPER_BASE = {
     },
     "mikrotik_routeros": {
         "oid": ".1.3.6.1.2.1.1.1.0",
-        "expr": re.compile(r"^RouterOS.*", re.IGNORECASE),
+        "expr": re.compile(r".*RouterOS.*", re.IGNORECASE),
         "priority": 60,
     },
 }

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -114,6 +114,11 @@ SNMP_MAPPER_BASE = {
         "expr": re.compile(r"PowerConnect.*", re.IGNORECASE),
         "priority": 50,
     },
+    "mikrotik_routeros": {
+        "oid": ".1.3.6.1.2.1.1.1.0",
+        "expr": re.compile(r"^RouterOS.*", re.IGNORECASE),
+        "priority": 60,
+    },
 }
 
 # Ensure all SNMP device types are supported by Netmiko


### PR DESCRIPTION
Hi Team,
I've found some Cisco ios devices that were not matching the regexp due to the "," not being present
Example `Cisco IOS Software C881 Software` will not match `".*Cisco IOS Software,.*"`
So I propose `".*Cisco IOS Software.*,.*"` instead.
I've run it successfully on many devices.
Additionally we can detect routeros via a very simple match.
Example of device output to snmprequest : 
`iso.3.6.1.2.1.1.1.0 = STRING: "RouterOS RB2011UiAS"`

Let me know what you think!
Kindly,