### PR TITLE
add prompt stripping to nokia srl

### DIFF
--- a/netmiko/nokia/nokia_srl.py
+++ b/netmiko/nokia/nokia_srl.py
@@ -53,6 +53,32 @@ class NokiaSrlSSH(BaseConnection, NoEnable):
             self.disable_paging(command=command, cmd_verify=True, pattern=r"#")
         self.set_base_prompt()
 
+    def strip_prompt(self, *args: Any, **kwargs: Any) -> str:
+        """Strip the line1 of multiline prompt from the output."""
+        a_string = super().strip_prompt(*args, **kwargs)
+        return self.strip_context_items(a_string)
+
+    def strip_context_items(self, a_string: str) -> str:
+        """Strip NokiaSRL-specific output.
+
+        Nokia will put extra context is line 1 of the prompt, such as:
+        --{ running }--[  ]--
+        --{ candidate private private-admin }--[  ]--
+        --{ candidate private private-admin }--[  ]--
+
+        This method removes those lines.
+        """
+        strings_to_strip = [
+            r"--{.*\B",
+        ]
+
+        response_list = a_string.split(self.RESPONSE_RETURN)
+        last_line = response_list[-1]
+        for pattern in strings_to_strip:
+            if re.search(pattern, last_line, flags=re.I):
+                return self.RESPONSE_RETURN.join(response_list[:-1])
+        return a_string
+
     def set_base_prompt(
         self,
         pri_prompt_terminator: str = "#",


### PR DESCRIPTION
fixes #3522 Uses prompt stripping logic similar to what was done in Juniper.

previous output from a show command had first line of prompt included
```python
{
  "basic system info": {
    "Hostname": "srl1",
    "Chassis Type": "7220 IXR-D2L",
    "Part Number": "Sim Part No.",
    "Serial Number": "Sim Serial No.",
    "System HW MAC Address": "1A:66:00:FF:00:00",
    "OS": "SR Linux",
    "Software Version": "v24.7.2",
    "Build Number": "319-g64b71941f7",
    "Architecture": "<Unknown>",
    "Last Booted": "2024-11-08T16:06:30.680Z",
    "Total Memory": "<Unknown>",
    "Free Memory": "<Unknown>"
  }
}
--{ running }--[  ]--
```

This change strips the trailing prompt lines.

```python
{
  "basic system info": {
    "Hostname": "srl1",
    "Chassis Type": "7220 IXR-D2L",
    "Part Number": "Sim Part No.",
    "Serial Number": "Sim Serial No.",
    "System HW MAC Address": "1A:66:00:FF:00:00",
    "OS": "SR Linux",
    "Software Version": "v24.7.2",
    "Build Number": "319-g64b71941f7",
    "Architecture": "<Unknown>",
    "Last Booted": "2024-11-08T16:06:30.680Z",
    "Total Memory": "<Unknown>",
    "Free Memory": "<Unknown>"
  }
}
```