### PR TITLE
FastIron: Fix missing non-greedy, fix no enable pwd, improve base_connection

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -723,7 +723,10 @@ parenthesis completely wrap the pattern '(pattern)'"""
                     pattern = f"({pattern})"
                     results = re.split(pattern, output, maxsplit=1, flags=re_flags)
 
-                if len(results) != 3:
+                if len(results) == 3:
+                    output, match_str, buffer = results
+
+                if len(results) != 3 or match_str is None:
                     # well, we tried
                     msg = f"""Unable to successfully split output based on pattern:
 pattern={pattern}
@@ -734,7 +737,6 @@ results={results}
 
                 # Process such that everything before and including pattern is return.
                 # Everything else is retained in the _read_buffer
-                output, match_str, buffer = results
                 output = output + match_str
                 if buffer:
                     self._read_buffer += buffer

--- a/netmiko/ruckus/ruckus_fastiron.py
+++ b/netmiko/ruckus/ruckus_fastiron.py
@@ -23,7 +23,7 @@ class RuckusFastironBase(CiscoSSHConnection):
     def enable(
         self,
         cmd: str = "enable",
-        pattern: str = r"(ssword|User Name|Login)",
+        pattern: str = r"(?:ssword|User Name|Login|No password has been assigned)",
         enable_pattern: Optional[str] = None,
         check_state: bool = True,
         re_flags: int = re.IGNORECASE,
@@ -59,6 +59,8 @@ class RuckusFastironBase(CiscoSSHConnection):
                 output += new_data
                 if not re.search(r"error.*incorrect.*password", new_data, flags=re.I):
                     break
+            if "No password has been assigned" in new_data:
+                break
 
             time.sleep(1)
             i += 1


### PR DESCRIPTION
Pattern in ruckus_fastiron was missing "?:" non-greedy.

Pattern didn't handle no enable secret case.

Finally improve base_connection split operation to try to ensure that failed pattern matches that are None don't get string concatenated and instead a more helpful error messages is raised.