### PR TITLE
Fixes 'enable' call issue when device prompt is a substring of literal 'password' string

### DIFF
--- a/netmiko/adtran/adtran.py
+++ b/netmiko/adtran/adtran.py
@@ -46,7 +46,7 @@ class AdtranOSBase(CiscoBaseConnection):
 
             # Search for trailing prompt or password pattern
             output += self.read_until_prompt_or_pattern(
-                pattern=pattern, re_flags=re_flags
+                pattern=pattern, re_flags=re_flags, read_entire_line=True
             )
 
             # Send the "secret" in response to password pattern

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2051,7 +2051,7 @@ You can also look at the Netmiko session_log or debug log for more information.
 
             # Search for trailing prompt or password pattern
             output += self.read_until_prompt_or_pattern(
-                pattern=pattern, re_flags=re_flags
+                pattern=pattern, re_flags=re_flags, read_entire_line=True
             )
 
             # Send the "secret" in response to password pattern


### PR DESCRIPTION
Fixes: https://github.com/ktbyers/netmiko/issues/3704