### PR TITLE
Mikrotik free version ssh login fix

### DIFF
--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -22,14 +22,16 @@ class MikrotikBase(NoEnable, NoConfig, CiscoSSHConnection):
 
     def special_login_handler(self, delay_factor: float = 1.0) -> None:
         """Handles special case scenarios for logins that might be encountered.
- 
+
         Special cases:
         Mikrotik might prompt to read software licenses before displaying the initial prompt.
         Mikrotik might also prompt for acknowledging no software key message if unlicensed.
         """
         no_license_message = 'Please press "Enter" to continue!'
         license_prompt = "Do you want to see the software license"
-        combined_pattern = rf"(?:{self.prompt_pattern}|{no_license_message}|{license_prompt})"
+        combined_pattern = (
+            rf"(?:{self.prompt_pattern}|{no_license_message}|{license_prompt})"
+        )
 
         data = self.read_until_pattern(pattern=combined_pattern, re_flags=re.I)
 

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -43,7 +43,7 @@ class MikrotikBase(NoEnable, NoConfig, CiscoSSHConnection):
             self.write_channel("n")
             data = self.read_until_pattern(pattern=self.prompt_pattern, re_flags=re.I)
         
-        # Do we nee do to raise exception? Doesn't look to be in the original pattern, leaving as pseudo-code
+        # Do we need to raise exception? Doesn't look to be in the original pattern, leaving as pseudo-code
         #if self.prompt_pattern not in data:
         #    raise ValueError("Did not find the expected prompt pattern.")
 


### PR DESCRIPTION
## Closes #3421

## Changes
Adds additional (special) case for Miktrotik devices that are unlicensed.

Similar to the "Do you want to see the software license" case-scenario, there is an additional message for unlicensed Mikrotrik devices that requires the return key input.

I have tested this to be working.
I tried follow the existing code pattern in Netmiko, let me know!
The remaining TODO item is if we want to raise an exception, otherwise I can strip from PR before merge.

### The prompt we are now also catching
```
  MMM      MMM       KKK                          TTTTTTTTTTT      KKK
  MMMM    MMMM       KKK                          TTTTTTTTTTT      KKK
  MMM MMMM MMM  III  KKK  KKK  RRRRRR     OOOOOO      TTT     III  KKK  KKK
  MMM  MM  MMM  III  KKKKK     RRR  RRR  OOO  OOO     TTT     III  KKKKK
  MMM      MMM  III  KKK KKK   RRRRRR    OOO  OOO     TTT     III  KKK KKK
  MMM      MMM  III  KKK  KKK  RRR  RRR   OOOOOO      TTT     III  KKK  KKK

  MikroTik RouterOS 7.15rc3 (c) 1999-2024       https://www.mikrotik.com/


ROUTER HAS NO SOFTWARE KEY
----------------------------
You have 21h2m to configure the router to be remotely accessible,
and to enter the key by pasting it in a Telnet window or in Winbox.
Turn off the device to stop the timer.
See www.mikrotik.com/key for more details.

Current installation "software ID": 0000-0000
Please press "Enter" to continue!
```