### PR TITLE
Patterns for DellOS10, OS9, Extreme and PowerConnect terminal improvement

### DIFF
--- a/netmiko/dell/dell_powerconnect.py
+++ b/netmiko/dell/dell_powerconnect.py
@@ -17,7 +17,11 @@ class DellPowerConnectBase(CiscoBaseConnection):
         self._test_channel_read(pattern=r"[>#]")
         self.set_base_prompt()
         self.enable()
-        self.disable_paging(command="terminal datadump")
+        self.disable_paging(command="terminal datadump")  # Dell 34xx
+        self.disable_paging(command="terminal length 0")  # Dell 7xxx
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
 
     def set_base_prompt(
         self,

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -163,6 +163,7 @@ SSH_MAPPER_DICT = {
         "search_patterns": [
             r"Dell Application Software Version:  9",
             r"Dell Networking OS Version : 9",
+            r"Dell EMC Networking OS Version : 9"
         ],
         "priority": 99,
         "dispatch": "_autodetect_std",

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -170,7 +170,10 @@ SSH_MAPPER_DICT = {
     },
     "dell_os10": {
         "cmd": "show version",
-        "search_patterns": [r"Dell EMC Networking OS10.Enterprise"],
+        "search_patterns": [
+            r"Dell EMC Networking OS10.Enterprise",
+            r"Dell SmartFabric OS10[\s*|-]Enterprise",
+        ],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -247,7 +247,7 @@ SSH_MAPPER_DICT = {
     },
     "extreme_exos": {
         "cmd": "show version",
-        "search_patterns": [r"ExtremeXOS"],
+        "search_patterns": [r"ExtremeXOS", "EXOS"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -161,9 +161,9 @@ SSH_MAPPER_DICT = {
     "dell_os9": {
         "cmd": "show system",
         "search_patterns": [
-            r"Dell Application Software Version:  9",
-            r"Dell Networking OS Version : 9",
-            r"Dell EMC Networking OS Version : 9"
+            r"Dell Application Software Version\s*:\s*9",
+            r"Dell Networking OS Version\s*:\s*9",
+            r"Dell EMC Networking OS Version\s*:\s*9",
         ],
         "priority": 99,
         "dispatch": "_autodetect_std",


### PR DESCRIPTION
This pull request introduces updates to improve device compatibility and enhance the accuracy of SSH autodetection in the `netmiko` library. The changes include adjustments to paging commands for Dell devices, updates to search patterns for device detection, and minor improvements to handle variations in device responses.

### Dell device compatibility improvements:
* [`netmiko/dell/dell_powerconnect.py`](diffhunk://#diff-8bb820456e5de590b9c16671a9c1517687398b6fe70019680faccad064a0b627L20-R24): Added an additional paging command (`terminal length 0`) for Dell 7xxx series devices and included a buffer clearing step to ensure reliable communication.

### SSH autodetection enhancements:
* [`netmiko/ssh_autodetect.py`](diffhunk://#diff-f75c75643fef9ba2a42b2fa97929bee7a6d398b33ea445d0dafd73017c728213L164-R176): Updated search patterns for `dell_os9` to include a new variant (`Dell EMC Networking OS Version\s*:\s*9`) and refined existing patterns for better matching.
* [`netmiko/ssh_autodetect.py`](diffhunk://#diff-f75c75643fef9ba2a42b2fa97929bee7a6d398b33ea445d0dafd73017c728213L164-R176): Enhanced search patterns for `dell_os10` to detect additional naming conventions such as `Dell SmartFabric OS10-Enterprise`.
* [`netmiko/ssh_autodetect.py`](diffhunk://#diff-f75c75643fef9ba2a42b2fa97929bee7a6d398b33ea445d0dafd73017c728213L246-R250): Added a new search pattern (`EXOS`) for `extreme_exos` to account for alternative device identifiers.