### PR TITLE
Allow check_string override in check_config_mode

### DIFF
--- a/netmiko/aruba/aruba_ssh.py
+++ b/netmiko/aruba/aruba_ssh.py
@@ -46,8 +46,12 @@ class ArubaSSH(CiscoSSHConnection):
         config_command: str = "configure term",
         pattern: str = "",
         re_flags: int = 0,
+        check_string: str = "",
     ) -> str:
         """Aruba auto completes on space so 'configure' needs fully spelled-out."""
         return super().config_mode(
-            config_command=config_command, pattern=pattern, re_flags=re_flags
+            config_command=config_command,
+            pattern=pattern,
+            re_flags=re_flags,
+            check_string=check_string,
         )

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2037,7 +2037,11 @@ You can also look at the Netmiko session_log or debug log for more information.
             return check_string in output
 
     def config_mode(
-        self, config_command: str = "", pattern: str = "", re_flags: int = 0
+        self,
+        config_command: str = "",
+        pattern: str = "",
+        re_flags: int = 0,
+        check_string: str = "",
     ) -> str:
         """Enter into config_mode.
 
@@ -2051,7 +2055,10 @@ You can also look at the Netmiko session_log or debug log for more information.
         :type re_flags: RegexFlag
         """
         output = ""
-        if not self.check_config_mode():
+        check_config_mode_kwargs = {}
+        if check_string:
+            check_config_mode_kwargs = {"check_string": check_string}
+        if not self.check_config_mode(check_config_mode_kwargs):
             self.write_channel(self.normalize_cmd(config_command))
             # Make sure you read until you detect the command echo (avoid getting out of sync)
             if self.global_cmd_verify is not False:
@@ -2062,7 +2069,7 @@ You can also look at the Netmiko session_log or debug log for more information.
                 output += self.read_until_pattern(pattern=pattern, re_flags=re_flags)
             else:
                 output += self.read_until_prompt(read_entire_line=True)
-            if not self.check_config_mode():
+            if not self.check_config_mode(check_config_mode_kwargs):
                 raise ValueError("Failed to enter configuration mode.")
         return output
 

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -43,9 +43,13 @@ class CiscoBaseConnection(BaseConnection):
         config_command: str = "configure terminal",
         pattern: str = "",
         re_flags: int = 0,
+        check_string: str = "",
     ) -> str:
         return super().config_mode(
-            config_command=config_command, pattern=pattern, re_flags=re_flags
+            config_command=config_command,
+            pattern=pattern,
+            re_flags=re_flags,
+            check_string=check_string,
         )
 
     def exit_config_mode(self, exit_config: str = "end", pattern: str = r"#.*") -> str:


### PR DESCRIPTION
Aruba switch 8325 uses `(config)#` as the config mode check string without any whitespace.
To support both old versions (`(config) #`) and the new version (`(config)#`), I tried to make `config_mode` function configurable config mode check string.

