### PR TITLE
Update scp_functions.py | Added support to display progress bar without cleaning the screen.

### DIFF
--- a/netmiko/scp_functions.py
+++ b/netmiko/scp_functions.py
@@ -18,18 +18,14 @@ if TYPE_CHECKING:
 def progress_bar(
     filename: AnyStr, size: int, sent: int, peername: Optional[str] = None
 ) -> None:
-    max_width = 50
     if isinstance(filename, bytes):
         filename_str = filename.decode()
     else:
         filename_str = filename
-    clear_screen = chr(27) + "[2J"
-    terminating_char = "|"
 
     # Percentage done
     percent_complete = sent / size
     percent_str = f"{percent_complete*100:.2f}%"
-
 
     if peername is None:
         header_msg = f"Transferring file: {filename_str}"

--- a/netmiko/scp_functions.py
+++ b/netmiko/scp_functions.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from netmiko.scp_handler import BaseFileTransfer
 from netmiko.ssh_dispatcher import FileTransfer
 from netmiko.cisco.cisco_ios import InLineTransfer
-
+import sys
 if TYPE_CHECKING:
     from netmiko.base_connection import BaseConnection
 
@@ -29,19 +29,15 @@ def progress_bar(
     # Percentage done
     percent_complete = sent / size
     percent_str = f"{percent_complete*100:.2f}%"
-    hash_count = int(percent_complete * max_width)
-    progress = hash_count * ">"
+
 
     if peername is None:
-        header_msg = f"Transferring file: {filename_str}\n"
+        header_msg = f"Transferring file: {filename_str}"
     else:
-        header_msg = f"Transferring file to {peername}: {filename_str}\n"
+        header_msg = f"Transferring file to {peername}: {filename_str}"
 
-    msg = f"{progress:<50}{terminating_char:1} ({percent_str})"
-    print(clear_screen)
-    print(header_msg)
-    print(msg)
-
+    msg = f"({percent_str})"
+    sys.stdout.writelines(f"%s %s\r" % (header_msg, msg))
 
 def verifyspace_and_transferfile(scp_transfer: BaseFileTransfer) -> None:
     """Verify space and transfer file."""


### PR DESCRIPTION
Added support to display progress bar without cleaning the screen.
Now it should only shows the percentange and not the progress bar char ">".
Also removed unused vars on the progress_bar function due to this update.
I thought this would be useful since clearing the screen makes the screen to scroll which is not often desired.