### PR TITLE
Fix fortinet _get_output_mode_v7 when in multiple VDOM mode

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -174,7 +174,7 @@ Alternatively you can try configuring 'configure system console -> set output st
         Retrieve the current output mode.
         """
         if self._vdoms:
-           self._config_global()
+            self._config_global()
 
         output = self._send_command_str(
             "get system console", expect_string=self.prompt_pattern

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -173,9 +173,15 @@ Alternatively you can try configuring 'configure system console -> set output st
         FortiOS V7 and later.
         Retrieve the current output mode.
         """
+        if self._vdoms:
+           self._config_global()
+
         output = self._send_command_str(
             "get system console", expect_string=self.prompt_pattern
         )
+
+        if self._vdoms:
+            self._exit_config_global()
 
         pattern = r"output\s+:\s+(?P<mode>\S+)\s*$"
         result_mode_re = re.search(pattern, output, flags=re.M)


### PR DESCRIPTION
_get_output_mode_v7 requires config global if multiple VDOM mode