### PR TITLE
Prevent channel reader from writing empty debug log lines

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -592,7 +592,8 @@ key_file: {self.key_file}
         new_data = self.normalize_linefeeds(new_data)
         if self.ansi_escape_codes:
             new_data = self.strip_ansi_escape_codes(new_data)
-        log.debug(f"read_channel: {new_data}")
+        if len(new_data) > 0:
+            log.debug(f"read_channel: {new_data}")
         if self.session_log:
             self.session_log.write(new_data)
 


### PR DESCRIPTION
Some commands sent through to the SSH endpoint can have delays between outputs.

When a read action encounters the pause in emitted output, the debug statement causes numerous debug lines to appear in logs such as 

```
read_channel: earlier data
read_channel:
read_channel:
read_channel:
read_channel:
read_channel: some new data
```

This change prevents logging from happening when exactly no new data was received.