### PR TITLE
update terminal width and return char to work for all oneos versions

### DIFF
--- a/netmiko/oneaccess/oneaccess_oneos.py
+++ b/netmiko/oneaccess/oneaccess_oneos.py
@@ -16,14 +16,25 @@ class OneaccessOneOSBase(CiscoBaseConnection):
         """Prepare connection - disable paging"""
         self._test_channel_read()
         self.set_base_prompt()
-        self.set_terminal_width(command="stty columns 255", pattern="stty")
         self.disable_paging(command="term len 0")
-        # Clear the read buffer
+
+        # try ONEOS6 command first - fallback to ONEOS5 if it fails
+        self.set_terminal_width(command="screen-width 512")
+        output = self._test_channel_read()
+        if "error" in output.lower():
+            self.set_terminal_width(command="stty columns 255")
+        else:
+            # ONEOS6 uses different enter
+            self.RETURN = "\n"
+
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
     def save_config(
-        self, cmd: str = "write mem", confirm: bool = False, confirm_response: str = ""
+        self,
+        cmd: str = "write mem",
+        confirm: bool = False,
+        confirm_response: str = "",
     ) -> str:
         """Save config: write mem"""
         return super().save_config(


### PR DESCRIPTION
Sets correct terminal width commands that will work for ONEOS5 + ONEOS6 versions. Also the return character will be changed for ONEOS6 devices, otherwise the prompt is repeated in the output results.


### ONEOS5 log  (runs hostname command) :

```
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
dops-lab-02#
DEBUG:netmiko:Pattern found: (\#|>) 
dops-lab-02#
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:[find_prompt()]: prompt is dops-lab-02#
DEBUG:netmiko:In disable_paging
DEBUG:netmiko:Command: term len 0

DEBUG:netmiko:write_channel: b'term len 0\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: term len 0

DEBUG:netmiko:Pattern found: (term\ len\ 0) term len 0
DEBUG:netmiko:term len 0
DEBUG:netmiko:Exiting disable_paging
DEBUG:netmiko:write_channel: b'screen-width 512\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: dops-lab-02#screen-width 512
            ^
Error: Invalid command
dops-lab-02#
DEBUG:netmiko:Pattern found: (dops\-lab\-02) 
dops-lab-02
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'stty columns 255\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: stty columns 255

DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: dops-lab-02#
DEBUG:netmiko:Pattern found: (dops\-lab\-02) stty columns 255
dops-lab-02
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:Clear buffer detects data in the channel
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\r\n'
DEBUG:netmiko:read_channel: 
dops-lab-02#
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:[find_prompt()]: prompt is dops-lab-02#
DEBUG:netmiko:write_channel: b'hostname\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: hostname

DEBUG:netmiko:Pattern found: (hostname) hostname
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: dops-lab-02
dops-lab-02#
DEBUG:netmiko:write_channel: b'\r\n'
DEBUG:netmiko:read_channel: 
dops-lab-02#
```






### ONEOS6 log (runs hostname command)

```
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
uliege01-41che-01#
uliege01-41che-01#
DEBUG:netmiko:Pattern found: (\#|>) 
uliege01-41che-01#
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:Clear buffer detects data in the channel
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:[find_prompt()]: prompt is uliege01-41che-01#
DEBUG:netmiko:In disable_paging
DEBUG:netmiko:Command: term len 0

DEBUG:netmiko:write_channel: b'term len 0\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: term len 0
DEBUG:netmiko:Pattern found: (term\ len\ 0) term len 0
DEBUG:netmiko:term len 0
DEBUG:netmiko:Exiting disable_paging
DEBUG:netmiko:write_channel: b'screen-width 512\r\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 

DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: uliege01-41che-01#

DEBUG:netmiko:Pattern found: (uliege01\-41che\-01) 
uliege01-41che-01
DEBUG:netmiko:read_channel: uliege01-41che-01#screen-width 512
uliege01-41che-01#
uliege01-41che-01#
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:write_channel: b'\n'
DEBUG:netmiko:read_channel: 
uliege01-41che-01#
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:[find_prompt()]: prompt is uliege01-41che-01#
DEBUG:netmiko:write_channel: b'hostname\n'
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: hostname
DEBUG:netmiko:Pattern found: (hostname) hostname
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 

DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: uliege01-41che-01
DEBUG:netmiko:read_channel: 

DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: uliege01-41che-01#
DEBUG:netmiko:write_channel: b'\n'
DEBUG:netmiko:read_channel: 
uliege01-41che-01#
```
