### PR TITLE
Update cisco_xr.py exit_config_mode function

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -191,7 +191,7 @@ class CiscoXrBase(CiscoBaseConnection):
             # Read until we detect either an Uncommitted change or the end prompt
             if not re.search(r"(Uncommitted|#$)", output):
                 output += self.read_until_pattern(pattern=r"(Uncommitted|#$)")
-            if "Uncommitted changes found" in output:
+            if "Uncommitted" in output:
                 self.write_channel(self.normalize_cmd("no\n"))
                 output += self.read_until_pattern(pattern=r"[>#]")
             if not re.search(pattern, output, flags=re.M):


### PR DESCRIPTION
Cisco_xr exit_config_mode function in case of uncommitted changes error.
The current function is not working in case of uncommitted changes.  because the output is until "uncommitted". function matching is for "Uncommitted changes found" .