### PR TITLE
Support basic telnet functionality and add CiscoS500 device type

### DIFF
--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -20,6 +20,8 @@ from netmiko.cisco.cisco_s200 import CiscoS200SSH
 from netmiko.cisco.cisco_s200 import CiscoS200Telnet
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
 from netmiko.cisco.cisco_s300 import CiscoS300Telnet
+from netmiko.cisco.cisco_s500 import CiscoS500SSH
+from netmiko.cisco.cisco_s500 import CiscoS500Telnet
 from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
 from netmiko.cisco.cisco_viptela import CiscoViptelaSSH
 from netmiko.cisco.cisco_apic import CiscoApicSSH
@@ -39,6 +41,8 @@ __all__ = [
     "CiscoS200Telnet",
     "CiscoS300SSH",
     "CiscoS300Telnet",
+    "CiscoS500SSH",
+    "CiscoS500Telnet",
     "CiscoTpTcCeSSH",
     "CiscoViptelaSSH",
     "CiscoIosBase",

--- a/netmiko/cisco/cisco_ios.py
+++ b/netmiko/cisco/cisco_ios.py
@@ -72,7 +72,10 @@ class CiscoIosSSH(CiscoIosBase):
 class CiscoIosTelnet(CiscoIosBase):
     """Cisco IOS Telnet driver."""
 
-    pass
+    def __init__(self, **kwargs: Any) -> None:
+        if "device_type" not in kwargs:
+            kwargs["device_type"] = "cisco_ios_telnet"
+        super().__init__(**kwargs)
 
 
 class CiscoIosSerial(CiscoIosBase):

--- a/netmiko/cisco/cisco_s500.py
+++ b/netmiko/cisco/cisco_s500.py
@@ -1,0 +1,82 @@
+from typing import Any
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+
+class CiscoS500Base(CiscoBaseConnection):
+    """
+    Support for Cisco SG500 series of devices.
+
+    Note, must configure the following to disable SG500 from prompting for username twice:
+
+    configure terminal
+    ip ssh password-auth
+    """
+
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.set_terminal_width(command="terminal width 511", pattern="terminal")
+        self.disable_paging(command="terminal datadump")
+
+    def save_config(
+        self,
+        cmd: str = "write memory",
+        confirm: bool = True,
+        confirm_response: str = "Y",
+    ) -> str:
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+
+class CiscoS500SSH(CiscoS500Base):
+    """
+    Support for Cisco SG500 series of devices, with ssh.
+    """
+
+    pass
+
+
+class CiscoS500Telnet(CiscoS500Base):
+    """
+    Support for Cisco SG500 series of devices, with telnet.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "device_type" not in kwargs:
+            kwargs["device_type"] = "cisco_s500_telnet"
+        super().__init__(**kwargs)
+
+    def telnet_login(
+        self,
+        pri_prompt_terminator: str = r"#\s*$",
+        alt_prompt_terminator: str = r">\s*$",
+        username_pattern: str = r"User Name:",
+        pwd_pattern: str = r"assword",
+        delay_factor: float = 1.0,
+        max_loops: int = 20,
+    ) -> str:
+        """Telnet login. Can be username/password or just password.
+
+        :param pri_prompt_terminator: Primary trailing delimiter for identifying a device prompt
+
+        :param alt_prompt_terminator: Alternate trailing delimiter for identifying a device prompt
+
+        :param username_pattern: Pattern used to identify the username prompt
+
+        :param pwd_pattern: Pattern used to identify the pwd prompt
+
+        :param delay_factor: See __init__: global_delay_factor
+
+        :param max_loops: Controls the wait time in conjunction with the delay_factor
+        """
+        return super().telnet_login(
+            pri_prompt_terminator,
+            alt_prompt_terminator,
+            username_pattern,
+            pwd_pattern,
+            delay_factor,
+            max_loops,
+        )


### PR DESCRIPTION
### Telnet Functionality

I noticed the Telnet connection types lacked implementation and thought this could be a good starting point.

I understand telnet _should not_ be used in production environments but for test environments where you come by a pile of cheap legacy switches that behave poorly with modern SSH kex algorithms and cipher types due to outdates IOS or otherwise .. sometimes telnet is the path of least resistance to getting your lab up and running.

Hope this is something we can continue developing, as I have several other legacy switch types I would like to support.

Cheers.

### test results
```
(netmiko-py3.13) srak@edge:~/netmiko$ py.test tests/unit/                                                                                                                                  
/home/srak/.cache/pypoetry/virtualenvs/netmiko-3kolGDjv-py3.13/lib/python3.13/site-packages/pylama/lint/__init__.py:10: UserWarning: pkg_resources is deprecated as an API. See https://set
uptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.             
  from pkg_resources import iter_entry_points                                                                                                                                              
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.13.5, pytest-8.3.3, pluggy-1.6.0                                                                                                                                
rootdir: /home/srak/netmiko                                                                                                                                                                
configfile: setup.cfg                                                                                                                                                                      
plugins: pylama-8.4.1, cov-4.1.0                                                                                                                                                           
collected 89 items                                                                                                                                                                         
                                                                                                                                                                                           
tests/unit/test_base_connection.py ................................                                                                                                                 [ 35%] 
tests/unit/test_clitools_helpers.py ..........                                                                                                                                      [ 47%] 
tests/unit/test_clitools_outputters.py ...                                                                                                                                          [ 50%] 
tests/unit/test_connection.py ....                                                                                                                                                  [ 55%] 
tests/unit/test_encryption_hanlding.py ....                                                                                                                                         [ 59%] 
tests/unit/test_entry_points.py .                                                                                                                                                   [ 60%] 
tests/unit/test_ssh_autodetect.py .                                                                                                                                                 [ 61%] 
tests/unit/test_utilities.py ..................................                                                                                                                     [100%]
                                                                                                                                                                                           
=================================================================================== 89 passed in 7.52s ====================================================================================
```