### PR TITLE
Add a check_state argument to enable() method to allow for bypassing 

### DIFF
--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -28,14 +28,14 @@ class AdtranOSBase(CiscoBaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
-        check_current_state: bool = True,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
             cmd=cmd,
             pattern=pattern,
             enable_pattern=enable_pattern,
-            check_current_state=check_current_state,
+            check_state=check_state,
             re_flags=re_flags,
         )
 

--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -28,10 +28,15 @@ class AdtranOSBase(CiscoBaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_current_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_current_state=check_current_state,
+            re_flags=re_flags,
         )
 
     def exit_enable_mode(self, exit_command: str = "disable") -> str:

--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -41,10 +41,15 @@ class AristaBase(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = r"\#",
+        check_current_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_current_state=check_current_state,
+            re_flags=re_flags,
         )
 
     def check_config_mode(

--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -41,14 +41,14 @@ class AristaBase(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = r"\#",
-        check_current_state: bool = True,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
             cmd=cmd,
             pattern=pattern,
             enable_pattern=enable_pattern,
-            check_current_state=check_current_state,
+            check_state=check_state,
             re_flags=re_flags,
         )
 

--- a/netmiko/audiocode/audiocode_ssh.py
+++ b/netmiko/audiocode/audiocode_ssh.py
@@ -104,10 +104,15 @@ class AudiocodeBase(BaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = "#",
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def exit_config_mode(self, exit_config: str = "exit", pattern: str = r"#") -> str:

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1964,7 +1964,7 @@ You can also look at the Netmiko session_log or debug log for more information.
         cmd: str = "",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
-        check_current_state: bool = True,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter enable mode.
@@ -1975,7 +1975,7 @@ You can also look at the Netmiko session_log or debug log for more information.
 
         :param enable_pattern: pattern indicating you have entered enable mode
 
-        :param check_current_state: Determine whether we are already in enable_mode using
+        :param check_state: Determine whether we are already in enable_mode using
                 check_enable_mode() before trying to elevate privileges (default: True)
 
         :param re_flags: Regular expression flags used in conjunction with pattern
@@ -1987,7 +1987,7 @@ You can also look at the Netmiko session_log or debug log for more information.
         )
 
         # Check if in enable mode already.
-        if check_current_state and self.check_enable_mode():
+        if check_state and self.check_enable_mode():
             return output
 
         # Send "enable" mode command

--- a/netmiko/cisco/cisco_asa_ssh.py
+++ b/netmiko/cisco/cisco_asa_ssh.py
@@ -54,10 +54,15 @@ class CiscoAsaSSH(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = r"\#",
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def send_command_timing(

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -19,7 +19,7 @@ class CiscoBaseConnection(BaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
-        check_current_state: bool = True,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter enable mode."""
@@ -27,7 +27,7 @@ class CiscoBaseConnection(BaseConnection):
             cmd=cmd,
             pattern=pattern,
             enable_pattern=enable_pattern,
-            check_current_state=check_current_state,
+            check_state=check_state,
             re_flags=re_flags,
         )
 

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -19,11 +19,16 @@ class CiscoBaseConnection(BaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_current_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter enable mode."""
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_current_state=check_current_state,
+            re_flags=re_flags,
         )
 
     def exit_enable_mode(self, exit_command: str = "disable") -> str:

--- a/netmiko/endace/endace_ssh.py
+++ b/netmiko/endace/endace_ssh.py
@@ -15,10 +15,15 @@ class EndaceSSH(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def check_config_mode(

--- a/netmiko/ericsson/ericsson_ipos.py
+++ b/netmiko/ericsson/ericsson_ipos.py
@@ -23,10 +23,15 @@ class EricssonIposSSH(BaseConnection):
         cmd: str = "enable 15",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def exit_enable_mode(self, exit_command: str = "disable") -> str:

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -109,13 +109,14 @@ class HPComwareBase(CiscoSSHConnection):
         cmd: str = "system-view",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """enable mode on Comware is system-view."""
         return self.config_mode(config_command=cmd)
 
     def exit_enable_mode(self, exit_command: str = "return") -> str:
-        """enable mode on Comware is system-view."""
+        """enable mode on Comware is system-view.:"""
         return self.exit_config_mode(exit_config=exit_command)
 
     def check_enable_mode(self, check_string: str = "]") -> bool:

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -116,7 +116,7 @@ class HPComwareBase(CiscoSSHConnection):
         return self.config_mode(config_command=cmd)
 
     def exit_enable_mode(self, exit_command: str = "return") -> str:
-        """enable mode on Comware is system-view.:"""
+        """enable mode on Comware is system-view."""
         return self.exit_config_mode(exit_config=exit_command)
 
     def check_enable_mode(self, check_string: str = "]") -> bool:

--- a/netmiko/hp/hp_procurve.py
+++ b/netmiko/hp/hp_procurve.py
@@ -80,13 +80,15 @@ class HPProcurveBase(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "password",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
         default_username: str = "",
     ) -> str:
         """Enter enable mode"""
 
-        if self.check_enable_mode():
+        if check_state and self.check_enable_mode():
             return ""
+
         if not default_username:
             default_username = self.username
 

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -99,10 +99,15 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         cmd: str = "enable",
         pattern: str = "",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, re_flags=re_flags, enable_pattern=enable_pattern
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def set_base_prompt(

--- a/netmiko/mellanox/mellanox_mlnxos_ssh.py
+++ b/netmiko/mellanox/mellanox_mlnxos_ssh.py
@@ -14,17 +14,21 @@ class MellanoxMlnxosSSH(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "#",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter into enable mode."""
+
         output = ""
+        if check_state and self.check_enable_mode():
+            return output
+
+        self.write_channel(self.normalize_cmd(cmd))
+        output += self.read_until_prompt_or_pattern(
+            pattern=pattern, re_flags=re_flags, read_entire_line=True
+        )
         if not self.check_enable_mode():
-            self.write_channel(self.normalize_cmd(cmd))
-            output += self.read_until_prompt_or_pattern(
-                pattern=pattern, re_flags=re_flags, read_entire_line=True
-            )
-            if not self.check_enable_mode():
-                raise ValueError("Failed to enter enable mode.")
+            raise ValueError("Failed to enter enable mode.")
         return output
 
     def config_mode(

--- a/netmiko/mrv/mrv_lx.py
+++ b/netmiko/mrv/mrv_lx.py
@@ -28,10 +28,17 @@ class MrvLxSSH(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = "assword",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter enable mode."""
-        return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
+        return super().enable(
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
+        )
 
     def save_config(
         self,

--- a/netmiko/mrv/mrv_ssh.py
+++ b/netmiko/mrv/mrv_ssh.py
@@ -25,21 +25,24 @@ class MrvOptiswitchSSH(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = r"#",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enable mode on MRV uses no password."""
         output = ""
+        if check_state and self.check_enable_mode():
+            return output
+
+        self.write_channel(self.normalize_cmd(cmd))
+        output += self.read_until_prompt_or_pattern(
+            pattern=pattern, re_flags=re_flags, read_entire_line=True
+        )
         if not self.check_enable_mode():
-            self.write_channel(self.normalize_cmd(cmd))
-            output += self.read_until_prompt_or_pattern(
-                pattern=pattern, re_flags=re_flags, read_entire_line=True
+            msg = (
+                "Failed to enter enable mode. Please ensure you pass "
+                "the 'secret' argument to ConnectHandler."
             )
-            if not self.check_enable_mode():
-                msg = (
-                    "Failed to enter enable mode. Please ensure you pass "
-                    "the 'secret' argument to ConnectHandler."
-                )
-                raise ValueError(msg)
+            raise ValueError(msg)
         return output
 
     def save_config(

--- a/netmiko/no_enable.py
+++ b/netmiko/no_enable.py
@@ -25,7 +25,7 @@ class NoEnable:
         cmd: str = "",
         pattern: str = "",
         enable_pattern: Optional[str] = None,
-        check_current_state: bool = True,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return ""

--- a/netmiko/no_enable.py
+++ b/netmiko/no_enable.py
@@ -25,6 +25,7 @@ class NoEnable:
         cmd: str = "",
         pattern: str = "",
         enable_pattern: Optional[str] = None,
+        check_current_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return ""

--- a/netmiko/nokia/nokia_sros.py
+++ b/netmiko/nokia/nokia_sros.py
@@ -91,12 +91,19 @@ class NokiaSros(BaseConnection):
         cmd: str = "enable",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enable SR OS administrative mode"""
         if "@" not in self.base_prompt:
             cmd = "enable-admin"
-        return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
+        return super().enable(
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
+        )
 
     def check_enable_mode(self, check_string: str = "in admin mode") -> bool:
         """Check if in enable mode."""

--- a/netmiko/ruckus/ruckus_fastiron.py
+++ b/netmiko/ruckus/ruckus_fastiron.py
@@ -25,6 +25,7 @@ class RuckusFastironBase(CiscoSSHConnection):
         cmd: str = "enable",
         pattern: str = r"(ssword|User Name|Login)",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """Enter enable mode.
@@ -35,32 +36,32 @@ class RuckusFastironBase(CiscoSSHConnection):
         SSH@Lab-ICX7250#
         """
         output = ""
-        if not self.check_enable_mode():
-            count = 4
-            i = 1
-            while i < count:
-                self.write_channel(self.normalize_cmd(cmd))
+        if check_state and self.check_enable_mode():
+            return output
+
+        count = 4
+        i = 1
+        while i < count:
+            self.write_channel(self.normalize_cmd(cmd))
+            new_data = self.read_until_prompt_or_pattern(
+                pattern=pattern, re_flags=re_flags, read_entire_line=True
+            )
+            output += new_data
+            if "User Name" in new_data or "Login" in new_data:
+                self.write_channel(self.normalize_cmd(self.username))
                 new_data = self.read_until_prompt_or_pattern(
                     pattern=pattern, re_flags=re_flags, read_entire_line=True
                 )
                 output += new_data
-                if "User Name" in new_data or "Login" in new_data:
-                    self.write_channel(self.normalize_cmd(self.username))
-                    new_data = self.read_until_prompt_or_pattern(
-                        pattern=pattern, re_flags=re_flags, read_entire_line=True
-                    )
-                    output += new_data
-                if "ssword" in new_data:
-                    self.write_channel(self.normalize_cmd(self.secret))
-                    new_data = self.read_until_prompt(read_entire_line=True)
-                    output += new_data
-                    if not re.search(
-                        r"error.*incorrect.*password", new_data, flags=re.I
-                    ):
-                        break
+            if "ssword" in new_data:
+                self.write_channel(self.normalize_cmd(self.secret))
+                new_data = self.read_until_prompt(read_entire_line=True)
+                output += new_data
+                if not re.search(r"error.*incorrect.*password", new_data, flags=re.I):
+                    break
 
-                time.sleep(1)
-                i += 1
+            time.sleep(1)
+            i += 1
 
         if not self.check_enable_mode():
             msg = (

--- a/netmiko/tplink/tplink_jetstream.py
+++ b/netmiko/tplink/tplink_jetstream.py
@@ -7,7 +7,7 @@ from cryptography.hazmat.primitives.asymmetric.dsa import DSAParameterNumbers
 
 from netmiko import log
 from netmiko.cisco_base_connection import CiscoSSHConnection
-from netmiko.exceptions import NetmikoTimeoutException
+from netmiko.exceptions import ReadTimeout
 
 
 class TPLinkJetStreamBase(CiscoSSHConnection):
@@ -40,6 +40,7 @@ class TPLinkJetStreamBase(CiscoSSHConnection):
         cmd: str = "",
         pattern: str = "ssword",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """
@@ -50,30 +51,40 @@ class TPLinkJetStreamBase(CiscoSSHConnection):
         enable all functions.
         """
 
+        msg = """
+Failed to enter enable mode. Please ensure you pass
+the 'secret' argument to ConnectHandler.
+"""
+
         # If end-user passes in "cmd" execute that using normal process.
         if cmd:
-            return super().enable(cmd=cmd, pattern=pattern, re_flags=re_flags)
+            return super().enable(
+                cmd=cmd,
+                pattern=pattern,
+                enable_pattern=enable_pattern,
+                check_state=check_state,
+                re_flags=re_flags,
+            )
 
         output = ""
-        msg = (
-            "Failed to enter enable mode. Please ensure you pass "
-            "the 'secret' argument to ConnectHandler."
-        )
+        if check_state and self.check_enable_mode():
+            return output
 
-        cmds = ["enable", "enable-admin"]
-        if not self.check_enable_mode():
-            for cmd in cmds:
-                self.write_channel(self.normalize_cmd(cmd))
-                try:
-                    output += self.read_until_prompt_or_pattern(
-                        pattern=pattern, re_flags=re_flags, read_entire_line=True
-                    )
+        for cmd in ("enable", "enable-admin"):
+            self.write_channel(self.normalize_cmd(cmd))
+            try:
+                new_data = self.read_until_prompt_or_pattern(
+                    pattern=pattern, re_flags=re_flags, read_entire_line=True
+                )
+                output += new_data
+                if re.search(pattern, new_data):
                     self.write_channel(self.normalize_cmd(self.secret))
                     output += self.read_until_prompt(read_entire_line=True)
-                except NetmikoTimeoutException:
-                    raise ValueError(msg)
-                if not self.check_enable_mode():
-                    raise ValueError(msg)
+            except ReadTimeout:
+                raise ValueError(msg)
+
+        if not self.check_enable_mode():
+            raise ValueError(msg)
         return output
 
     def config_mode(

--- a/netmiko/yamaha/yamaha.py
+++ b/netmiko/yamaha/yamaha.py
@@ -22,10 +22,15 @@ class YamahaBase(BaseConnection):
         cmd: str = "administrator",
         pattern: str = r"Password",
         enable_pattern: Optional[str] = None,
+        check_state: bool = True,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         return super().enable(
-            cmd=cmd, pattern=pattern, enable_pattern=enable_pattern, re_flags=re_flags
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
         )
 
     def exit_enable_mode(self, exit_command: str = "exit") -> str:


### PR DESCRIPTION
of the initial check_enable_mode()

In other words, by default Netmiko will check if you are already in enable mode before sending the "enable" command down the channel.

This can cause problems on certain platforms like Cisco IOS/IOS-XE which have intermediate privilege levels (like priv level 3) where the prompt has already changed to `#`.

You can now pass an argument:

```python
netmiko_obj.enable(check_state=False)
```

That should generally force Netmiko to send the `enable` command regardless of the current prompt (in other words, Netmiko will not check the current enable state when `check_state=False`.