### PR TITLE
Updating to single command to parse 'set output mode'

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -148,13 +148,7 @@ Alternatively you can try configuring 'configure system console -> set output st
         if self._vdoms:
             self._config_global()
 
-        self._send_command_str(
-            "config system console", expect_string=self.prompt_pattern
-        )
-        output = self._send_command_str(
-            "show full-configuration", expect_string=self.prompt_pattern
-        )
-        self._send_command_str("end", expect_string=self.prompt_pattern)
+        output = self._send_command_str("show full-configuration system console")
 
         if self._vdoms:
             self._exit_config_global()


### PR DESCRIPTION
Current method which sends `config system console` ,  `show full-configuration` , `end` commands in order to parse the set output mode has a limitation to run the commands with a user which has a global configuration permission. 

When a RO user tries to create a connection "show full-configuration" commands run without entering the console section and displays full configuration of the system. prompt_pattern which was used to find the end of the output is not suitable to parse the set output mode from full device configuration. In this situation netmiko raises below error.

`ValueError("Unable to determine the output mode on the Fortinet device.")`

`show full-configuration system console` command produces the expected result as the original commands as RO user can create a successful connection.
