### PR TITLE
Update adva_aos_fsp_150_f3.py

### DIFF
--- a/netmiko/adva/adva_aos_fsp_150_f3.py
+++ b/netmiko/adva/adva_aos_fsp_150_f3.py
@@ -82,7 +82,7 @@ class AdvaAosFsp150F3SSH(NoEnable, NoConfig, CiscoSSHConnection):
 
         commands = [
             "configure user-security",
-            "config-user {self.username} cli-paging disabled",
+            f"config-user {self.username} cli-paging disabled",
             "home",
         ]
         return self.send_config_set(


### PR DESCRIPTION
disable_paging command missing f string for the username. Not sure how this was missed during the regression testing, all tests passed, but I noticed this during some extended testing.