### PR TITLE
Update ssh_autodetect.py to support h3c device auto detect.

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -166,6 +166,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "h3c": {
+        "cmd": "display version",
+        "search_patterns": ["H3C Comware Software"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "hp_comware": {
         "cmd": "display version",
         "search_patterns": ["HPE Comware", "HP Comware"],

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -229,6 +229,7 @@ CLASS_MAPPER_BASE = {
     "generic": GenericSSH,
     "generic_termserver": TerminalServerSSH,
     "hillstone_stoneos": HillstoneStoneosSSH,
+    "h3c": HPComwareSSH,
     "hp_comware": HPComwareSSH,
     "hp_procurve": HPProcurveSSH,
     "huawei": HuaweiSSH,


### PR DESCRIPTION
When I used the autodetect method on H3C devices, the return was empty, so I added H3C related content to SSH_MAPPER_DICT