### PR TITLE
Adding Cisco AP to Device Types

### DIFF
--- a/netmiko/cisco/cisco_ap_ssh.py
+++ b/netmiko/cisco/cisco_ap_ssh.py
@@ -1,0 +1,15 @@
+"""Subclass specific to Cisco AP."""
+from typing import Any
+from netmiko.no_config import NoConfig
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+
+class CiscoApSSH(NoConfig, CiscoBaseConnection):
+    """Subclass specific to Cisco AP."""
+
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        cmd = "terminal width 132"
+        self.set_terminal_width(command=cmd, pattern=cmd)
+        self.disable_paging()
+        self.set_base_prompt()

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -100,6 +100,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "cisco_ap": {
+        "cmd": "show version",
+        "search_patterns": [r"Cisco AP Software"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "cisco_ios": {
         "cmd": "show version",
         "search_patterns": [

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -31,6 +31,7 @@ from netmiko.centec import CentecOSSSH, CentecOSTelnet
 from netmiko.checkpoint import CheckPointGaiaSSH
 from netmiko.ciena import CienaSaosSSH, CienaSaosTelnet, CienaSaosFileTransfer
 from netmiko.cisco import CiscoAsaSSH, CiscoAsaFileTransfer
+from netmiko.cisco import CiscoApSSH
 from netmiko.cisco import CiscoFtdSSH
 from netmiko.cisco import (
     CiscoIosSSH,
@@ -169,6 +170,7 @@ CLASS_MAPPER_BASE = {
     "centec_os": CentecOSSSH,
     "ciena_saos": CienaSaosSSH,
     "cisco_asa": CiscoAsaSSH,
+    "cisco_ap": CiscoApSSH,
     "cisco_ftd": CiscoFtdSSH,
     "cisco_ios": CiscoIosSSH,
     "cisco_nxos": CiscoNxosSSH,

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -67,6 +67,12 @@ cisco_asa:
   config_verification: "show run | inc logging buffer"
   config_file: "cisco_asa_commands.txt"
 
+cisco_ap:
+  version: "show version"
+  basic: "show ip interface brief"
+  wide_command: "show configuration wlan myverybiglonglistthatdoesntexistandwherethisexceeds80characterssolinewrappingoccurs"
+  extended_output: "show version" # requires paging to be disabled
+
 arista_eos:
   version: "show version"
   basic: "show ip int brief"

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -10,6 +10,14 @@ cisco_ios:
   file_check_cmd: "logging buffered 8880"
   save_config: 'OK'
 
+cisco_ap:
+  base_prompt: ap01-test
+  router_prompt: ap01-test>
+  enable_prompt: ap01-test#
+  interface_ip: 10.10.10.100
+  version_banner: "Cisco AP Software"
+  multiple_line_output: "Cisco AP Software"
+
 juniper:
   base_prompt: pyclass@pynet-jnpr-srx1
   router_prompt: pyclass@pynet-jnpr-srx1>

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -17,6 +17,13 @@ cisco_asa_21:               # the device_name does not have to match the device 
   password: cisco123
   secret: cisco123
 
+cisco_ap:
+  device_type: cisco_ap
+  ip: 10.10.10.100
+  username: admin
+  password: cisco123
+  secret: cisco123
+
 arista_eos:
   device_type: arista_eos
   ip: 10.10.10.12


### PR DESCRIPTION
Adding cisco_ap to supported device types. Tested on models 3700, 3800, and 9100 WAPs.

Example banner:
```
             Restricted Rights Legend

Use, duplication, or disclosure by the Government is subject to
restrictions as set forth in subparagraph (c) of the Commercial
Computer Software - Restricted Rights clause at FAR sec. 52.227-19 and
subparagraph (c) (1) (ii) of the Rights in Technical Data and Computer
Software clause at DFARS sec. 252.227-7013.

            Cisco Systems, Inc.
            170 West Tasman Drive
            San Jose, California 95134-1706

This product contains cryptographic features and is subject to United
States and local country laws governing import, export, transfer and
use. Delivery of Cisco cryptographic products does not imply
third-party authority to import, export, distribute or use encryption.
Importers, exporters, distributors and users are responsible for
compliance with U.S. and local country laws. By using this product you
agree to comply with applicable laws and regulations. If you are unable
to comply with U.S. and local laws, return this product immediately.

A summary of U.S. laws governing Cisco cryptographic products may be found at:
http://www.cisco.com/wwl/export/crypto/tool/stqrg.html

If you require further assistance please contact us by sending email to
export@cisco.com.

This product contains some software licensed under the
"GNU General Public License, version 2" provided with
ABSOLUTELY NO WARRANTY under the terms of
"GNU General Public License, version 2", available here:
http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

This product contains some software licensed under the
"GNU Library General Public License, version 2" provided
with ABSOLUTELY NO WARRANTY under the terms of "GNU Library
General Public License, version 2", available here:
http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html

This product contains some software licensed under the
"GNU Lesser General Public License, version 2.1" provided
with ABSOLUTELY NO WARRANTY under the terms of "GNU Lesser
General Public License, version 2.1", available here:
http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html

This product contains some software licensed under the 
"GNU General Public License, version 3" provided with 
ABSOLUTELY NO WARRANTY under the terms of  
"GNU General Public License, Version 3", available here: 
http://www.gnu.org/licenses/gpl.html.

This product contains some software licensed under the
"GNU Affero General Public License, version 3" provided
with ABSOLUTELY NO WARRANTY under the terms of
"GNU Affero General Public License, version 3", available here:
http://www.gnu.org/licenses/agpl-3.0.html.

Cisco AP Software, (ap3g3), C3802, RELEASE SOFTWARE
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2023 by Cisco Systems, Inc.
Compiled Wed Nov 10 08:49:19 GMT 2021

ROM: Bootstrap program is U-Boot boot loader
BOOTLDR: U-Boot boot loader Version 2013.01-gcb01933d4 (Nov 10 2020 - 23:41:12)

{{ REDACTED }}
```

Updated test example and below is the results.

Test Results:
```
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.9.13, pytest-7.2.2, pluggy-1.0.0 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /netmiko2, configfile: setup.cfg
collected 25 items                                                                                                                                                             

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                       [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                         [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                         [ 12%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                            [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                         [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                    [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                     [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                           [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                            [ 36%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                            [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                           [ 44%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                        [ 48%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                             [ 52%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                                 [ 56%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                        [ 60%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                                 [ 64%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                                 [ 68%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                            [ 72%]
test_netmiko_show.py::test_strip_prompt FAILED                                                                                                                           [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                          [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                    [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                           [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                            [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                             [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                                  [100%]

=================================================================================== FAILURES ===================================================================================
______________________________________________________________________________ test_strip_prompt _______________________________________________________________________________

net_connect = <netmiko.cisco.cisco_ios.CiscoIosSSH object at 0x7f1a002de6d0>
commands = {'basic': 'show ip interface brief', 'extended_output': 'show version', 'version': 'show version', 'wide_command': 'show configuration wlan myverybiglonglistthatdoesntexistandwherethisexceeds80characterssolinewrappingoccurs'}
expected_responses = {'base_prompt': 'ap01-test', 'enable_prompt': 'ap01-test#', 'interface_ip': '10.10.10.100', 'multiple_line_output': 'Cisco AP Software', ...}

    def test_strip_prompt(net_connect, commands, expected_responses):
        """Ensure the router prompt is not in the command output."""
    
        if expected_responses["base_prompt"] == "":
            return
        show_ip = net_connect.send_command_timing(commands["basic"])
        show_ip_alt = net_connect.send_command(commands["basic"])
>       assert expected_responses["base_prompt"] not in show_ip
E       AssertionError: assert 'ap01-test' not in 'Interface  ...1-EARTHCITY>'
E         'ap01-test' is contained here:
E           Interface            IP-Address      Method   Status                 Protocol   Speed      Duplex  
E           wired0               10.10.10.100    DHCP     up                     up         1000       full    
E           auxiliary-client     unassigned      unset    up                     up         n/a        n/a     
E           wifi0                n/a             n/a      up                     up         n/a        n/a     
E           wifi1                n/a             n/a      up                     up         n/a        n/a     
E           ...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

test_netmiko_show.py:321: AssertionError
=========================================================================== short test summary info ============================================================================
SKIPPED [1] test_netmiko_show.py:25: Not using SSH-keys
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
================================================================== 1 failed, 12 passed, 12 skipped in 24.96s ===================================================================
```