### PR TITLE
ssh_autodetect fix for IOS XR

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -388,7 +388,7 @@ class SSHDetect(object):
                     # WLC needs two different auto-dectect solutions
                     if "cisco_wlc_85" in best_match[0]:
                         best_match[0] = ("cisco_wlc", 99)
-                    # IOS needs two different auto-dectect solutions
+                    # IOS XR needs two different auto-dectect solutions
                     if "cisco_xr_2" in best_match[0]:
                         best_match[0] = ("cisco_xr", 99)
                     self.connection.disconnect()

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -127,6 +127,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "cisco_xr_2": {
+        "cmd": "show version brief",
+        "search_patterns": [r"Cisco IOS XR"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "dell_force10": {
         "cmd": "show version",
         "search_patterns": [r"Real Time Operating System Software"],
@@ -382,7 +388,9 @@ class SSHDetect(object):
                     # WLC needs two different auto-dectect solutions
                     if "cisco_wlc_85" in best_match[0]:
                         best_match[0] = ("cisco_wlc", 99)
-
+                    # IOS needs two different auto-dectect solutions
+                    if "cisco_xr_2" in best_match[0]:
+                        best_match[0] = ("cisco_xr", 99)
                     self.connection.disconnect()
                     return best_match[0][0]
 


### PR DESCRIPTION
In the SSH_MAPPER_DICT, IOS XR devices have the cmd key variable assigned "show version". This works on some of our IOS XR devices (Version 7.5.2) but not on others (Version 6.1.4[Default]). I think this is due to all the additional output on our 6.1.4 routers which comes to a total of 184 lines. On these versions of XR we can use the command "show version brief" instead which fixes the issue and detects the device as expected.