### PR TITLE
Huawei SmartAX driver: disable alarms

### DIFF
--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -45,9 +45,7 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
     def __send_command(
         self, command: str, delay_factor: float = 1.0, mode: Mode = Mode.BASE
     ) -> None:
-        """
-        Send a command on startup to disable the automatic paging.
-        """
+        """ Send a command during startup """
         if mode in [Mode.ENABLE, Mode.CONFIG]:
             self.enable()
         if mode == Mode.CONFIG:

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -9,6 +9,7 @@ from netmiko import log
 
 class Mode(Enum):
     """Define the mode of the device."""
+
     BASE = "base"
     ENABLE = "enable"
     CONFIG = "config"
@@ -42,9 +43,7 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         )
 
     def __send_command(
-        self, command: str,
-        delay_factor: float = 1.0,
-        mode: Mode = Mode.BASE
+        self, command: str, delay_factor: float = 1.0, mode: Mode = Mode.BASE
     ) -> None:
         """
         Send a command on startup to disable the automatic paging.

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -45,7 +45,7 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
     def __send_command(
         self, command: str, delay_factor: float = 1.0, mode: Mode = Mode.BASE
     ) -> None:
-        """ Send a command during startup """
+        """Send a command during startup"""
         if mode in [Mode.ENABLE, Mode.CONFIG]:
             self.enable()
         if mode == Mode.CONFIG:

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -6,12 +6,13 @@ from enum import Enum
 from netmiko.cisco_base_connection import CiscoBaseConnection
 from netmiko import log
 
+
 class Mode(Enum):
     """Define the mode of the device."""
-
     BASE = "base"
     ENABLE = "enable"
     CONFIG = "config"
+
 
 class HuaweiSmartAXSSH(CiscoBaseConnection):
     """Supports Huawei SmartAX and OLT."""
@@ -39,7 +40,6 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
             command="infoswitch cli OFF",
             mode=Mode.ENABLE,
         )
-
 
     def __send_command(
         self, command: str,


### PR DESCRIPTION
Related to #3681

*This PR is the base for upcoming changes.*

It fixes the case when there are alarms shown in the CLI which might happen. When an alarm is shown it breaks the driver.

The following has been done:
- A new command is being sent when establishing the command: `infoswitch cli OFF`. This command must be sent using the enable mode, but after being sent it returns to the base mode.
- A simple ENUM with the states as certain command needs certain states. See `infoswitch cli OFF`.
- A __send_command function only for the huawei_smartax module has been implemented. It is similar to the _disable_smart_interaction (which has been removed) and it add the modes.
- Small changes on a 2 logs on line 80 and 81.