### PR TITLE
Bugfix Graceful exit command

### DIFF
--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -136,6 +136,9 @@ class MikrotikBase(NoEnable, NoConfig, CiscoSSHConnection):
             command_string=command_string, cmd_verify=cmd_verify, **kwargs
         )
 
+    def cleanup(self, command: str = "quit") -> None:
+        """MikroTik uses 'quit' command instead of 'exit'."""
+        return super().cleanup(command=command)
 
 class MikrotikRouterOsSSH(MikrotikBase):
     """Mikrotik RouterOS SSH driver."""

--- a/netmiko/mikrotik/mikrotik_ssh.py
+++ b/netmiko/mikrotik/mikrotik_ssh.py
@@ -140,6 +140,7 @@ class MikrotikBase(NoEnable, NoConfig, CiscoSSHConnection):
         """MikroTik uses 'quit' command instead of 'exit'."""
         return super().cleanup(command=command)
 
+
 class MikrotikRouterOsSSH(MikrotikBase):
     """Mikrotik RouterOS SSH driver."""
 


### PR DESCRIPTION
MikroTik uses 'quit' comand instead of 'exit' in order to terminate session, so 'cleanup' function has been overridden to adjust its behavior.