### PR TITLE
Allow specifying custom policy

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -228,8 +228,9 @@ class BaseConnection:
 
         :param allow_agent: Enable use of SSH key-agent.
 
-        :param ssh_strict: Automatically reject unknown SSH host keys (default: False, which
-                means unknown SSH host keys will be accepted).
+        :param ssh_strict: If True, automatically reject unknown SSH host keys (default: False, which
+                means unknown SSH host keys will be accepted). Can be a paramiko.client.MissingHostKeyPolicy
+                instance, in which case, that specific policy instance is used directly.
 
         :param system_host_keys: Load host keys from the users known_hosts file.
 
@@ -415,7 +416,9 @@ class BaseConnection:
             self.protocol = "ssh"
 
             self.key_policy: paramiko.client.MissingHostKeyPolicy
-            if not ssh_strict:
+            if isinstance(ssh_strict, paramiko.client.MissingHostKeyPolicy):
+                self.key_policy = ssh_strict
+            elif not ssh_strict:
                 self.key_policy = paramiko.AutoAddPolicy()
             else:
                 self.key_policy = paramiko.RejectPolicy()


### PR DESCRIPTION
I have use-cases where neither "Reject" nor "Accept and register host key" are suitable (testing suite which brings up fresh boxes with different fingerprints on a regular basis).

This change overrides `ssh_strict` to allow it to receive and use an explicit policy object.

My own purpose is to provide a customised policy instance to directly pass into our existing connection implementation.

I concede this is not the cleanest solution ; this PR may also stand as a discussion point for what better solution would be preferred. If a separate parameter (there are already many!) were preferable, what to do with `ssh_strict` ? Ignore it ? Raise exception for incompatible flag if `ssh_strict==True` ?