### PR TITLE
fixing safe configuration for Huawei VRPv8

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -104,12 +104,18 @@ class HuaweiBase(NoEnable, CiscoBaseConnection):
          Configuration file had been saved successfully
          Note: The configuration file will take effect after being activated
         ######################################################################
+        or
+        ######################################################################
+        Warning: The current configuration will be written to the device. Continue? [Y/N]:y
+        Now saving the current configuration to the slot 1 .
+        Info: Save the configuration successfully.
+        ######################################################################
         """
 
         # Huawei devices might break if you try to use send_command_timing() so use send_command()
         # instead.
         if confirm:
-            pattern = rf"(?:Are you sure|{self.prompt_pattern})"
+            pattern = rf"(?:[Cc]ontinue\?|{self.prompt_pattern})"
             output = self._send_command_str(
                 command_string=cmd,
                 expect_string=pattern,
@@ -117,7 +123,7 @@ class HuaweiBase(NoEnable, CiscoBaseConnection):
                 strip_command=False,
                 read_timeout=100.0,
             )
-            if confirm_response and "Are you sure" in output:
+            if confirm_response and re.search(r"[Cc]ontinue\?", output):
                 output += self._send_command_str(
                     command_string=confirm_response,
                     expect_string=self.prompt_pattern,
@@ -266,7 +272,3 @@ class HuaweiVrpv8SSH(HuaweiSSH):
         if error_marker in output:
             raise ValueError(f"Commit failed with following errors:\n\n{output}")
         return output
-
-    def save_config(self, *args: Any, **kwargs: Any) -> str:
-        """Not Implemented"""
-        raise NotImplementedError


### PR DESCRIPTION
Method safe_config for class HuaweiVrpv8SSH is not implemented.

To Fix this I've modified safe_config of class HuaweiBase therefore it applies now for  Huawei VRPv8 devices.

These changes were tested with Huawei hardware/software below:

1. NetEngine Series Routers (VRP software, Versions 8.200/8.210/8.220)
- HUAWEI NE20E-S2F
- HUAWEI NE40E-X8A
- HUAWEI NE8000 F1A-8H20Q

2. CloudEngine Series Data Center Switches (VRP software, Versions 8.150/8.180/8.191/8.210):
- HUAWEI CE12804
- HUAWEI CE8850-64CQ-EI
- HUAWEI CE6881-48S6CQ 
- HUAWEI CE6870-48S6CQ-EI
 
3. CloudEngine S-Series Campus Switches (VRP software, Versions 5.130/5.160)
- HUAWEI S5700-52X-LI-AC
- HUAWEI S5720-52X-SI-AC
