### PR TITLE
Fix screenos accept

### DIFF
--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -13,12 +13,11 @@ class JuniperScreenOsSSH(NoEnable, NoConfig, BaseConnection):
         ScreenOS can be configured to require: Accept this agreement y/[n]
         """
         terminator = r"\->"
-        pattern = rf"(?:Accept this|{terminator})"
-        data = self._test_channel_read(pattern=pattern)
+        pattern = rf"(?:Accept this.*|{terminator})"
+        data = self.read_until_pattern(pattern=pattern)
         if "Accept this" in data:
             self.write_channel("y")
-            data += self._test_channel_read(pattern=terminator)
-
+            data += self.read_until_pattern(pattern=terminator)
         self.set_base_prompt()
         self.disable_paging(command="set console page 0")
 


### PR DESCRIPTION
Looking at debug that was sent over--it looks like the SSH channel is being terminated, my hypothesis is that the channel is being closed by the remote networking device due to us sending an `\n` key (from _test_channel_read()). 

We are sending an <enter> and the device says, you are not <accepting> the conditions by typing "y" so it closes the channel.

So shifted to `read_until_pattern()` so that the extra newline send goes away.