### PR TITLE
add split-task to possible vdom configs

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -74,7 +74,9 @@ class FortinetSSH(NoConfig, NoEnable, CiscoSSHConnection):
             check_command, expect_string=self.prompt_pattern
         )
         return bool(
-            re.search(r"Virtual domain configuration: (multiple|enable)", output)
+            re.search(
+                r"Virtual domain configuration: (multiple|enable|split-task)", output
+            )
         )
 
     def _config_global(self) -> str:


### PR DESCRIPTION
Edge case of having exactly two vdoms is called split-task in fortinet land, add that to possible vdom configs