### PR TITLE
Support ipv4 & ipv6 , static and fqdn in snmpdetect #3144

### DIFF
--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -133,19 +133,19 @@ for device_type in std_device_types:
 def identify_address_type(entry):
     try:
         socket.inet_pton(socket.AF_INET, entry)
-        return "IPv4"
+        return ["IPv4"]
     except socket.error:
         pass
 
     try:
         socket.inet_pton(socket.AF_INET6, entry)
-        return "IPv6"
+        return ["IPv6"]
     except socket.error:
         pass
 
+    ip_types = []
     try:
         addrinfo = socket.getaddrinfo(entry, None)
-        ip_types = []
         for info in addrinfo:
             ip = info[4][0]
             try:
@@ -153,17 +153,14 @@ def identify_address_type(entry):
                 ip_types.append("IPv4")
             except socket.error:
                 pass
-
             try:
                 socket.inet_pton(socket.AF_INET6, ip)
                 ip_types.append("IPv6")
             except socket.error:
                 pass
-
-        return ip_types
-
     except socket.gaierror:
         return "Invalid entry"
+    return ip_types
 
 
 class SNMPDetect(object):

--- a/netmiko/snmp_autodetect.py
+++ b/netmiko/snmp_autodetect.py
@@ -145,25 +145,22 @@ def identify_address_type(entry):
 
     try:
         addrinfo = socket.getaddrinfo(entry, None)
-        ip_types = set()
+        ip_types = []
         for info in addrinfo:
             ip = info[4][0]
             try:
                 socket.inet_pton(socket.AF_INET, ip)
-                ip_types.add("IPv4")
+                ip_types.append("IPv4")
             except socket.error:
                 pass
 
             try:
                 socket.inet_pton(socket.AF_INET6, ip)
-                ip_types.add("IPv6")
+                ip_types.append("IPv6")
             except socket.error:
                 pass
 
-        if ip_types:
-            return ", ".join(ip_types)
-        else:
-            return "Hostname with no valid IP"
+        return ip_types
 
     except socket.gaierror:
         return "Invalid entry"
@@ -283,7 +280,7 @@ class SNMPDetect(object):
         self._response_cache: Dict[str, str] = {}
         self.snmp_target = (self.hostname, self.snmp_port)
 
-        if identify_address_type(self.hostname) == "IPv6":
+        if "IPv6" in identify_address_type(self.hostname):
             self.udp_transport_target = cmdgen.Udp6TransportTarget(
                 self.snmp_target, timeout=1.5, retries=2
             )


### PR DESCRIPTION
Fixing [bug ](https://github.com/ktbyers/netmiko/issues/3144#)

- Removing ipaddress lib and using socket instead.
- adding a function identify_address_type which returns a list containing one or more entry, "IPv4" or "IPv6". Not a huge fan of it ...let me know what you think.

Tested scenarios : 

- IPV4 Static
- IPV6 static
- IPV4 FQDN ("A" record)
- IPV6 FQDN ("AAAA" record)
- IPV4+IPV6 FQDN ("A" & "AAAA" records for the same fqdn)

In the last scenario, IPV6 is priorized due to line 280...
Should we do it another way?
