### PR TITLE
Including support for Cisco Firepower on ssh_autodetect.py

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -94,6 +94,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "cisco_ftd": {
+        "cmd": "show version",
+        "search_patterns": [r"Cisco Firepower"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "cisco_ios": {
         "cmd": "show version",
         "search_patterns": [


### PR DESCRIPTION
Adding the logic for the Firepower Threat Defense in ssh_autodetect since "cisco_ftd" is already mapped.

Local test results:

BEFORE:
```
Python 3.8.16 (default, May 31 2023, 12:44:21) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> from netmiko import SSHDetect
>>> device =  {
...     'host': '10.10.10.10',
...     'username': 'username',
...     'password': '*********',
...     'device_type': 'autodetect',
... }
>>> print(SSHDetect(**device).autodetect())
None
>>> 
```

AFTER:
```
Python 3.8.16 (default, May 31 2023, 12:44:21) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> from netmiko import SSHDetect
>>> device =  {
...     'host': '10.10.10.10',
...     'username': 'username',
...     'password': '*********',
...     'device_type': 'autodetect',
... }
>>> print(SSHDetect(**device).autodetect())
cisco_ftd
>>> 
```