### PR TITLE
dell: fix save_config for Dell Force10 / OS9 devices

### DIFF
--- a/netmiko/dell/dell_force10_ssh.py
+++ b/netmiko/dell/dell_force10_ssh.py
@@ -7,7 +7,7 @@ class DellForce10SSH(CiscoSSHConnection):
 
     def save_config(
         self,
-        cmd: str = "copy running-configuration startup-configuration",
+        cmd: str = "write memory",
         confirm: bool = False,
         confirm_response: str = "",
     ) -> str:


### PR DESCRIPTION
On a Dell S4048-ON switch running OS9 version 9.14(2.5), the current save_config() implementation does not work:

    sw#copy running-configuration startup-configuration
    % Error: The source file does not exist.

There are two ways to save on OS9: either "copy running-config startup-config" (but it requires a confirmation), or "write memory". We use the latter to avoid dealing with the confirmation prompt.

Also tested on a Dell S4810 running Dell OS 8.3.10.1, it has the same behaviour.

Unfortunately I don't have access to a device with the original Force10 OS, but according to old manuals found online, "write memory" seems to also be supported.