### PR TITLE
Added Netgear ProSafe to ssh_autodetect.py

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -302,6 +302,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "netgear_prosafe": {
+        "cmd": "show version",
+        "search_patterns": [r"ProSAFE"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
 }
 
 # Sort SSH_MAPPER_DICT such that the most common commands are first


### PR DESCRIPTION
Hi, Noticed SSHDetect was failing for Netgear ProSAFE switches (Fastpath based like Dell PowerConnect). 

Added autodetect entry based off of Dell PowerConnect. 

Let me know if you need anything else, as I don't do PR's often