### PR TITLE
Add support for Fasa Si-R router

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -100,6 +100,7 @@
 - F5 TMSH
 - F5 Linux
 - Fortinet
+- Fsas Technologies (Fujitsu) Si-R
 - Garderos GRS
 - Genexis Saturn SOLT33 (telnet only)
 - MRV Communications OptiSwitch
@@ -203,6 +204,7 @@
 - fiberstore_fsos
 - flexvnf
 - fortinet
+- fsas_sir
 - garderos_grs
 - generic
 - generic_termserver

--- a/netmiko/fsas/__init__.py
+++ b/netmiko/fsas/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.fsas.fsas_sir import FsasSirSSH
+
+__all__ = ["FsasSirSSH"]

--- a/netmiko/fsas/fsas_sir.py
+++ b/netmiko/fsas/fsas_sir.py
@@ -1,0 +1,102 @@
+import time
+import re
+from typing import Optional
+
+from netmiko.base_connection import BaseConnection
+
+
+class FsasSirBase(BaseConnection):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.disable_paging(command="terminal pager disable")
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_enable_mode(self, check_string: str = "#") -> bool:
+        """Checks if the device is in administrator mode or not."""
+        return super().check_enable_mode(check_string=check_string)
+
+    def enable(
+        self,
+        cmd: str = "admin",
+        pattern: str = r"Password",
+        enable_pattern: Optional[str] = None,
+        check_state: bool = True,
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        return super().enable(
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
+        )
+
+    def exit_enable_mode(self, exit_command: str = "exit") -> str:
+        """Exits administrator mode."""
+        return super().exit_enable_mode(exit_command=exit_command)
+
+    def check_config_mode(
+        self,
+        check_string: str = "(config)#",
+        pattern: str = "",
+        force_regex: bool = False,
+    ) -> bool:
+        """Checks if the device is in configuration mode or not."""
+        return super().check_config_mode(
+            check_string=check_string, pattern=pattern, force_regex=force_regex
+        )
+
+    def config_mode(
+        self,
+        config_command: str = "configure",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
+
+    def exit_config_mode(self, exit_config: str = "end", pattern: str = "#") -> str:
+        """Exit from configuration mode."""
+        return super().exit_config_mode(exit_config=exit_config, pattern=pattern)
+
+    def commit(
+        self,
+        cmd: str = "commit",
+        read_timeout: float = 120.0,
+    ) -> str:
+        """Commit the candidate configuration."""
+        self.config_mode()
+        return self._send_command_str(
+            command_string=cmd,
+            strip_prompt=False,
+            strip_command=False,
+            read_timeout=read_timeout,
+        )
+
+    def save_config(
+        self,
+        cmd: str = "save",
+        confirm: bool = False,
+        confirm_response: str = "",
+        read_timeout: float = 120.0,
+    ) -> str:
+        """Saves Config."""
+        if confirm is True:
+            raise ValueError("Fsas Si-R does not support save_config confirmation.")
+        self.config_mode()
+        return self._send_command_str(
+            command_string=cmd,
+            strip_prompt=False,
+            strip_command=False,
+            read_timeout=read_timeout,
+        )
+
+
+class FsasSirSSH(FsasSirBase):
+    """FsasSir SSH driver."""
+
+    pass

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -97,6 +97,7 @@ from netmiko.fiberstore import FiberstoreFsosSSH, FiberstoreNetworkOSSSH
 from netmiko.flexvnf import FlexvnfSSH
 from netmiko.fortinet import FortinetSSH
 from netmiko.fs import FSOSSSH
+from netmiko.fsas import FsasSirSSH
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.genexis import GenexisSOLT33Telnet
 from netmiko.hillstone import HillstoneStoneosSSH
@@ -260,6 +261,7 @@ CLASS_MAPPER_BASE = {
     "flexvnf": FlexvnfSSH,
     "fortinet": FortinetSSH,
     "fs_os": FSOSSSH,
+    "fsas_sir": FsasSirSSH,
     "garderos_grs": GarderosGrsSSH,
     "generic": GenericSSH,
     "generic_termserver": TerminalServerSSH,


### PR DESCRIPTION
I added support for Fsas Technologies Si-R router.
[https://www.fujitsu.com/jp/products/network/router/sir/](url)

## Tests

test_devices.yml
```yaml
fsas_sir:
  device_type: fsas_sir
  ip: 192.168.50.23
  username: user
  password: user
  secret: admin
```

commands.yml
```yaml
---
fsas_sir:
  version: "show system information"
  basic: "show interface"
  extended_output: "show ether"
  config:
    - "host 9 name example.com"
    - "host 9 ip address 10.0.0.1"
  support_commit: true
  config_verification: "show running-config"
```

responses.yml
```yaml
---
fsas_sir:
  base_prompt: G120-3
  router_prompt: G120-3>
  enable_prompt: G120-3#
  interface_ip: 192.168.50.23
  version_banner: "System : Si-R"
  multiple_line_output: "ETHER GROUP-2 PORT-4"
```

Test results
```
$ py.test -v test_netmiko_show.py --test_device fsas_sir
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0 -- /home/user01/.cache/pypoetry/virtualenvs/netmiko-biWU3unC-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /home/user01/repos/netmiko
configfile: setup.cfg
plugins: pylama-8.4.1
collected 25 items                                                                                                                                                                                               

test_netmiko_show.py::test_failed_key SKIPPED (Not using SSH-keys)                                                                                                                                         [  4%]
test_netmiko_show.py::test_disable_paging PASSED                                                                                                                                                           [  8%]
test_netmiko_show.py::test_terminal_width PASSED                                                                                                                                                           [ 12%]
test_netmiko_show.py::test_ssh_connect PASSED                                                                                                                                                              [ 16%]
test_netmiko_show.py::test_ssh_connect_cm PASSED                                                                                                                                                           [ 20%]
test_netmiko_show.py::test_send_command_timing PASSED                                                                                                                                                      [ 24%]
test_netmiko_show.py::test_send_command_timing_no_cmd_verify SKIPPED                                                                                                                                       [ 28%]
test_netmiko_show.py::test_send_command PASSED                                                                                                                                                             [ 32%]
test_netmiko_show.py::test_send_command_no_cmd_verify SKIPPED                                                                                                                                              [ 36%]
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED                                                                                                                                              [ 40%]
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)                                                                                             [ 44%]
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)                                                                                                          [ 48%]
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)                                                                                                               [ 52%]
test_netmiko_show.py::test_send_multiline_timing SKIPPED                                                                                                                                                   [ 56%]
test_netmiko_show.py::test_send_multiline SKIPPED                                                                                                                                                          [ 60%]
test_netmiko_show.py::test_send_multiline_prompt SKIPPED                                                                                                                                                   [ 64%]
test_netmiko_show.py::test_send_multiline_simple SKIPPED                                                                                                                                                   [ 68%]
test_netmiko_show.py::test_base_prompt PASSED                                                                                                                                                              [ 72%]
test_netmiko_show.py::test_strip_prompt PASSED                                                                                                                                                             [ 76%]
test_netmiko_show.py::test_strip_command PASSED                                                                                                                                                            [ 80%]
test_netmiko_show.py::test_normalize_linefeeds PASSED                                                                                                                                                      [ 84%]
test_netmiko_show.py::test_clear_buffer PASSED                                                                                                                                                             [ 88%]
test_netmiko_show.py::test_enable_mode PASSED                                                                                                                                                              [ 92%]
test_netmiko_show.py::test_disconnect PASSED                                                                                                                                                               [ 96%]
test_netmiko_show.py::test_disconnect_no_enable SKIPPED                                                                                                                                                    [100%]

============================================================================================ short test summary info =============================================================================================
SKIPPED [1] test_netmiko_show.py:25: Not using SSH-keys
SKIPPED [1] test_netmiko_show.py:88: Skipped
SKIPPED [1] test_netmiko_show.py:106: Skipped
SKIPPED [1] test_netmiko_show.py:128: Skipped
SKIPPED [1] test_netmiko_show.py:149: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:171: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:211: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:231: Skipped
SKIPPED [1] test_netmiko_show.py:247: Skipped
SKIPPED [1] test_netmiko_show.py:272: Skipped
SKIPPED [1] test_netmiko_show.py:296: Skipped
SKIPPED [1] test_netmiko_show.py:401: Skipped
======================================================================================== 13 passed, 12 skipped in 36.74s =========================================================================================

$ py.test -v test_netmiko_config.py --test_device fsas_sir
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0 -- /home/user01/.cache/pypoetry/virtualenvs/netmiko-biWU3unC-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /home/user01/repos/netmiko
configfile: setup.cfg
plugins: pylama-8.4.1
collected 13 items                                                                                                                                                                                               

test_netmiko_config.py::test_ssh_connect PASSED                                                                                                                                                            [  7%]
test_netmiko_config.py::test_enable_mode PASSED                                                                                                                                                            [ 15%]
test_netmiko_config.py::test_config_mode PASSED                                                                                                                                                            [ 23%]
test_netmiko_config.py::test_exit_config_mode PASSED                                                                                                                                                       [ 30%]
test_netmiko_config.py::test_config_set PASSED                                                                                                                                                             [ 38%]
test_netmiko_config.py::test_config_set_generator PASSED                                                                                                                                                   [ 46%]
test_netmiko_config.py::test_config_set_longcommand PASSED                                                                                                                                                 [ 53%]
test_netmiko_config.py::test_config_hostname PASSED                                                                                                                                                        [ 61%]
test_netmiko_config.py::test_config_from_file SKIPPED                                                                                                                                                      [ 69%]
test_netmiko_config.py::test_config_error_pattern SKIPPED (No error_pattern defined.)                                                                                                                      [ 76%]
test_netmiko_config.py::test_banner SKIPPED (No banner defined.)                                                                                                                                           [ 84%]
test_netmiko_config.py::test_global_cmd_verify SKIPPED (No banner defined.)                                                                                                                                [ 92%]
test_netmiko_config.py::test_disconnect PASSED                                                                                                                                                             [100%]

============================================================================================ short test summary info =============================================================================================
SKIPPED [1] test_netmiko_config.py:163: Skipped
SKIPPED [1] test_netmiko_config.py:175: No error_pattern defined.
SKIPPED [1] test_netmiko_config.py:209: No banner defined.
SKIPPED [1] test_netmiko_config.py:242: No banner defined.
==================================================================================== 9 passed, 4 skipped in 70.92s (0:01:10) =====================================================================================
```


