### PR TITLE
linux_ssh: fix for 'Invalid output from MD5 command'

### DIFF
--- a/netmiko/linux/linux_ssh.py
+++ b/netmiko/linux/linux_ssh.py
@@ -211,7 +211,7 @@ class LinuxFileTransfer(CiscoFileTransfer):
                 remote_file = self.source_file
         remote_md5_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
         dest_md5 = self.ssh_ctl_chan._send_command_str(remote_md5_cmd, read_timeout=300)
-        dest_md5 = self.process_md5(dest_md5).strip()
+        dest_md5 = self.process_md5(dest_md5.strip()).strip()
         return dest_md5
 
     @staticmethod


### PR DESCRIPTION
I believe that this:

fixes issue #3209

Original credit goes to commenter on the issue: https://github.com/ktbyers/netmiko/issues/3209#issuecomment-2245991018

Locally I am using this change and it fixes the problem. 