### PR TITLE
Adding support for graceful and faster closing on Huawei SmartAX.

### DIFF
--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -153,6 +153,9 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         output: str = ""
         # If after 30 seconds the device hasn't logged out, force it
         while time.time() - start_time < timeout:
+            # Check if SSH session is even alive
+            if not self.is_alive():
+                return
             output += self.read_channel()
             if "Are you sure to log out? (y/n)[n]:" in output:
                 self.write_channel("y" + self.RETURN)

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -133,10 +133,7 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         )
 
     def cleanup(self, command: str = "quit") -> None:
-        """
-        Gracefully exit the SSH session.
-        If mmi-mode is activated the session is automatically logged out.
-        """
+        """Gracefully exit the SSH session."""
         timeout: int = 30
         super().cleanup(command=command)
         start_time = time.time()

--- a/netmiko/huawei/huawei_smartax.py
+++ b/netmiko/huawei/huawei_smartax.py
@@ -138,15 +138,13 @@ class HuaweiSmartAXSSH(CiscoBaseConnection):
         super().cleanup(command=command)
         start_time = time.time()
         output: str = ""
-        # If after 20 seconds the device hasn't logged out, force it
+        # If after 30 seconds the device hasn't logged out, force it
         while time.time() - start_time < timeout:
             output += self.read_channel()
-            if output.endswith("Are you sure to log out? (y/n)[n]:"):
+            if "Are you sure to log out? (y/n)[n]:" in output:
                 self.write_channel("y" + self.RETURN)
                 output = ""
-            elif output.endswith(
-                "Configuration console exit, please retry to log on\n"
-            ):
+            elif "Configuration console exit, please retry to log on" in output:
                 return
             time.sleep(0.01)
         raise ValueError("Failed to log out of the device")


### PR DESCRIPTION
Related to #3681

Adding a graceful and faster closing for Huawei SmartAX. If for any reason gets stuck it timeouts after 30 seconds.

This is the log:
````

OLT#

OLT#quit
quit 
  Check whether system data has been changed. Please save data before logout. Are you sure to log out? (y/n)[n]:y
y

  Configuration console exit, please retry to log on
````


