### PR TITLE
H3C switches are too slow in executing commands

### DIFF
--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -37,10 +37,10 @@ class HPComwareBase(CiscoSSHConnection):
         return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
 
     def check_config_mode(
-        self, check_string: str = "]", pattern: str = "", force_regex: bool = False
+        self, check_string: str = "]", pattern: str = r"[>]|]", force_regex: bool = False
     ) -> bool:
         """Check whether device is in configuration mode. Return a boolean."""
-        return super().check_config_mode(check_string=check_string)
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
 
     def send_config_set(
         self,


### PR DESCRIPTION
Compared to Cisco switches, H3C switches are too slow in executing
commands because the value of the pattern is not set in the
check_config_mode function. This function is called twice in both
the config_mode and exit_config_mode, each time using read_channel_timing
instead of read_until_pattern, which greatly extends the duration.
This commit set default pattern of hp_comware to save time when
checking the config mode.