### PR TITLE
Update f5_tmsh_ssh.py fixed "quit"

### DIFF
--- a/netmiko/f5/f5_tmsh_ssh.py
+++ b/netmiko/f5/f5_tmsh_ssh.py
@@ -22,7 +22,7 @@ class F5TmshSSH(NoConfig, BaseConnection):
         return output
 
     def exit_tmsh(self) -> str:
-        output = self._send_command_str("quit", expect_string=r"#")
+        output = self._send_command_str("quit", expect_string=r"")
         self.set_base_prompt()
         return output
 


### PR DESCRIPTION
Fixed "quit" closing session command, nothing is expected since the session is terminated immediately.