### PR TITLE
Adding support for FS OS

### DIFF
--- a/netmiko/fs/__init__.py
+++ b/netmiko/fs/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.fs.fs_os import FSOSSSH, FSOSTelnet
+
+__all__ = ["FSOSSSH", "FSOSTelnet"]

--- a/netmiko/fs/fs_os.py
+++ b/netmiko/fs/fs_os.py
@@ -1,4 +1,5 @@
 """FS Support"""
+
 import time
 from typing import Any
 

--- a/netmiko/fs/fs_os.py
+++ b/netmiko/fs/fs_os.py
@@ -1,0 +1,39 @@
+"""FS Support"""
+import time
+from typing import Any
+
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+
+class FSOSBase(CiscoBaseConnection):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        """FS OS requires enable mode to set terminal width"""
+        self.enable()
+        self.set_terminal_width(command="terminal width 256", pattern="terminal")
+        self.disable_paging(command="terminal length 0")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def save_config(
+        self, cmd: str = "write", confirm: bool = False, confirm_response: str = ""
+    ) -> str:
+        """Save config: write"""
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+
+class FSOSSSH(FSOSBase):
+
+    pass
+
+
+class FSOSTelnet(FSOSBase):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -87,6 +87,7 @@ from netmiko.f5 import F5LinuxSSH
 from netmiko.fiberstore import FiberstoreFsosSSH
 from netmiko.flexvnf import FlexvnfSSH
 from netmiko.fortinet import FortinetSSH
+from netmiko.fs import FSOSSSH, FSOSTelnet
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.genexis import GenexisSOLT33Telnet
 from netmiko.hillstone import HillstoneStoneosSSH
@@ -240,6 +241,7 @@ CLASS_MAPPER_BASE = {
     "fiberstore_fsos": FiberstoreFsosSSH,
     "flexvnf": FlexvnfSSH,
     "fortinet": FortinetSSH,
+    "fs_os": FSOSSSH,
     "garderos_grs": GarderosGrsSSH,
     "generic": GenericSSH,
     "generic_termserver": TerminalServerSSH,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -87,7 +87,7 @@ from netmiko.f5 import F5LinuxSSH
 from netmiko.fiberstore import FiberstoreFsosSSH
 from netmiko.flexvnf import FlexvnfSSH
 from netmiko.fortinet import FortinetSSH
-from netmiko.fs import FSOSSSH, FSOSTelnet
+from netmiko.fs import FSOSSSH
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.genexis import GenexisSOLT33Telnet
 from netmiko.hillstone import HillstoneStoneosSSH

--- a/tests/etc/commands.yml.example
+++ b/tests/etc/commands.yml.example
@@ -618,3 +618,14 @@ fiberstore_fsos:
     - 'no logging console'
     - 'logging buffered severity 3'
   config_verification: "show run"
+
+fs_os:
+  version: "show version"
+  basic: "show ip interface brief"
+  extended_output: "show run"
+  config:
+    - "logging buffered 4096"
+  config_verification: "show run | inc logging buffer"
+  save_config_cmd: 'write'
+  save_config_confirm: False
+  save_config_response: 'OK'

--- a/tests/etc/responses.yml.example
+++ b/tests/etc/responses.yml.example
@@ -455,3 +455,12 @@ fiberstore_fsos:
   version_banner: "Loader Version   :"
   multiple_line_output: "! System Description: "
   save_config: 'Success'
+
+fs_os:
+  base_prompt: FS
+  router_prompt: FS>
+  enable_prompt: FS#
+  interface_ip: 10.1.11.200
+  version_banner: "FS Data Center Switch"
+  multiple_line_output: "Building configuration..."
+  save_config: '[OK]'

--- a/tests/etc/test_devices.yml.example
+++ b/tests/etc/test_devices.yml.example
@@ -322,3 +322,9 @@ hillstone:
   ip: 192.168.100.234
   username: hillstone
   password: Hillstone
+
+fs_os:
+  device_type: fs_os
+  ip: 10.1.11.200
+  username: admin
+  password: admin


### PR DESCRIPTION
The goal of this PR is to help merge #3372, since the original poster did not respond to the comments.
I did not write the code, I only added tests.
FS OS would be helpful to have.

output from `show` test:
```py.test -v test_netmiko_show.py --test_device fs_os
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/ticktock/netmiko
configfile: setup.cfg
collected 25 items                                                                                                                                                          

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                    [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                      [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                      [ 12%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                         [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                      [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                 [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                  [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                        [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                         [ 36%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                         [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                        [ 44%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                     [ 48%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                          [ 52%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                              [ 56%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                     [ 60%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                              [ 64%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                              [ 68%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                         [ 72%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                        [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                       [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                 [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                        [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                         [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                          [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                               [100%]

========================================================================== short test summary info ==========================================================================
SKIPPED [1] test_netmiko_show.py:25: Not using SSH-keys
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
====================================================================== 13 passed, 12 skipped in 22.91s ======================================================================
```


output from `config` test:
```py.test -v test_netmiko_config.py --test_device fs_os
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/ticktock/netmiko
configfile: setup.cfg
collected 13 items                                                                                                                                                          

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                       [  7%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                       [ 15%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                       [ 23%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                  [ 30%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                        [ 38%]
test_netmiko_config.py::test_config_set_generator PASSED                                                                                                              [ 46%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                            [ 53%]
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                   [ 61%]
test_netmiko_config.py::test_config_from_file SKIPPED                                                                                                                 [ 69%]
test_netmiko_config.py::test_config_error_pattern SKIPPED (No error_pattern defined.)                                                                                 [ 76%]
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)                                                                                                      [ 84%]
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)                                                                                           [ 92%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                        [100%]

========================================================================== short test summary info ==========================================================================
SKIPPED [1] test_netmiko_config.py:163: Skipped
SKIPPED [1] test_netmiko_config.py:175: No error_pattern defined.
SKIPPED [1] test_netmiko_config.py:209: No banner defined.
SKIPPED [1] test_netmiko_config.py:242: No banner defined.
======================================================================= 9 passed, 4 skipped in 59.45s =======================================================================
```