### PR TITLE
fortinet _preferred_kex settings interfering with other devices

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -472,15 +472,12 @@ class BaseConnection:
             self.system_host_keys = system_host_keys
             self.alt_host_keys = alt_host_keys
             self.alt_key_file = alt_key_file
+            self.disabled_algorithms = disabled_algorithms or {}
 
-            if disabled_algorithms:
-                self.disabled_algorithms = disabled_algorithms
-            else:
-                self.disabled_algorithms = (
-                    {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
-                    if disable_sha2_fix
-                    else {}
-                )
+            if disable_sha2_fix:
+                sha2_pubkeys = ["rsa-sha2-256", "rsa-sha2-512"]
+                # Merge sha2_pubkeys into pubkeys and prevent duplicates with a set
+                self.disabled_algorithms["pubkeys"] = list(set(self.disabled_algorithms.get("pubkeys", []) + sha2_pubkeys))
 
             # For SSH proxy support
             self.ssh_config_file = ssh_config_file

--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -1,6 +1,6 @@
 import paramiko
 import re
-from typing import Optional
+from typing import Optional, Any
 
 from netmiko.no_config import NoConfig
 from netmiko.no_enable import NoEnable
@@ -10,15 +10,22 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 class FortinetSSH(NoConfig, NoEnable, CiscoSSHConnection):
     prompt_pattern = r"[#$]"
 
-    def _modify_connection_params(self) -> None:
-        """Modify connection parameters prior to SSH connection."""
-        paramiko_transport = getattr(paramiko, "Transport")
-        paramiko_transport._preferred_kex = (
-            "diffie-hellman-group14-sha1",
-            "diffie-hellman-group-exchange-sha1",
-            "diffie-hellman-group-exchange-sha256",
-            "diffie-hellman-group1-sha1",
-        )
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        disabled_algorithms = kwargs.get("disabled_algorithms")
+        if disabled_algorithms is None:
+            # We only want these and disable the rest
+            _preferred_kex = {
+                "diffie-hellman-group14-sha1",
+                "diffie-hellman-group-exchange-sha1",
+                "diffie-hellman-group-exchange-sha256",
+                "diffie-hellman-group1-sha1",
+            }
+            paramiko_transport = getattr(paramiko, "Transport")
+            kwargs["disabled_algorithms"] = {
+                "kex": list(set(paramiko_transport._preferred_kex) - _preferred_kex)
+            }
+
+        super().__init__(*args, **kwargs)
 
     def _try_session_preparation(self, force_data: bool = False) -> None:
         super()._try_session_preparation(force_data=force_data)


### PR DESCRIPTION
I have a program that connects to multiple devcies, which include fortinet and aruba_os. The moment I connected to a fortinet device I could no longer connect to aruba_os, with the error `paramiko.ssh_exception.IncompatiblePeer: Incompatible ssh peer (no acceptable kex algorithm)`.

Turns out the fortinet driver is editing the paramiko Transport class. This commit fixes that by using `disabled_algorithms` instead.