### PR TITLE
ADD: Support for LANCOM LCOS SX 5

### DIFF
--- a/netmiko/lancom/__init__.py
+++ b/netmiko/lancom/__init__.py
@@ -1,3 +1,4 @@
 from netmiko.lancom.lancom_lcossx4 import LancomLCOSSX4SSH
+from netmiko.lancom.lancom_lcossx5 import LancomLCOSSX5SSH
 
-__all__ = ["LancomLCOSSX4SSH"]
+__all__ = ["LancomLCOSSX4SSH", "LancomLCOSSX5SSH"]

--- a/netmiko/lancom/lancom_lcossx5.py
+++ b/netmiko/lancom/lancom_lcossx5.py
@@ -1,0 +1,97 @@
+from netmiko.cisco_base_connection import CiscoSSHConnection
+
+
+class LancomLCOSSX5SSH(CiscoSSHConnection):
+    def session_preparation(self) -> None:
+        """
+        Prepare the session after the connection has been established.
+
+        The connection will enter `Privileged EXEC` by default, as the `EXEC` mode
+        offers inconsistent command options
+        """
+        self._test_channel_read()
+        super().send_command_timing(
+            "enable",
+            strip_prompt=False,
+            strip_command=False,
+        )
+        super().set_base_prompt()
+        super().disable_paging()
+        self.clear_buffer()
+
+    def set_terminal_width(self, *args, **kwargs) -> str:
+        """
+        LCOS SX 5 does not support 'terminal width', therefore skip it.
+        """
+        return ""
+
+    def check_config_mode(
+        self,
+        check_string: str = "(Config)#",
+        pattern: str = "#",
+        force_regex: bool = False,
+    ) -> bool:
+        """
+        Checks if the device is in configuration mode or not.
+
+        :param check_string: Identification of configuration mode from the device
+        :type check_string: str
+
+        :param pattern: Pattern to terminate reading of channel
+        :type pattern: str
+
+        :param force_regex: Use regular expression pattern to find check_string in output
+        :type force_regex: bool
+
+        :return: True if in configuration mode, False if not
+        """
+        return super().check_config_mode(
+            check_string=check_string, pattern=pattern, force_regex=force_regex
+        )
+
+    def exit_enable_mode(self, exit_command: str = "end") -> str:
+        """Exits enable (privileged exec) mode."""
+        return super().exit_enable_mode(exit_command=exit_command)
+
+    def cleanup(self, command: str = "logout") -> None:
+        """
+        Cleanup / Gracefully exit the SSH session
+
+        :param command: LANCOM LCOS SX 5.x uses logout to exit the session
+        :type command: str
+        """
+        # LANCOM does not allow running "Exec" commands in configuration mode
+        if self.check_config_mode():
+            command = "do " + command
+        return super().cleanup(command)
+
+    def save_config(
+        self,
+        cmd: str = "write memory confirm",
+        confirm: bool = False,
+        confirm_response: str = "y",
+    ) -> str:
+        """
+        Save the running Config.
+
+        :param cmd: The command to send to the device to save the configuration
+        :type cmd: str
+
+        :param confirm: Whether to confirm the save or not
+        :type confirm: bool
+
+        :param confirm_response: The response to send to the device to confirm the save
+        :type confirm_response: str
+
+        :param output_pattern: The pattern to match the output of the save command
+        :type output_pattern: str
+        """
+
+        # LANCOM does not allow running "Exec" commands in configuration mode
+        if self.check_config_mode():
+            cmd = "do " + cmd
+        return super().save_config(
+            cmd=cmd,
+            confirm=confirm,
+            confirm_response=confirm_response,
+        )

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -114,7 +114,7 @@ from netmiko.ipinfusion import IpInfusionOcNOSSSH, IpInfusionOcNOSTelnet
 from netmiko.juniper import JuniperSSH, JuniperTelnet, JuniperScreenOsSSH
 from netmiko.juniper import JuniperFileTransfer
 from netmiko.keymile import KeymileSSH, KeymileNOSSSH
-from netmiko.lancom import LancomLCOSSX4SSH
+from netmiko.lancom import LancomLCOSSX4SSH, LancomLCOSSX5SSH
 from netmiko.linux import LinuxSSH, LinuxFileTransfer
 from netmiko.maipu import MaipuSSH
 from netmiko.maipu import MaipuTelnet
@@ -289,6 +289,7 @@ CLASS_MAPPER_BASE = {
     "keymile": KeymileSSH,
     "keymile_nos": KeymileNOSSSH,
     "lancom_lcossx4": LancomLCOSSX4SSH,
+    "lancom_lcossx5": LancomLCOSSX5SSH,
     "linux": LinuxSSH,
     "mikrotik_routeros": MikrotikRouterOsSSH,
     "mikrotik_switchos": MikrotikSwitchOsSSH,


### PR DESCRIPTION
### Title
ADD: Support for LANCOM LCOS SX 5

### Description
This PR introduces a new driver for LANCOM devices running LCOS SX 5, which is the OS for the Enterprise models.

### Peculiarity
LANCOM does not allow `Exec` commands to be run in `Config` Mode, therefore a `config-mode-check` is added to `save_config` and `cleanup`.
SSH Connection to LCOS SX 5 devices normally start in the `EXEC` Mode. This Mode however offers only inconsistent command usage. Therefore the driver will elevate the Session to `privileged EXEC` Mode by default during `session_preparation`
The `terminal width` commands dont work on LCOS SX 5

### Testing
Tested on:
- XS-6128QF

A File with full `show` and `config` test result is attached.

[2025-05-02_netmiko-lancom-driver-LCOSSX5-test.txt](https://github.com/user-attachments/files/20014014/2025-05-02_netmiko-lancom-driver-LCOSSX5-test.txt)

