### PR TITLE
fix tplink "Pattern not detected" #3125

### DIFF
--- a/netmiko/tplink/tplink_jetstream.py
+++ b/netmiko/tplink/tplink_jetstream.py
@@ -27,6 +27,7 @@ class TPLinkJetStreamBase(CiscoSSHConnection):
         delay_factor = self.select_delay_factor(delay_factor=0)
         time.sleep(0.3 * delay_factor)
         self.clear_buffer()
+        self.write_channel(self.RETURN)
         self._test_channel_read(pattern=r"[>#]")
         self.set_base_prompt()
         self.enable()


### PR DESCRIPTION
don't know if clear_buffer() is needed (what for?)
but it swallows the initial prompt, we send a RETURN to get a fresh one
should fix #3125 on main netmiko repo
