### PR TITLE
Add support to connect to HPE 1920 and 1950 OfficeConnect switches

### DIFF
--- a/netmiko/hp/__init__.py
+++ b/netmiko/hp/__init__.py
@@ -1,4 +1,7 @@
 from netmiko.hp.hp_procurve import HPProcurveSSH, HPProcurveTelnet
 from netmiko.hp.hp_comware import HPComwareSSH, HPComwareTelnet
+from netmiko.hp.hp_comware1920 import HPComware1920SSH, HPComware1920Telnet
+from netmiko.hp.hp_comware1950 import HPComware1950SSH, HPComware1950Telnet
 
-__all__ = ["HPProcurveSSH", "HPProcurveTelnet", "HPComwareSSH", "HPComwareTelnet"]
+__all__ = ["HPProcurveSSH", "HPProcurveTelnet", "HPComwareSSH", "HPComwareTelnet", "HPComware1920SSH",
+           "HPComware1920Telnet", "HPComware1950SSH", "HPComware1950Telnet"]

--- a/netmiko/hp/__init__.py
+++ b/netmiko/hp/__init__.py
@@ -2,6 +2,7 @@ from netmiko.hp.hp_procurve import HPProcurveSSH, HPProcurveTelnet
 from netmiko.hp.hp_comware import HPComwareSSH, HPComwareTelnet
 from netmiko.hp.hp_comware1920 import HPComware1920SSH, HPComware1920Telnet
 from netmiko.hp.hp_comware1950 import HPComware1950SSH, HPComware1950Telnet
+from netmiko.hp.hpe_comware1910 import HPComware1910SSH, HPComware1910Telnet
 
 __all__ = ["HPProcurveSSH", "HPProcurveTelnet", "HPComwareSSH", "HPComwareTelnet", "HPComware1920SSH",
-           "HPComware1920Telnet", "HPComware1950SSH", "HPComware1950Telnet"]
+           "HPComware1920Telnet", "HPComware1950SSH", "HPComware1950Telnet", "HPComware1910SSH", "HPComware1910Telnet"]

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -10,8 +10,6 @@ class HPComwareBase(CiscoSSHConnection):
         global_cmd_verify = kwargs.get("global_cmd_verify")
         if global_cmd_verify is None:
             kwargs["global_cmd_verify"] = False
-
-        self.officeconnect_model = kwargs.pop('hpe_officeconnect_model', None)
         super().__init__(**kwargs)
 
     def session_preparation(self) -> None:
@@ -24,12 +22,6 @@ class HPComwareBase(CiscoSSHConnection):
             self._test_channel_read(pattern=r"[>\]]")
 
         self.set_base_prompt()
-
-        if self.officeconnect_model == 'hpe1920':
-            self.enable_cmd_hpe1920()
-        elif self.officeconnect_model == 'hpe1950':
-            self.enable_cmd_hpe1950()
-
         command = "screen-length disable"
         self.disable_paging(command=command)
 
@@ -59,22 +51,6 @@ class HPComwareBase(CiscoSSHConnection):
         return super().check_config_mode(
             check_string=check_string, pattern=pattern, force_regex=force_regex
         )
-
-    def enable_cmd_hpe1920(self):
-        """
-        Enable terminal cmdline for HPE OfficeConnect 1920
-        """
-        self.send_command('_cmdline-mode on', 'Continue?')
-        self.send_command('y', 'password:')
-        self.send_command('Jinhua1920unauthorized', 'Warning:')
-
-    def enable_cmd_hpe1950(self):
-        """
-        Enable terminal cmdline for HPE OfficeConnect 1950
-        """
-        self.send_command('xtd-cli-mode', 'Switch to extended CLI mode?')
-        self.send_command('y', 'Password:')
-        self.send_command('foes-bent-pile-atom-ship', 'Warning:')
 
     def send_config_set(
         self,

--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -10,6 +10,8 @@ class HPComwareBase(CiscoSSHConnection):
         global_cmd_verify = kwargs.get("global_cmd_verify")
         if global_cmd_verify is None:
             kwargs["global_cmd_verify"] = False
+
+        self.officeconnect_model = kwargs.pop('hpe_officeconnect_model', None)
         super().__init__(**kwargs)
 
     def session_preparation(self) -> None:
@@ -22,6 +24,12 @@ class HPComwareBase(CiscoSSHConnection):
             self._test_channel_read(pattern=r"[>\]]")
 
         self.set_base_prompt()
+
+        if self.officeconnect_model == 'hpe1920':
+            self.enable_cmd_hpe1920()
+        elif self.officeconnect_model == 'hpe1950':
+            self.enable_cmd_hpe1950()
+
         command = "screen-length disable"
         self.disable_paging(command=command)
 
@@ -51,6 +59,22 @@ class HPComwareBase(CiscoSSHConnection):
         return super().check_config_mode(
             check_string=check_string, pattern=pattern, force_regex=force_regex
         )
+
+    def enable_cmd_hpe1920(self):
+        """
+        Enable terminal cmdline for HPE OfficeConnect 1920
+        """
+        self.send_command('_cmdline-mode on', 'Continue?')
+        self.send_command('y', 'password:')
+        self.send_command('Jinhua1920unauthorized', 'Warning:')
+
+    def enable_cmd_hpe1950(self):
+        """
+        Enable terminal cmdline for HPE OfficeConnect 1950
+        """
+        self.send_command('xtd-cli-mode', 'Switch to extended CLI mode?')
+        self.send_command('y', 'Password:')
+        self.send_command('foes-bent-pile-atom-ship', 'Warning:')
 
     def send_config_set(
         self,

--- a/netmiko/hp/hp_comware1920.py
+++ b/netmiko/hp/hp_comware1920.py
@@ -1,0 +1,33 @@
+from typing import Optional, Any
+from netmiko.hp.hp_comware import HPComwareBase
+
+
+class HPComware1920Base(HPComwareBase):
+    """
+    Connection class for OfficeConnect 1920 series switches
+    """
+
+    def set_base_prompt(self, pri_prompt_terminator: str = ">", alt_prompt_terminator: str = "]",
+                        delay_factor: float = 1.0, pattern: Optional[str] = None) -> str:
+        ret =  super().set_base_prompt(pri_prompt_terminator, alt_prompt_terminator, delay_factor, pattern)
+        self.enable_cmd_hpe1920()
+        return ret
+
+    def enable_cmd_hpe1920(self):
+        """
+        Enable terminal cmdline for HPE OfficeConnect 1920
+        """
+        self.send_command('_cmdline-mode on', 'Continue?')
+        self.send_command('y', 'password:')
+        self.send_command('Jinhua1920unauthorized', 'Warning:')
+
+
+class HPComware1920SSH(HPComware1920Base):
+    pass
+
+
+class HPComware1920Telnet(HPComware1920Base):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)

--- a/netmiko/hp/hp_comware1950.py
+++ b/netmiko/hp/hp_comware1950.py
@@ -1,0 +1,33 @@
+from typing import Optional, Any
+from netmiko.hp.hp_comware import HPComwareBase
+
+
+class HPComware1950Base(HPComwareBase):
+    """
+    Connection class for OfficeConnect 1950 series switches
+    """
+
+    def set_base_prompt(self, pri_prompt_terminator: str = ">", alt_prompt_terminator: str = "]",
+                        delay_factor: float = 1.0, pattern: Optional[str] = None) -> str:
+        ret =  super().set_base_prompt(pri_prompt_terminator, alt_prompt_terminator, delay_factor, pattern)
+        self.enable_cmd_hpe1950()
+        return ret
+
+    def enable_cmd_hpe1950(self):
+        """
+        Enable terminal cmdline for HPE OfficeConnect 1950
+        """
+        self.send_command('xtd-cli-mode', 'Switch to extended CLI mode?')
+        self.send_command('y', 'Password:')
+        self.send_command('foes-bent-pile-atom-ship', 'Warning:')
+
+
+class HPComware1950SSH(HPComware1950Base):
+    pass
+
+
+class HPComware1950Telnet(HPComware1950Base):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)

--- a/netmiko/hp/hpe_comware1910.py
+++ b/netmiko/hp/hpe_comware1910.py
@@ -1,0 +1,33 @@
+from typing import Optional, Any
+from netmiko.hp.hp_comware import HPComwareBase
+
+
+class HPComware1910Base(HPComwareBase):
+    """
+    Connection class for OfficeConnect 1920 series switches
+    """
+
+    def set_base_prompt(self, pri_prompt_terminator: str = ">", alt_prompt_terminator: str = "]",
+                        delay_factor: float = 1.0, pattern: Optional[str] = None) -> str:
+        ret =  super().set_base_prompt(pri_prompt_terminator, alt_prompt_terminator, delay_factor, pattern)
+        self.enable_cmd_hpe1910()
+        return ret
+
+    def enable_cmd_hpe1910(self):
+        """
+        Enable terminal cmdline for HPE OfficeConnect 1920
+        """
+        self.send_command('_cmdline-mode on', 'Continue?')
+        self.send_command('y', 'password:')
+        self.send_command('512900', 'Warning:')
+
+
+class HPComware1910SSH(HPComware1910Base):
+    pass
+
+
+class HPComware1910Telnet(HPComware1910Base):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\r\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -106,7 +106,16 @@ from netmiko.fortinet import FortinetSSH
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.genexis import GenexisSOLT33Telnet
 from netmiko.hillstone import HillstoneStoneosSSH
-from netmiko.hp import HPProcurveSSH, HPProcurveTelnet, HPComwareSSH, HPComwareTelnet
+from netmiko.hp import (
+    HPProcurveSSH,
+    HPProcurveTelnet,
+    HPComwareSSH,
+    HPComwareTelnet,
+    HPComware1920SSH,
+    HPComware1920Telnet,
+    HPComware1950SSH,
+    HPComware1950Telnet
+)
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH, HuaweiTelnet
 from netmiko.huawei import HuaweiSmartAXSSH, HuaweiSmartAXSSHMMI
 from netmiko.infinera import InfineraPacketSSH, InfineraPacketTelnet
@@ -277,6 +286,8 @@ CLASS_MAPPER_BASE = {
     "h3c_comware": HPComwareSSH,
     "hillstone_stoneos": HillstoneStoneosSSH,
     "hp_comware": HPComwareSSH,
+    "hp_comware1920": HPComware1920SSH,
+    "hp_comware1950": HPComware1950SSH,
     "hp_procurve": HPProcurveSSH,
     "huawei": HuaweiSSH,
     "huawei_smartaxmmi": HuaweiSmartAXSSHMMI,
@@ -400,6 +411,8 @@ CLASS_MAPPER["generic_termserver_telnet"] = TerminalServerTelnet
 CLASS_MAPPER["genexis_solt33_telnet"] = GenexisSOLT33Telnet
 CLASS_MAPPER["hp_procurve_telnet"] = HPProcurveTelnet
 CLASS_MAPPER["hp_comware_telnet"] = HPComwareTelnet
+CLASS_MAPPER["hp_comware1920_telnet"] = HPComware1920Telnet
+CLASS_MAPPER["hp_comware1950_telnet"] = HPComware1950Telnet
 CLASS_MAPPER["huawei_telnet"] = HuaweiTelnet
 CLASS_MAPPER["huawei_olt_telnet"] = HuaweiSmartAXSSH
 CLASS_MAPPER["infinera_packet_telnet"] = InfineraPacketTelnet

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -114,7 +114,9 @@ from netmiko.hp import (
     HPComware1920SSH,
     HPComware1920Telnet,
     HPComware1950SSH,
-    HPComware1950Telnet
+    HPComware1950Telnet,
+    HPComware1910SSH,
+    HPComware1910Telnet
 )
 from netmiko.huawei import HuaweiSSH, HuaweiVrpv8SSH, HuaweiTelnet
 from netmiko.huawei import HuaweiSmartAXSSH, HuaweiSmartAXSSHMMI
@@ -288,6 +290,7 @@ CLASS_MAPPER_BASE = {
     "hp_comware": HPComwareSSH,
     "hp_comware1920": HPComware1920SSH,
     "hp_comware1950": HPComware1950SSH,
+    "hp_comware1910": HPComware1910SSH,
     "hp_procurve": HPProcurveSSH,
     "huawei": HuaweiSSH,
     "huawei_smartaxmmi": HuaweiSmartAXSSHMMI,
@@ -413,6 +416,7 @@ CLASS_MAPPER["hp_procurve_telnet"] = HPProcurveTelnet
 CLASS_MAPPER["hp_comware_telnet"] = HPComwareTelnet
 CLASS_MAPPER["hp_comware1920_telnet"] = HPComware1920Telnet
 CLASS_MAPPER["hp_comware1950_telnet"] = HPComware1950Telnet
+CLASS_MAPPER["hp_comware1910_telnet"] = HPComware1910Telnet
 CLASS_MAPPER["huawei_telnet"] = HuaweiTelnet
 CLASS_MAPPER["huawei_olt_telnet"] = HuaweiSmartAXSSH
 CLASS_MAPPER["infinera_packet_telnet"] = InfineraPacketTelnet


### PR DESCRIPTION
HPE 1920 and 1950 switches has standard Comware5 / Comware7 CLI but it needs to be enabled with special command sent to the CLI. This patch add new hpe_officeconnect_model argument to HPComwareBase class. When this argument is populated with hpe1920 or hpe1950 string value, it send magic command immediately after establishing connection with switch and therefore these switches can be handled as standard Comware switches.