### PR TITLE
Lower cisco ios priority such that IOS-XE is preferred

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -107,7 +107,7 @@ SSH_MAPPER_DICT = {
             "Cisco IOS Software",
             "Cisco Internetwork Operating System Software",
         ],
-        "priority": 99,
+        "priority": 95,
         "dispatch": "_autodetect_std",
     },
     "cisco_xe": {


### PR DESCRIPTION
This is for the case when both `Cisco IOS` and `Cisco XE` patterns match...should use `cisco_xe` in that case.