### PR TITLE
Add Perle SSH class

### DIFF
--- a/netmiko/perle/__init__.py
+++ b/netmiko/perle/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.perle.perle_ssh import PerleSSH
+
+__all__ = ("PerleSSH",)

--- a/netmiko/perle/perle_ssh.py
+++ b/netmiko/perle/perle_ssh.py
@@ -1,0 +1,99 @@
+import re
+from typing import Any, Dict, List, Optional, Union
+
+from netmiko.cisco_base_connection import CiscoBaseConnection
+from netmiko.utilities import structured_data_converter
+
+
+class PerleSSH(CiscoBaseConnection):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.default_enter = kwargs.get("default_enter", "\r")
+
+    def enable(
+        self,
+        cmd: str = "admin",
+        pattern: str = "ssword:",
+        enable_pattern: Optional[str] = None,
+        check_state: bool = True,
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        return super().enable(cmd, pattern, enable_pattern, check_state, re_flags)
+
+    def exit_enable_mode(self, *args: Any, **kwargs: Any) -> str:
+        # Perle does not have this concept
+        return ""
+
+    def config_mode(self, *args: Any, **kwargs: Any) -> str:
+        # Perle has no config mode
+        return ""
+
+    def exit_config_mode(self, *args: Any, **kwargs: Any) -> str:
+        # Perle has no config mode
+        return ""
+
+    def save_config(
+        self, cmd: str = "save", confirm: bool = True, confirm_response: str = "y"
+    ) -> str:
+        return super().save_config(cmd, confirm, confirm_response)
+
+    def session_preparation(self) -> None:
+        self._test_channel_read()
+        self.set_base_prompt(pri_prompt_terminator="$")
+
+    def send_command_timing(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Union[str, List[Any], Dict[str, Any]]:
+        real_command_string = kwargs["command_string"]
+        real_strip_command = kwargs.get("strip_command", True)
+        real_strip_prompt = kwargs.get("strip_prompt", True)
+        command = kwargs["command_string"] + "\n"
+        more = r"< Hit any key >"
+        kwargs["strip_prompt"] = False
+        kwargs["strip_command"] = False
+
+        output = str(super().send_command_timing(*args, **kwargs))
+
+        kwargs["command_string"] = " "
+        kwargs["normalize"] = False
+        kwargs["strip_command"] = True
+        while more in output:
+            output = re.sub(r"\n" + more, "", output)
+            output += str(
+                super().send_command_timing(
+                    *args,
+                    **kwargs,
+                )
+            )
+
+        output = self._sanitize_output(
+            output,
+            strip_command=real_strip_command,
+            command_string=command,
+            strip_prompt=real_strip_prompt,
+        )
+        return_data = structured_data_converter(
+            command=real_command_string,
+            raw_data=output,
+            platform=self.device_type,
+            use_textfsm=kwargs.get("use_textfsm", False),
+            use_ttp=kwargs.get("use_ttp", False),
+            use_genie=kwargs.get("use_genie", False),
+            textfsm_template=kwargs.get("textfsm_template", None),
+            ttp_template=kwargs.get("ttp_template", None),
+            raise_parsing_error=kwargs.get("raise_parsing_error", False),
+        )
+
+        return return_data
+
+    def strip_prompt(self, a_string: str) -> str:
+        # Delete repeated prompts
+        old_string = a_string
+        while (a_string := super().strip_prompt(a_string)) != old_string:
+            old_string = a_string
+        return a_string
+
+    def cleanup(self, command: str = "logout") -> None:
+        return super().cleanup(command)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -140,6 +140,7 @@ from netmiko.ovs import OvsLinuxSSH
 from netmiko.paloalto import PaloAltoPanosSSH
 from netmiko.paloalto import PaloAltoPanosTelnet
 from netmiko.pluribus import PluribusSSH
+from netmiko.perle import PerleSSH
 from netmiko.quanta import QuantaMeshSSH
 from netmiko.rad import RadETXSSH
 from netmiko.rad import RadETXTelnet
@@ -309,6 +310,7 @@ CLASS_MAPPER_BASE = {
     "ovs_linux": OvsLinuxSSH,
     "paloalto_panos": PaloAltoPanosSSH,
     "pluribus": PluribusSSH,
+    "perle": PerleSSH,
     "quanta_mesh": QuantaMeshSSH,
     "rad_etx": RadETXSSH,
     "raisecom_roap": RaisecomRoapSSH,


### PR DESCRIPTION
NB:  This class is for connecting to / configuring Perle SCS/SCR devices, not for connecting to reverse telnet/SSH devices managed by them.

`send_command_timing` is the only supported command method, as there is a paginator that cannot be disabled.