### PR TITLE
Fix correction of ansi characters of next line

### DIFF
--- a/netmiko/zyxel/zyxel_ssh.py
+++ b/netmiko/zyxel/zyxel_ssh.py
@@ -1,3 +1,5 @@
+import re
+
 from typing import Any, Sequence, Iterator, TextIO, Union
 from netmiko.base_connection import BaseConnection
 from netmiko.no_enable import NoEnable
@@ -28,3 +30,8 @@ class ZyxelSSH(NoEnable, NoConfig, BaseConnection):
         super().session_preparation()
         # Zyxel switches output ansi codes
         self.ansi_escape_codes = True
+
+    def strip_ansi_escape_codes(self, string_buffer: str) -> str:
+        """Replace '^J' code by next line"""
+        output = re.sub(r"^\^J", self.RETURN, string_buffer)
+        return super().strip_ansi_escape_codes(output)


### PR DESCRIPTION
Some time the character ANSI "^J" is returned by Zyxel router. We need to replace it by new line because with it the prompt found is wrong.

Example of output:

```
ZySH> 
ZySH> sys atsh
Firmware Version        : V5.50(ABPM.5)C0
Bootbase Version        : V1.46 | 12/02/2020 19:26:12
Vendor Name             : Zyxel Communications Corp.
Product Model           : VMG3625-T50B
Serial Number           : S210Y22036929
First MAC Address       : 5C648E13D570
Last MAC Address        : 5C648E13D57F
MAC Address Quantity    : 16
Default Country Code    : E1
Boot Module Debug Flag  : 00
Kernel Checksum         : 216D97EA
RootFS Checksum         : 662A48BE
Romfile Checksum        : 0000F4A1
Main Feature Bits       : 00
Other Feature Bits      : 
7fd9127d: 04050503 00000100 00000000 00000000
7fd9128d: 00000000 00000000 00000000 0000
ZySH> ^Jsys atsh
ZySH> 
```

So we have this error:
`Pattern not detected: '\\^J' in output.`