### PR TITLE
Implemented new "AgnosticHandler" entrypoint

### DIFF
--- a/netmiko/__init__.py
+++ b/netmiko/__init__.py
@@ -38,6 +38,7 @@ log.addHandler(logging.NullHandler())
 
 
 from netmiko.ssh_dispatcher import ConnectHandler  # noqa
+from netmiko.ssh_dispatcher import AgnosticHandler  # noqa
 from netmiko.ssh_dispatcher import ConnLogOnly  # noqa
 from netmiko.ssh_dispatcher import ConnUnify  # noqa
 from netmiko.ssh_dispatcher import ssh_dispatcher  # noqa
@@ -66,6 +67,7 @@ Netmiko = ConnectHandler
 
 __all__ = (
     "ConnectHandler",
+    "AgnosticHandler",
     "ConnLogOnly",
     "ConnUnify",
     "ssh_dispatcher",


### PR DESCRIPTION
~~This PR implements the new optional flag "try_alternative" in ConnectHandler.~~

~~It defaults to False.~~

~~Setting this flag to True, if a SSH connection fails, it will try using Telnet and vice versa.~~

This PR implements the new "AgnosticHandler" entrypoint.

By using it, if a SSH connection fails, it will try using Telnet and vice versa.

I find it useful because in large network environments with mixed devices configurations, it could be boring to fix all device_type fields.

Sometimes when you operate on hundreds of devices, you don't know if SSH or Telnet is active. With this ~~flag~~ entrypoint, you can save a lot of time in fixing.

I very often deploy a similar behavior in my applications that use Netmiko, so I thought it might be useful to bring the functionality upstream.

The default behavior of Netmiko doesn't change. It just adds a functionality that could be useful in some scenarios.

Hope this community will appreciate this.