### PR TITLE
Screenos 'accept' fix (attempt #3)

### DIFF
--- a/netmiko/juniper/juniper_screenos.py
+++ b/netmiko/juniper/juniper_screenos.py
@@ -8,6 +8,9 @@ class JuniperScreenOsSSH(NoEnable, NoConfig, BaseConnection):
     Implement methods for interacting with Juniper ScreenOS devices.
     """
 
+    def _try_session_preparation(self, force_data: bool = False) -> None:
+        return super()._try_session_preparation(force_data=force_data)
+
     def session_preparation(self) -> None:
         """
         ScreenOS can be configured to require: Accept this agreement y/[n]


### PR DESCRIPTION
Newline before 'accept' message was still happening. This was due to `_try_session_preparation` and `force_data=True` behavior.

So set `force_data=False` to eliminate this newline.