### PR TITLE
Add code_disable_bracketed_paste_mode to set of ansi escape codes to strip and strip ansi escape codes on Arista EOS devices

### DIFF
--- a/netmiko/arista/arista.py
+++ b/netmiko/arista/arista.py
@@ -13,6 +13,7 @@ class AristaBase(CiscoSSHConnection):
 
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
         self._test_channel_read(pattern=self.prompt_pattern)
         cmd = "terminal width 511"
         self.set_terminal_width(command=cmd, pattern=r"Width set to")

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2364,6 +2364,8 @@ You can also look at the Netmiko session_log or debug log for more information.
         ESC[9999B    Move cursor down N-lines (very large value is attempt to move to the
                      very bottom of the screen)
         ESC[c        Query Device (used by MikroTik in 'Safe-Mode')
+        ESC[2004h    Enable bracketed paste mode
+        ESC[2004l    Disable bracketed paste mode
 
         :param string_buffer: The string to be processed to remove ANSI escape codes
         :type string_buffer: str
@@ -2397,7 +2399,8 @@ You can also look at the Netmiko session_log or debug log for more information.
         code_cursor_up = chr(27) + r"\[\d*A"
         code_cursor_down = chr(27) + r"\[\d*B"
         code_wrap_around = chr(27) + r"\[\?7h"
-        code_bracketed_paste_mode = chr(27) + r"\[\?2004h"
+        code_enable_bracketed_paste_mode = chr(27) + r"\[\?2004h"
+        code_disable_bracketed_paste_mode = chr(27) + r"\[\?2004l"
         code_underline = chr(27) + r"\[4m"
         code_query_device = chr(27) + r"\[c"
 
@@ -2429,7 +2432,8 @@ You can also look at the Netmiko session_log or debug log for more information.
             code_cursor_down,
             code_cursor_forward,
             code_wrap_around,
-            code_bracketed_paste_mode,
+            code_enable_bracketed_paste_mode,
+            code_disable_bracketed_paste_mode,
             code_underline,
             code_query_device,
         ]

--- a/tests/unit/test_base_connection.py
+++ b/tests/unit/test_base_connection.py
@@ -469,6 +469,8 @@ def test_strip_ansi_codes():
         "\x1b[0m",  # code_attrs_off
         "\x1b[7m",  # code_reverse
         "\x1b[c",  # code_query_device
+        "\x1b[?2004h",  # code_enable_bracketed_paste_mode
+        "\x1b[?2004l",  # code_disable_bracketed_paste_mode
     ]
     for ansi_code in ansi_codes_to_strip:
         assert connection.strip_ansi_escape_codes(ansi_code) == ""


### PR DESCRIPTION
Closes https://github.com/ktbyers/netmiko/issues/3482

Beginning in Bash 5.1, the default is to enable bracketed-paste-mode, which results in escape code characters being sent back to the Netmiko client. 

This PR adds `disable-bracketed-paste-mode` to the set of ansi escape codes that are stripped from the response from devices and updates the session preparation method for Arista devices to strip ansi escape codes from the response from Arista EOS devices. Beginning in the Arista EOS 4.32 train, the default bash version used is 5.1. 
