### PR TITLE
Add Hillstone device type

### DIFF
--- a/netmiko/hillstone/__init__.py
+++ b/netmiko/hillstone/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.hillstone.hillstone import hillstoneSSH
+
+__all__ = ["hillstoneSSH"]

--- a/netmiko/hillstone/hillstone.py
+++ b/netmiko/hillstone/hillstone.py
@@ -1,0 +1,46 @@
+import time
+from netmiko.no_enable import NoEnable
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+
+class hillstoneBase(NoEnable,CiscoBaseConnection):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"#")
+        self.set_base_prompt()
+        # self.enable()
+        self.disable_paging(command="terminal length 0")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def config_mode(
+        self,
+        config_command: str = "configure",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        """Enter configuration mode."""
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
+
+    def check_config_mode(
+        self, check_string: str = ")#", pattern: str = "#", force_regex: bool = False
+    ) -> bool:
+        """
+        Checks if the device is in configuration mode or not.
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def save_config(
+        self, cmd: str = "save all", confirm: bool = True, confirm_response: str = "y"
+    ) -> str:
+        """Saves Config Using Copy Run Start"""
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+
+class hillstoneSSH(hillstoneBase):
+    pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -124,6 +124,7 @@ from netmiko.zte import ZteZxrosTelnet
 from netmiko.supermicro import SmciSwitchSmisSSH
 from netmiko.supermicro import SmciSwitchSmisTelnet
 from netmiko.zyxel import ZyxelSSH
+from netmiko.hillstone import hillstoneSSH
 
 if TYPE_CHECKING:
     from netmiko.base_connection import BaseConnection
@@ -255,6 +256,7 @@ CLASS_MAPPER_BASE = {
     "zte_zxros": ZteZxrosSSH,
     "yamaha": YamahaSSH,
     "zyxel_os": ZyxelSSH,
+    "hillstone": hillstoneSSH,
 }
 
 FILE_TRANSFER_MAP = {

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -549,3 +549,13 @@ audiocode_shell:
   save_config_confirm: False
   save_config_response: 'Configuration has been saved'
   config_mode_command: "conf"         # only use if needed
+hillstone:
+  version: "show version"
+  basic: "show interface"
+  extended_output: "show configuration"
+  config:
+    - "clock zone china"
+  config_verification: "show configuration | inc clock"
+  save_config_cmd: 'save all'
+  save_config_confirm: True
+  save_config_response: 'Saving configuration is finished'

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -396,3 +396,11 @@ audiocode_shell:
   save_config: 'Configuration has been saved'
   cmd_response_init: "Test_String1"
   cmd_response_final: "Test_String2"
+hillstone:
+  base_prompt: SG-6000
+  router_prompt : SG-6000#
+  enable_prompt: SG-6000#
+  interface_ip: 192.168.100.234
+  version_banner: "Hillstone Networks StoneOS software"
+  multiple_line_output: ""
+  save_config: 'Saving configuration is finished'

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -289,3 +289,8 @@ audiocode_shell:
   ip: 192.168.1.3
   username: TestUser
   password: TestPass
+hillstone:
+  device_type: hillstone
+  ip: 192.168.100.234
+  username: hillstone
+  password: Hillstone


### PR DESCRIPTION
Hello,ktbyer,
please review and consider this PR to enable support for hillstone (https://www.hillstonenet.com/)

Support for:

SSH 
send commands
save config

I had run tests for ssh connection.
show and config and save config Test run output bellow,

PS D:\netmiko\tests> py.test -v test_netmiko_show.py --test_device hillstone
============================================================================================================================ test session starts ============================================================================================================================
platform win32 -- Python 3.8.0, pytest-7.2.0, pluggy-1.0.0 -- d:\python38\python.exe
cachedir: .pytest_cache
rootdir: D:\netmiko, configfile: setup.cfg
collected 25 items

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                                                                                                                     [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                                                                                       [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                                                                                       [ 12%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                                                                                          [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                                                                                       [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                                                                                  [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                                                                                                                   [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                                                                                         [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                                                                                                                          [ 36%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                                                                                          [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                                                                                                                         [ 44%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                                                                                                                      [ 48%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                                                                                                                           [ 52%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                                                                                                                               [ 56%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                                                                                                                      [ 60%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                                                                                                                               [ 64%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                                                                                                                               [ 68%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                                                                                          [ 72%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                                                                                         [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                                                                                        [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                                                                                  [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                                                                                         [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                                                                                          [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                                                                                           [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                                                                                                                                [100%]

========================================================================================================================== short test summary info ==========================================================================================================================
SKIPPED [1] test_netmiko_show.py:25: Not using SSH-keys
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
====================================================================================================================== 13 passed, 12 skipped in 19.74s ======================================================================================================================
PS D:\netmiko\tests> py.test -v test_netmiko_config.py --test_device hillstone
============================================================================================================================ test session starts ============================================================================================================================
platform win32 -- Python 3.8.0, pytest-7.2.0, pluggy-1.0.0 -- d:\python38\python.exe
cachedir: .pytest_cache
rootdir: D:\netmiko, configfile: setup.cfg
collected 13 items

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                                                                                        [  7%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                                                                                        [ 15%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                                                                                        [ 23%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                                                                                   [ 30%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                                                                                         [ 38%]
test_netmiko_config.py::test_config_set_generator PASSED                                                                                                                                                                                                               [ 46%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                                                                                             [ 53%]
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                                                                                                                    [ 61%]
test_netmiko_config.py::test_config_from_file SKIPPED                                                                                                                                                                                                                  [ 69%]
test_netmiko_config.py::test_config_error_pattern SKIPPED (No error_pattern defined.)                                                                                                                                                                                  [ 76%]
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)                                                                                                                                                                                                       [ 84%]
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)                                                                                                                                                                                            [ 92%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                                                                                         [100%]

========================================================================================================================== short test summary info ==========================================================================================================================
SKIPPED [1] test_netmiko_config.py:163: Skipped
SKIPPED [1] test_netmiko_config.py:175: No error_pattern defined.
SKIPPED [1] test_netmiko_config.py:209: No banner defined.
SKIPPED [1] test_netmiko_config.py:242: No banner defined.
======================================================================================================================= 9 passed, 4 skipped in 5.87s ========================================================================================================================
PS D:\netmiko\tests> py.test -v test_netmiko_save.py --test_device hillstone
============================================================================================================================ test session starts ============================================================================================================================
platform win32 -- Python 3.8.0, pytest-7.2.0, pluggy-1.0.0 -- d:\python38\python.exe
cachedir: .pytest_cache
rootdir: D:\netmiko, configfile: setup.cfg
collected 2 items

test_netmiko_save.py::test_save_base PASSED                                                                                                                                                                                                                            [ 50%]
test_netmiko_save.py::test_disconnect PASSED                                                                                                                                                                                                                           [100%]

============================================================================================================================= 2 passed in 7.28s =============================================================================================================================
PS D:\netmiko\tests>