### PR TITLE
Remove unused dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2963,13 +2963,13 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "setuptools"
-version = "75.1.0"
+version = "75.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-75.1.0-py3-none-any.whl", hash = "sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2"},
-    {file = "setuptools-75.1.0.tar.gz", hash = "sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"},
+    {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
+    {file = "setuptools-75.2.0.tar.gz", hash = "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"},
 ]
 
 [package.extras]
@@ -3413,4 +3413,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "9d6612a32172ccfd1d6cf4011847882574873722a4fd73d49f712522fe07b223"
+content-hash = "405231099d6a49eae3cdc0b65c3dc7d63c280159c3f656f762bc21ce9d920f53"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,12 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-setuptools = ">=65.0.0"
 paramiko = ">=2.9.5"
 scp = ">=0.13.6"
 pyyaml = ">=6.0.2"
 textfsm = ">=1.1.3"
 ntc-templates = ">=3.1.0"
 pyserial = ">=3.3"
-cffi = ">=1.17.0rc1"
 rich = ">=13.8"
 "ruamel.yaml" = ">=0.17"
 
@@ -45,6 +43,7 @@ pysnmp = "6.2.6"
 pdoc3 = "0.11.1"
 types-paramiko = "3.5.0.20240918"
 types-PyYAML = "6.0.12.20240917"
+setuptools = ">=65.0.0"
 
 [tool.poetry.group.parsers]
 optional = true


### PR DESCRIPTION
`setuptools` and `cffi` still appear to be indirect dependencies, but there's no need to depend on them directly when they aren't used directly.