### PR TITLE
Added search string to catch virtual Arista devices

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -72,7 +72,7 @@ SSH_MAPPER_DICT = {
     },
     "arista_eos": {
         "cmd": "show version",
-        "search_patterns": [r"Arista"],
+        "search_patterns": [r"Arista", r"vEOS"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
Currently, virtual Arista devices do not get detected by the auto function. I have added additional search criteria to handle this.

Virtual show version output:

```
rain-device-1>show version
 vEOS
Hardware version:
Serial number:
Hardware MAC address: xxxxxxxxxx
System MAC address: xxxxxxxxxxx

Software image version: 4.25.1F
Architecture: i686
Internal build version: 4.25.1F-20001546.4251F
Internal build ID: 4fbd07b3-ca20-4c9a-969e-4eb2faca7531

Uptime: 25 weeks, 0 days, 21 hours and 8 minutes
Total memory: 2014428 kB
Free memory: 1209048 kB
```