### PR TITLE
Remove SecretsFilter from log after disconnection

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -388,7 +388,8 @@ class BaseConnection:
         if self.secret:
             no_log["secret"] = self.secret
         # Always sanitize username and password
-        log.addFilter(SecretsFilter(no_log=no_log))
+        self._secrets_filter = SecretsFilter(no_log=no_log)
+        log.addFilter(self._secrets_filter)
 
         # Netmiko will close the session_log if we open the file
         if session_log is not None:
@@ -2480,6 +2481,7 @@ You can also look at the Netmiko session_log or debug log for more information.
             self.remote_conn = None
             if self.session_log:
                 self.session_log.close()
+            log.removeFilter(self._secrets_filter)
 
     def commit(self) -> str:
         """Commit method for platforms that support this."""

--- a/tests/unit/test_base_connection.py
+++ b/tests/unit/test_base_connection.py
@@ -4,7 +4,7 @@ import time
 from os.path import dirname, join
 from threading import Lock
 
-from netmiko import NetmikoTimeoutException
+from netmiko import NetmikoTimeoutException, log
 from netmiko.base_connection import BaseConnection
 
 RESOURCE_FOLDER = join(dirname(dirname(__file__)), "etc")
@@ -480,3 +480,13 @@ def test_strip_ansi_codes():
 
     # code_next_line must be substituted with a return
     assert connection.strip_ansi_escape_codes("\x1bE") == "\n"
+
+
+def test_remove_SecretsFilter_after_disconnection():
+    connection = BaseConnection(
+        host="testhost",  # Enter the hostname to pass initialization
+        auto_connect=False,  # No need to connect for the test purposes
+    )
+    connection.disconnect()
+
+    assert not log.filters


### PR DESCRIPTION
A memory leak happens because a new 'SecretsFilter' is added to the 'log' object every time a new 'BaseConnection' object is initialized. Remove the filter when 'disconnect' is called.