### PR TITLE
Change Sophos module allowing the user to navigate the interactive menu prompt.

### DIFF
--- a/netmiko/sophos/sophos_sfos_ssh.py
+++ b/netmiko/sophos/sophos_sfos_ssh.py
@@ -15,7 +15,7 @@ SOPHOS_MENU_DEFAULT = os.getenv("NETMIKO_SOPHOS_MENU", "4")
 class SophosSfosSSH(NoEnable, NoConfig, CiscoSSHConnection):
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
-        self._test_channel_read(pattern=r"Main Menu")
+        self._test_channel_read(pattern=r"Select Menu Number")
         """
         Sophos Firmware Version SFOS 18.0.0 GA-Build339
 
@@ -32,9 +32,7 @@ class SophosSfosSSH(NoEnable, NoConfig, CiscoSSHConnection):
 
             Select Menu Number [0-7]:
         """
-        self.write_channel(SOPHOS_MENU_DEFAULT + self.RETURN)
-        self._test_channel_read(pattern=r"[#>]")
-        self.set_base_prompt()
+        self.send_command_expect("\r", expect_string=r"Select Menu Number")
         # Clear the read buffer
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()


### PR DESCRIPTION
The default functionality of Netmiko is passing an initial carriage return once the connection is established, this was breaking the compatibility with the Sophos interface which displays an interactive prompt where you need to make a numeric selection and press enter, this would set up the session in a bad place to pass the command to reach the Device Console as you need another carriage return before passing the numeric selection.

With the changes made now the user can decide whether to use any of these predefined functions of the interactive main menu, including stepping into the Device Console, or even Advanced Shell, by passing the appropriate menu selections to the connection.