### PR TITLE
Improve Check Point Gaia

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -25,6 +25,7 @@
 - Calix B6
 - Casa Systems CMTS
 - Centec Networks
+- Check Point GAiA
 - Cisco AireOS (Wireless LAN Controllers)
 - Cisco ASA
 - Cisco S200
@@ -92,7 +93,6 @@
 - Cisco APIC (Linux)
 - Cisco Telepresence
 - Cisco Viptela
-- Check Point GAiA
 - Corelight Linux
 - Coriant
 - Cumulus VX Linux

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2011,6 +2011,29 @@ You can also look at the Netmiko session_log or debug log for more information.
         output = self.read_until_prompt(read_entire_line=True)
         return check_string in output
 
+    def enable_secret_handler(
+        self,
+        pattern: str,
+        output: str,
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        """
+        Some platforms require special handling when entering 'enable' mode.
+
+        Send the "secret" in response to password pattern
+
+        :param pattern: pattern to search for indicating device is waiting for password
+
+        :param output: Accumulated output from 'enable()' method.
+
+        :param re_flags: Regular expression flags used in conjunction with pattern
+
+        """
+        if re.search(pattern, output, flags=re_flags):
+            self.write_channel(self.normalize_cmd(self.secret))
+            new_output = self.read_until_prompt()
+        return new_output
+
     def enable(
         self,
         cmd: str = "",
@@ -2054,10 +2077,9 @@ You can also look at the Netmiko session_log or debug log for more information.
                 pattern=pattern, re_flags=re_flags, read_entire_line=True
             )
 
-            # Send the "secret" in response to password pattern
-            if re.search(pattern, output, flags=re_flags):
-                self.write_channel(self.normalize_cmd(self.secret))
-                output += self.read_until_prompt()
+            output += self.enable_secret_handler(
+                pattern=pattern, output=output, re_flags=re_flags
+            )
 
             # Search for terminating pattern if defined
             if enable_pattern and not re.search(enable_pattern, output):

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -15,11 +15,6 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
 
     prompt_pattern = r"[>#]"
 
-#    def __init__(self, *args, **kwargs) -> None:
-#        default_enter = kwargs.get("default_enter") or "\r\n"
-#        kwargs["default_enter"] = default_enter
-#        return super().__init__(*args, **kwargs)
-
     def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
@@ -97,7 +92,6 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
                 time.sleep(.5)
                 self.write_channel("\r")
 
-            import ipdb; ipdb.set_trace()
             # Search for terminating pattern if defined
             if enable_pattern:
                 output += self.read_until_pattern(pattern=enable_pattern)
@@ -109,6 +103,7 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         except NetmikoTimeoutException:
             raise ValueError(msg)
 
+        print(output)
         self.set_base_prompt()
         return output
 

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -36,6 +36,34 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         """Check if in enable mode. Return boolean."""
         return super().check_enable_mode(check_string=check_string)
 
+    def enable_secret_handler(
+        self,
+        pattern: str,
+        output: str
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        """
+        Check Point Gaia requires very particular timing for this 'expert'
+        password handling to work.
+
+        Send the "secret" in response to password pattern
+        """
+        if re.search(pattern, output, flags=re_flags):
+            self.write_channel(self.secret))
+            print(output)
+            time.sleep(.3)
+            self.write_channel("\n")
+            time.sleep(.3)
+            output += self.read_until_pattern(pattern=r"[>#]")
+            #print(self.read_channel())
+#2060                 #output += self.read_until_prompt()
+#2061                 print(output)
+#2062                 time.sleep(.3)
+#2063                 self.write_channel("\n")
+#2064                 time.sleep(.3)
+#2065                 #print(self.read_channel())
+#2066                 output += self.read_until_pattern(pattern=r"[>#]")
+
     def enable(
         self,
         cmd: str = "expert",
@@ -49,6 +77,16 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
 
         Check Point Gaia is very finicky on the timing of sending this 'expert' password.
         """
+        output = super().enable(
+            cmd=cmd,
+            pattern=pattern,
+            enable_pattern=enable_pattern,
+            check_state=check_state,
+            re_flags=re_flags,
+        )
+        self.set_base_prompt()
+        return output
+
         output = ""
         msg = (
             "Failed to enter enable mode. Please ensure you pass "

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from netmiko.no_config import NoConfig
 from netmiko.base_connection import BaseConnection
-from netmiko.exceptions import ReadTimeout
 
 
 class CheckPointGaiaSSH(NoConfig, BaseConnection):
@@ -39,7 +38,7 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
     def enable_secret_handler(
         self,
         pattern: str,
-        output: str
+        output: str,
         re_flags: int = re.IGNORECASE,
     ) -> str:
         """
@@ -49,20 +48,15 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         Send the "secret" in response to password pattern
         """
         if re.search(pattern, output, flags=re_flags):
-            self.write_channel(self.secret))
+            self.write_channel(self.secret)
             print(output)
-            time.sleep(.3)
-            self.write_channel("\n")
-            time.sleep(.3)
-            output += self.read_until_pattern(pattern=r"[>#]")
-            #print(self.read_channel())
-#2060                 #output += self.read_until_prompt()
-#2061                 print(output)
-#2062                 time.sleep(.3)
-#2063                 self.write_channel("\n")
-#2064                 time.sleep(.3)
-#2065                 #print(self.read_channel())
-#2066                 output += self.read_until_pattern(pattern=r"[>#]")
+            time.sleep(0.3)
+            self.write_channel(self.RETURN)
+            time.sleep(0.3)
+            new_output = self.read_until_pattern(pattern=r"[>#]")
+            print(new_output)
+
+        return new_output
 
     def enable(
         self,
@@ -84,64 +78,6 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
             check_state=check_state,
             re_flags=re_flags,
         )
-        self.set_base_prompt()
-        return output
-
-        output = ""
-        msg = (
-            "Failed to enter enable mode. Please ensure you pass "
-            "the 'secret' argument to ConnectHandler."
-        )
-
-        # Check if in enable mode already.
-        if check_state and self.check_enable_mode():
-            return output
-
-        # Send "enable" mode command
-        self.write_channel(self.normalize_cmd(cmd))
-        try:
-            # Read the command echo
-            if self.global_cmd_verify is not False:
-                output += self.read_until_pattern(pattern=re.escape(cmd.strip()))
-
-            # Gaia is really tricky as it frequently double echoes the cmd
-            try:
-                tmp_pattern = rf"(?:>\s{re.escape(cmd.strip())}|{pattern})"
-                output += self.read_until_pattern(pattern=tmp_pattern, read_timeout=3)
-            except ReadTimeout:
-                # No double echo / no prompt to enter password (give up).
-                raise ValueError(msg)
-
-            print(output)
-
-            # Must have hit double echo
-            if not re.search(pattern, output):
-                time.sleep(.3)
-                # Search for trailing prompt or password pattern
-                output += self.read_until_prompt_or_pattern(
-                    pattern=pattern, re_flags=re_flags, read_entire_line=True
-                )
-
-            print(output)
-
-            # Send the "secret" in response to password pattern
-            if re.search(pattern, output, flags=re_flags):
-                self.write_channel(self.secret)
-                time.sleep(.5)
-                self.write_channel("\r")
-
-            # Search for terminating pattern if defined
-            if enable_pattern:
-                output += self.read_until_pattern(pattern=enable_pattern)
-            else:
-                output += self.read_until_prompt()
-                if not self.check_enable_mode():
-                    raise ValueError(msg)
-
-        except NetmikoTimeoutException:
-            raise ValueError(msg)
-
-        print(output)
         self.set_base_prompt()
         return output
 

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -52,7 +52,6 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         Send the "secret" in response to password pattern
         """
         if re.search(pattern, output, flags=re_flags):
-            print(self.global_delay_factor)
             self.write_channel(self.secret)
             time.sleep(0.3 * self.global_delay_factor)
             self.write_channel(self.RETURN)
@@ -84,9 +83,14 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         return output
 
     def exit_enable_mode(self, exit_command: str = "exit") -> str:
-        """Exits enable (privileged exec) mode."""
-        output = super().exit_enable_mode(exit_command=exit_command)
-        self.set_base_prompt()
+        """Exit expert mode."""
+        output = ""
+        if self.check_enable_mode():
+            self.write_channel(self.normalize_cmd(exit_command))
+            output += self.read_until_pattern(pattern=r">")
+            self.set_base_prompt()
+            if self.check_enable_mode():
+                raise ValueError("Failed to exit enable mode.")
         return output
 
     def save_config(

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -1,8 +1,10 @@
 import time
 import re
+from typing import Optional
 
 from netmiko.no_config import NoConfig
 from netmiko.base_connection import BaseConnection
+from netmiko.exceptions import ReadTimeout
 
 
 class CheckPointGaiaSSH(NoConfig, BaseConnection):
@@ -13,12 +15,20 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
 
     prompt_pattern = r"[>#]"
 
+#    def __init__(self, *args, **kwargs) -> None:
+#        default_enter = kwargs.get("default_enter") or "\r\n"
+#        kwargs["default_enter"] = default_enter
+#        return super().__init__(*args, **kwargs)
+
     def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
 
         Set the base prompt for interaction ('>').
         """
+        # Kept running into issues with command_echo and duplicate
+        # echoes of commands.
+        self.fast_cli = False
         self._test_channel_read(pattern=self.prompt_pattern)
         self.set_base_prompt()
         self.disable_paging(command="set clienv rows 0")
@@ -27,26 +37,86 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         time.sleep(0.3 * self.global_delay_factor)
         self.clear_buffer()
 
-    def command_echo_read(self, cmd: str, read_timeout: float) -> str:
-        """Check Point clish double echoes the command (at least sometimes)"""
+    def check_enable_mode(self, check_string: str = "#") -> bool:
+        """Check if in enable mode. Return boolean."""
+        return super().check_enable_mode(check_string=check_string)
 
-        re_cmd = re.escape(cmd)
-        pattern = rf"{self.prompt_pattern}\s{re_cmd}"
+    def enable(
+        self,
+        cmd: str = "expert",
+        pattern: str = r"expert password",
+        enable_pattern: Optional[str] = r"\#",
+        check_state: bool = True,
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        """
+        Enter expert mode.
 
-        # Make sure you read until you detect the command echo (avoid getting out of sync)
-        new_data = self.read_until_pattern(pattern=pattern, read_timeout=read_timeout)
+        Check Point Gaia is very finicky on the timing of sending this 'expert' password.
+        """
+        output = ""
+        msg = (
+            "Failed to enter enable mode. Please ensure you pass "
+            "the 'secret' argument to ConnectHandler."
+        )
 
-        # There can be echoed prompts that haven't been cleared before the cmd echo
-        # this can later mess up the trailing prompt pattern detection. Clear this out.
-        lines = new_data.split(cmd)
-        if len(lines) in [2, 3]:
-            # lines[-1] should realistically just be the null string
-            new_data = f"{cmd}{lines[-1]}"
-        else:
-            # cmd exists in the output multiple times? Just retain the original output
-            pass
+        # Check if in enable mode already.
+        if check_state and self.check_enable_mode():
+            return output
 
-        return new_data
+        # Send "enable" mode command
+        self.write_channel(self.normalize_cmd(cmd))
+        try:
+            # Read the command echo
+            if self.global_cmd_verify is not False:
+                output += self.read_until_pattern(pattern=re.escape(cmd.strip()))
+
+            # Gaia is really tricky as it frequently double echoes the cmd
+            try:
+                tmp_pattern = rf"(?:>\s{re.escape(cmd.strip())}|{pattern})"
+                output += self.read_until_pattern(pattern=tmp_pattern, read_timeout=3)
+            except ReadTimeout:
+                # No double echo / no prompt to enter password (give up).
+                raise ValueError(msg)
+
+            print(output)
+
+            # Must have hit double echo
+            if not re.search(pattern, output):
+                time.sleep(.3)
+                # Search for trailing prompt or password pattern
+                output += self.read_until_prompt_or_pattern(
+                    pattern=pattern, re_flags=re_flags, read_entire_line=True
+                )
+
+            print(output)
+
+            # Send the "secret" in response to password pattern
+            if re.search(pattern, output, flags=re_flags):
+                self.write_channel(self.secret)
+                time.sleep(.5)
+                self.write_channel("\r")
+
+            import ipdb; ipdb.set_trace()
+            # Search for terminating pattern if defined
+            if enable_pattern:
+                output += self.read_until_pattern(pattern=enable_pattern)
+            else:
+                output += self.read_until_prompt()
+                if not self.check_enable_mode():
+                    raise ValueError(msg)
+
+        except NetmikoTimeoutException:
+            raise ValueError(msg)
+
+        self.set_base_prompt()
+        return output
+
+    def exit_enable_mode(self, exit_command: str = "exit") -> str:
+        """Exits enable (privileged exec) mode."""
+        output = super().exit_enable_mode(exit_command=exit_command)
+        self.set_base_prompt()
+        return output
 
     def save_config(
         self, cmd: str = "", confirm: bool = False, confirm_response: str = ""

--- a/netmiko/checkpoint/checkpoint_gaia_ssh.py
+++ b/netmiko/checkpoint/checkpoint_gaia_ssh.py
@@ -1,6 +1,6 @@
 import time
 import re
-from typing import Optional
+from typing import Optional, Any
 
 from netmiko.no_config import NoConfig
 from netmiko.base_connection import BaseConnection
@@ -14,15 +14,19 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
 
     prompt_pattern = r"[>#]"
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Kept running into issues with command_echo and duplicate echoes of commands.
+        self.fast_cli = False
+        fast_cli = kwargs.get("fast_cli") or False
+        kwargs["fast_cli"] = fast_cli
+        return super().__init__(*args, **kwargs)
+
     def session_preparation(self) -> None:
         """
         Prepare the session after the connection has been established.
 
         Set the base prompt for interaction ('>').
         """
-        # Kept running into issues with command_echo and duplicate
-        # echoes of commands.
-        self.fast_cli = False
         self._test_channel_read(pattern=self.prompt_pattern)
         self.set_base_prompt()
         self.disable_paging(command="set clienv rows 0")
@@ -48,14 +52,12 @@ class CheckPointGaiaSSH(NoConfig, BaseConnection):
         Send the "secret" in response to password pattern
         """
         if re.search(pattern, output, flags=re_flags):
+            print(self.global_delay_factor)
             self.write_channel(self.secret)
-            print(output)
-            time.sleep(0.3)
+            time.sleep(0.3 * self.global_delay_factor)
             self.write_channel(self.RETURN)
-            time.sleep(0.3)
-            new_output = self.read_until_pattern(pattern=r"[>#]")
-            print(new_output)
-
+            time.sleep(0.3 * self.global_delay_factor)
+            new_output = self.read_until_pattern(pattern=self.prompt_pattern)
         return new_output
 
     def enable(

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -382,6 +382,7 @@ def test_enable_mode(net_connect, commands, expected_responses):
     except AttributeError:
         assert True
 
+
 def test_disconnect(net_connect, commands, expected_responses):
     """Terminate the SSH session."""
     start_time = datetime.now()

--- a/tests/test_netmiko_show.py
+++ b/tests/test_netmiko_show.py
@@ -374,6 +374,13 @@ def test_enable_mode(net_connect, commands, expected_responses):
     except AttributeError:
         assert True
 
+    # Now verify you can exit enable mode
+    try:
+        net_connect.exit_enable_mode()
+        prompt = net_connect.find_prompt()
+        assert prompt == expected_responses["router_prompt"]
+    except AttributeError:
+        assert True
 
 def test_disconnect(net_connect, commands, expected_responses):
     """Terminate the SSH session."""


### PR DESCRIPTION
$ $PYTEST test_netmiko_show.py --test_device chkpnt_pod2 
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.0, pytest-8.3.3, pluggy-1.6.0 -- /home/kbyers/netmiko/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/kbyers/netmiko
configfile: setup.cfg
plugins: pylama-8.4.1
collected 25 items                                                                                                                                                                         

test_netmiko_show.py::test_failed_key PASSED
test_netmiko_show.py::test_disable_paging PASSED
test_netmiko_show.py::test_terminal_width PASSED
test_netmiko_show.py::test_ssh_connect PASSED
test_netmiko_show.py::test_ssh_connect_cm PASSED
test_netmiko_show.py::test_send_command_timing PASSED
test_netmiko_show.py::test_send_command_timing_no_cmd_verify PASSED
test_netmiko_show.py::test_send_command PASSED
test_netmiko_show.py::test_send_command_no_cmd_verify PASSED
test_netmiko_show.py::test_complete_on_space_disabled SKIPPED
test_netmiko_show.py::test_send_command_textfsm SKIPPED (TextFSM/ntc-templates not supported on this platform)
test_netmiko_show.py::test_send_command_ttp SKIPPED (TTP template not existing for this platform)
test_netmiko_show.py::test_send_command_genie SKIPPED (Genie not supported on this platform)
test_netmiko_show.py::test_send_multiline_timing SKIPPED
test_netmiko_show.py::test_send_multiline SKIPPED
test_netmiko_show.py::test_send_multiline_prompt SKIPPED
test_netmiko_show.py::test_send_multiline_simple SKIPPED
test_netmiko_show.py::test_base_prompt PASSED
test_netmiko_show.py::test_strip_prompt PASSED
test_netmiko_show.py::test_strip_command PASSED
test_netmiko_show.py::test_normalize_linefeeds PASSED
test_netmiko_show.py::test_clear_buffer PASSED
test_netmiko_show.py::test_enable_mode PASSED
test_netmiko_show.py::test_disconnect PASSED
test_netmiko_show.py::test_disconnect_no_enable SKIPPED

================================================================================= short test summary info ==================================================================================
SKIPPED [1] test_netmiko_show.py:127: Skipped
SKIPPED [1] test_netmiko_show.py:148: TextFSM/ntc-templates not supported on this platform
SKIPPED [1] test_netmiko_show.py:170: TTP template not existing for this platform
SKIPPED [1] test_netmiko_show.py:210: Genie not supported on this platform
SKIPPED [1] test_netmiko_show.py:230: Skipped
SKIPPED [1] test_netmiko_show.py:246: Skipped
SKIPPED [1] test_netmiko_show.py:271: Skipped
SKIPPED [1] test_netmiko_show.py:295: Skipped
SKIPPED [1] test_netmiko_show.py:407: Skipped
============================================================================== 16 passed, 9 skipped in 42.65s ==============================================================================

