### PR TITLE
nokia_isam improvements

### DIFF
--- a/netmiko/nokia/nokia_isam.py
+++ b/netmiko/nokia/nokia_isam.py
@@ -12,8 +12,8 @@ class NokiaIsamSSH(BaseConnection, NoEnable):
         self._test_channel_read()
         self.set_base_prompt()
         commands = [
-            "environment inhibit-alarms",
-            "environment screen-length 0",
+            "environment mode batch",
+            "exit",
         ]
         for command in commands:
             self.disable_paging(command=command, cmd_verify=True, pattern=r"#")
@@ -60,7 +60,7 @@ class NokiaIsamSSH(BaseConnection, NoEnable):
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )
 
-    def exit_config_mode(self, exit_config: str = "exit", pattern: str = "") -> str:
+    def exit_config_mode(self, exit_config: str = "exit all", pattern: str = "") -> str:
         return super().exit_config_mode(exit_config=exit_config)
 
     def save_config(


### PR DESCRIPTION
It looks like `environment mode batch` was made to disable paging and other interactive elements on a nokia_isam. Plus an exit to go out of the >environment 'node'

```
device>#environment mode ?
batch                 ! non-interactive mode intended for scripting tools
interactive           ! interactive mode intended for human operators

device>#environment mode batch ?
[no] prompt           : the specification of the prompt
                        default = ""
[no] terminal-timeout : specify the inactivity timeout of the terminal
                        default = timeout:30
[no] print            : specifies the way the output is printed on the terminal
                        default = default
[no] screen-length    : specifies the number of lines to be printed on the
                        terminal for paging
                        default = 0

[no] inhibit-alarms   : disables the alarm reporting in the current  session
```

For the exit config, `exit all`, exits out of all 'nodes'. Which is better incase they are deep into a bunch 'nodes'.

```
device>#exit ?
[no] all              : set the current position to the top node
[no] one              : set the current position to the parent node ```