### PR TITLE
[MikroTik] Corrected the terminal size definition

### DIFF
--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -39,10 +39,10 @@ class MikrotikBase(NoEnable, NoConfig, CiscoSSHConnection):
         c: disable console colors
         e: enable dumb terminal mode
         t: disable auto detect terminal capabilities
-        w511: set term width
-        h4098: set term height
+        511w: set term width
+        4098h: set term height
         """
-        self.username += "+ctw511h4098"
+        self.username += "+ct511w4098h"
 
     def disable_paging(self, *args: Any, **kwargs: Any) -> str:
         """Mikrotik does not have paging by default."""


### PR DESCRIPTION
Order of the terminal size definition is bad. The value need to be placed before key. I find this information in official documentation of MikroTik:
https://wiki.mikrotik.com/wiki/Manual:Console_login_process#Console_login_options