### PR TITLE
Add additional search pattern for AOS-CX (e.g. CX 6300M)

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -85,7 +85,7 @@ SSH_MAPPER_DICT = {
     },
     "aruba_aoscx": {
         "cmd": "show version",
-        "search_patterns": [r"ArubaOS-CX"],
+        "search_patterns": [r"ArubaOS-CX", r"AOS-CX"],
         "priority": 99,
         "dispatch": "_autodetect_std",
     },


### PR DESCRIPTION
# Change
* Add additional search pattern needed for SSH autodetect for some AOS-CX devices to `SSH_MAPPER_DICT`
# Test Script
```
from netmiko.ssh_autodetect import SSHDetect

JL658A = {
    'device_type': 'autodetect',
    'host':   'x.x.x.x',
    'username': 'user',
    'password': 'pwd',
}

guesser = SSHDetect(**JL658A)
print(guesser.autodetect())
```
# Before
`None`
# After
`aruba_aoscx`
# Device Output
```
HOSTNAME# show version
-----------------------------------------------------------------------------
AOS-CX
(c) Copyright 2017-2025 Hewlett Packard Enterprise Development LP
-----------------------------------------------------------------------------
Version      : FL.10.16.1006
Build Date   : 2025-08-22 14:37:24 UTC
Build ID     : AOS-CX:FL.10.16.1006:565bef1995a0:202508221412
Build SHA    : 565bef1995a0915eba454bdd5ad9b39d3d3c935b
Hot Patches  :
Active Image : primary

Service OS Version : FL.01.17.0002
BIOS Version       : FL.01.0016
```