### PR TITLE
Adding support for corvil

### DIFF
--- a/netmiko/corvil/__init__.py
+++ b/netmiko/corvil/__init__.py
@@ -1,0 +1,5 @@
+from netmiko.corvil.corvilcne_ssh import CorvilCNESSH
+
+__all__ = [
+    "CorvilCNESSH"
+]

--- a/netmiko/corvil/corvilcne_ssh.py
+++ b/netmiko/corvil/corvilcne_ssh.py
@@ -1,0 +1,45 @@
+"""
+Corvil CNE support.
+
+For use with Corvil CNE devices.
+
+"""
+from typing import Any
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class CorvilCNESSH(CiscoSSHConnection):
+    """Corvil CNE support"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        if kwargs.get("default_enter") is None:
+            kwargs["default_enter"] = "\r"
+        return super().__init__(**kwargs)
+
+    def session_preparation(self) -> None:
+        self.ansi_escape_codes = True
+        self._test_channel_read(pattern="$")
+        self.disable_paging(command="terminal length 0")
+
+    def check_config_mode(
+        self,
+        check_string: str = "(config) $",
+        pattern: str = r"[$]",
+        force_regex: bool = False,
+    ) -> bool:
+        """
+        Checks if the device is in configuration mode or not.
+
+        Corvil uses "<devicename>(config) $" as config prompt
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def config_mode(
+        self,
+        config_command: str = "config",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )

--- a/netmiko/gigamon/__init__.py
+++ b/netmiko/gigamon/__init__.py
@@ -1,0 +1,5 @@
+from netmiko.gigamon.gigamonvue_ssh import GigamonVUESSH
+
+__all__ = [
+    "GigamonVUESSH"
+]

--- a/netmiko/gigamon/gigamonvue_ssh.py
+++ b/netmiko/gigamon/gigamonvue_ssh.py
@@ -1,0 +1,45 @@
+"""
+Gigamon GigaVUE support.
+
+For use with Gigamon GigaVUE devices.
+
+"""
+from typing import Any
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class GigamonVUESSH(CiscoSSHConnection):
+    """Gigamon GigaVUE support"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        if kwargs.get("default_enter") is None:
+            kwargs["default_enter"] = "\r"
+        return super().__init__(**kwargs)
+
+    def session_preparation(self) -> None:
+        self.ansi_escape_codes = True
+        self.set_base_prompt()
+        self.disable_paging(command="no cli session paging enable")
+
+    def check_config_mode(
+        self,
+        check_string: str = "(config) #",
+        pattern: str = r"[>#]",
+        force_regex: bool = False,
+    ) -> bool:
+        """
+        Checks if the device is in configuration mode or not.
+
+        Perle uses "(<devicename>) (config) #" as config prompt
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def config_mode(
+        self,
+        config_command: str = "configure terminal",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -52,6 +52,7 @@ from netmiko.cisco import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer
 from netmiko.citrix import NetscalerSSH
 from netmiko.cloudgenix import CloudGenixIonSSH
 from netmiko.coriant import CoriantSSH
+from netmiko.corvil import CorvilCNESSH
 from netmiko.dell import DellDNOS6SSH
 from netmiko.dell import DellDNOS6Telnet
 from netmiko.dell import DellForce10SSH
@@ -202,6 +203,7 @@ CLASS_MAPPER_BASE = {
     "cisco_xr": CiscoXrSSH,
     "cloudgenix_ion": CloudGenixIonSSH,
     "coriant": CoriantSSH,
+    "corvil_cne": CorvilCNESSH,
     "dell_dnos9": DellForce10SSH,
     "dell_force10": DellForce10SSH,
     "dell_os6": DellDNOS6SSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -86,6 +86,7 @@ from netmiko.f5 import F5LinuxSSH
 from netmiko.fiberstore import FiberstoreFsosSSH
 from netmiko.flexvnf import FlexvnfSSH
 from netmiko.fortinet import FortinetSSH
+from netmiko.gigamon import GigamonVUESSH
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.hillstone import HillstoneStoneosSSH
 from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
@@ -240,6 +241,7 @@ CLASS_MAPPER_BASE = {
     "garderos_grs": GarderosGrsSSH,
     "generic": GenericSSH,
     "generic_termserver": TerminalServerSSH,
+    "gigamon_gigavue": GigamonVUESSH,
     "hillstone_stoneos": HillstoneStoneosSSH,
     "hp_comware": HPComwareSSH,
     "hp_procurve": HPProcurveSSH,


### PR DESCRIPTION
Show

commands = ["show version”]

Output

Corvil CNE Appliance software: Version 10.0.1 (10.0.1.20732-GA.296474-64bit Thu
17 Oct 2024)
CorvilMeter software: CDK_3_0_BUILD_73 (conf May 30 03:18:34 2024)
Application Recognition Module: ARM v6.86 (full)

Config

config_commands = [
‘subnet-group bla’,
‘description “Azure ip space”’,
‘subnet 1.2.3.45/32’,
‘end’
}

Output

switch(config)$ subnet-group bla
Created: subnet-group bla
switch(config-subnet-group)$ description "Azure ip space"
switch(config-subnet-group)$ subnet 1.2.3.4/32
switch(config-subnet-group)$ end
switch(config)$