### PR TITLE
Huawei smartax ssh autodetect

### DIFF
--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -2,7 +2,7 @@
 
 import time
 import re
-from typing import Optional
+from typing import Optional, Any
 from enum import Enum
 
 from netmiko.cisco_base_connection import CiscoBaseConnection
@@ -22,7 +22,7 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
 
     prompt_pattern = r"[>$]"
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.mmi_mode = False
         if "mmi-mode" in kwargs:
             if not isinstance(kwargs["mmi-mode"], bool):

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -194,6 +194,14 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "huawei_smartax": {
+        "cmd": "display system sys-info\n",
+        "search_patterns": [
+            r'Huawei Integrated Access Software',
+        ],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "juniper_junos": {
         "cmd": "show version",
         "search_patterns": [
@@ -537,6 +545,7 @@ class SSHDetect(object):
             r"command not found",
             r"Syntax Error: unexpected argument",
             r"% Unrecognized command found at",
+            r"% Unknown command, the error locates at \'^\'"
         ]
         if not cmd or not search_patterns:
             return 0

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -197,7 +197,7 @@ SSH_MAPPER_DICT = {
     "huawei_smartax": {
         "cmd": "display system sys-info\n",
         "search_patterns": [
-            r'Huawei Integrated Access Software',
+            r"Huawei Integrated Access Software",
         ],
         "priority": 99,
         "dispatch": "_autodetect_std",
@@ -545,7 +545,7 @@ class SSHDetect(object):
             r"command not found",
             r"Syntax Error: unexpected argument",
             r"% Unrecognized command found at",
-            r"% Unknown command, the error locates at \'^\'"
+            r"% Unknown command, the error locates at \'^\'",
         ]
         if not cmd or not search_patterns:
             return 0


### PR DESCRIPTION
Adding support for Huawei SmartAX. The `\n` is important because by default this device has a smart mode completion. This way the final output would be like this:
```
OLT>display system sys-info 
{ <cr>||<K> }: 

  Command:
          display system sys-info
  --------------------------------------------------
  The main service identification of this node:
    1

  The IP address of this node:
    1.1.1.1

  The description of this node:
    Huawei Integrated Access Software
  --------------------------------------------------
```