### PR TITLE
Cisco WLC Read-Only user config paging disable fails

### DIFF
--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -197,12 +197,13 @@ output:
         while True:
             output += new_output
             if "--more-- or (q)uit" in new_output.lower():
-                new_output = self._send_command_timing_str(*second_args, **kwargs)
+                #new_output = self._send_command_timing_str(*second_args, **kwargs)
+                new_output = self._send_command_timing_str(*second_args,last_read=0,**kwargs)
             else:
                 break
 
         # Remove from output '--More-- or (q)uit'
-        pattern = r"^--More-- or \(q\)uit"
+        pattern = r"--More-- or \(q\)uit"
         output = re.sub(pattern, "", output, flags=re.M)
 
         if strip_prompt:

--- a/netmiko/cisco/cisco_wlc_ssh.py
+++ b/netmiko/cisco/cisco_wlc_ssh.py
@@ -196,13 +196,13 @@ output:
 
         while True:
             output += new_output
-            if "--More-- or (q)uit" in new_output.lower():
+            if "--more-- or (q)uit" in new_output.lower():
                 new_output = self._send_command_timing_str(*second_args, **kwargs)
             else:
                 break
 
-        # Remove from output 'Would you like to display the next 15 entries? (y/n)'
-        pattern = r"^.*--More-- or (q)uit.*\n$"
+        # Remove from output '--More-- or (q)uit'
+        pattern = r"^--More-- or \(q\)uit"
         output = re.sub(pattern, "", output, flags=re.M)
 
         if strip_prompt:


### PR DESCRIPTION
add send_command_w_paging function

For using a read-only user, 'config paging disable'will fail (config requires write). For results longer than a page Cisco WLC adds a '--More-- or (q)uit' message because pagination is still enabled.  This function sends a "space" if '--More-- or (q)uit' is identified