### PR TITLE
Add support Furukawa FITELnet series

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -42,6 +42,7 @@
 - Extreme VDX (Brocade)
 - Extreme VSP (Avaya)
 - Fiberstore FSOS
+- Furukawa FITELnet
 - Hillstone StoneOS
 - HPE Comware7
 - HPE ProCurve
@@ -228,6 +229,7 @@
 - fiberstore_networkos
 - flexvnf
 - fortinet
+- furukawa_fitelnet
 - garderos_grs
 - generic
 - generic_termserver
@@ -319,6 +321,7 @@
 - extreme_netiron_telnet
 - extreme_telnet
 - fiberstore_fsosv2_telnet
+- furukawa_fitelnet_telnet
 - generic_telnet
 - generic_termserver_telnet
 - genexis_solt33_telnet

--- a/netmiko/furukawa/__init__.py
+++ b/netmiko/furukawa/__init__.py
@@ -1,0 +1,5 @@
+from netmiko.furukawa.furukawa_fitelnet import FurukawaFitelnetSSH
+from netmiko.furukawa.furukawa_fitelnet import FurukawaFitelnetTelnet
+from netmiko.furukawa.furukawa_fitelnet import FurukawaFitelnetSerial
+
+__all__ = ["FurukawaFitelnetSSH", "FurukawaFitelnetTelnet", "FurukawaFitelnetSerial"]

--- a/netmiko/furukawa/furukawa_fitelnet.py
+++ b/netmiko/furukawa/furukawa_fitelnet.py
@@ -1,0 +1,361 @@
+import re
+import time
+from typing import Any, Optional, Union, Sequence, Iterator, TextIO
+
+from netmiko.cisco_base_connection import CiscoBaseConnection
+from netmiko.exceptions import NetmikoAuthenticationException
+
+
+class FurukawaFitelnetBase(CiscoBaseConnection):
+    """Common methods for Furukawa FITELnet VPN routers.
+
+    FITELnet prompts vary by model:
+    - Bare prompts: ">" (user mode), "#" (enable mode)
+    - Hostname prompts: "F220>", "F220#", "F220(config)#",
+      "F220(config-GigaEthernet1/1)#", etc.
+
+    FITELnet password model:
+        - Login password: set via ``username <name> password <pass>`` or
+          ``line telnet/console password <pass>``.
+        - Enable password: separate from login, set via
+          ``enable password <pass>``.
+        - The device may show ``<WARNING> weak login password: set the
+          password`` messages that contain the word 'password' but are NOT
+          actual password prompts.
+    """
+
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.enable()
+        # Re-set base prompt after enable (prompt changes from ">" to "#")
+        self.set_base_prompt()
+        self.disable_paging(command="no more")
+
+    def telnet_login(
+        self,
+        pri_prompt_terminator: str = r"\#\s*$",
+        alt_prompt_terminator: str = r">\s*$",
+        username_pattern: str = r"(?:user:|username|login|user name)",
+        pwd_pattern: str = r"assword",
+        delay_factor: float = 1.0,
+        max_loops: int = 20,
+    ) -> str:
+        """Telnet/Serial login for FITELnet.
+
+        Overridden because FITELnet shows ``<WARNING>`` messages after login
+        that contain the word 'password' (e.g. ``<WARNING> weak login
+        password: set the password``).  The base class matches this as a
+        password prompt and incorrectly sends the password as a CLI command.
+
+        This override checks for the command prompt **before** checking for
+        the password pattern so that warning messages are not confused with
+        real password prompts.
+        """
+        delay_factor = self.select_delay_factor(delay_factor)
+        if delay_factor < 1:
+            if not self._legacy_mode and self.fast_cli:
+                delay_factor = 1
+
+        time.sleep(1 * delay_factor)
+
+        output = ""
+        return_msg = ""
+        outer_loops = 3
+        inner_loops = int(max_loops / outer_loops)
+        i = 1
+        for _ in range(outer_loops):
+            while i <= inner_loops:
+                try:
+                    output = self.read_channel()
+                    return_msg += output
+
+                    # Search for username pattern / send username
+                    if re.search(username_pattern, output, flags=re.I):
+                        self.write_channel(self.username + "\r")
+                        time.sleep(1 * delay_factor)
+                        output = self.read_channel()
+                        return_msg += output
+
+                    # FITELnet fix: check for prompt BEFORE password pattern.
+                    # This prevents matching 'password' in <WARNING> messages.
+                    if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
+                        alt_prompt_terminator, output, flags=re.M
+                    ):
+                        return return_msg
+
+                    # Only check for password if no prompt was detected
+                    if re.search(pwd_pattern, output, flags=re.I):
+                        assert isinstance(self.password, str)
+                        self.write_channel(self.password + "\r")
+                        time.sleep(0.5 * delay_factor)
+                        output = self.read_channel()
+                        return_msg += output
+                        if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
+                            alt_prompt_terminator, output, flags=re.M
+                        ):
+                            return return_msg
+
+                    # Check for device with no password configured
+                    if re.search(r"assword required, but none set", output):
+                        assert self.remote_conn is not None
+                        self.remote_conn.close()
+                        msg = f"Login failed - Password required, but none set: {self.host}"
+                        raise NetmikoAuthenticationException(msg)
+
+                    time.sleep(0.5 * delay_factor)
+                    i += 1
+
+                except EOFError:
+                    assert self.remote_conn is not None
+                    self.remote_conn.close()
+                    msg = f"Login failed: {self.host}"
+                    raise NetmikoAuthenticationException(msg)
+
+            # Send RETURN to prompt the device (especially needed for serial)
+            self.write_channel(self.TELNET_RETURN)
+            time.sleep(0.5 * delay_factor)
+            i = 1
+
+        # Last try to see if we already logged in
+        self.write_channel(self.TELNET_RETURN)
+        time.sleep(0.5 * delay_factor)
+        output = self.read_channel()
+        return_msg += output
+        if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
+            alt_prompt_terminator, output, flags=re.M
+        ):
+            return return_msg
+
+        assert self.remote_conn is not None
+        self.remote_conn.close()
+        msg = f"Login failed: {self.host}"
+        raise NetmikoAuthenticationException(msg)
+
+    def check_enable_mode(self, check_string: str = "#") -> bool:
+        """Check if in enable mode.
+
+        FITELnet uses bare prompts (just ">" or "#"), so we read until
+        either prompt character appears rather than relying on base_prompt.
+        """
+        self.write_channel(self.RETURN)
+        output = self.read_until_pattern(pattern=r"[>#]")
+        return check_string in output
+
+    def enable(
+        self,
+        cmd: str = "enable",
+        pattern: str = "ssword",
+        enable_pattern: Optional[str] = None,
+        check_state: bool = True,
+        re_flags: int = re.IGNORECASE,
+    ) -> str:
+        """Enter enable mode on FITELnet.
+
+        Overridden because:
+        1. The bare prompt changes from ">" to "#" after enable, causing the
+           default ``read_until_prompt()`` to fail.
+        2. If the wrong enable password is supplied, the device responds with
+           ``<ERROR> Authentication failed`` followed by another ``password:``
+           prompt.  The base implementation would hang waiting for "#".
+           This override detects the failure immediately.
+        """
+        output = ""
+        if check_state and self.check_enable_mode():
+            return output
+
+        self.write_channel(self.normalize_cmd(cmd))
+        output += self.read_until_pattern(pattern=rf"(?:{pattern}|#)", re_flags=re_flags)
+
+        if re.search(pattern, output, flags=re_flags):
+            self.write_channel(self.normalize_cmd(self.secret))
+            # Read until "#" (success) or "Authentication failed" (wrong pw).
+            output += self.read_until_pattern(pattern=r"(?:#|Authentication failed)")
+            if "Authentication failed" in output:
+                raise ValueError(
+                    "Failed to enter enable mode. The enable password "
+                    "(secret) was rejected by the device."
+                )
+
+        if not self.check_enable_mode():
+            raise ValueError(
+                "Failed to enter enable mode. Please ensure you pass "
+                "the 'secret' argument to ConnectHandler."
+            )
+        return output
+
+    def exit_enable_mode(self, exit_command: str = "disable") -> str:
+        """Exit enable mode on FITELnet.
+
+        Overridden because the base implementation uses read_until_prompt()
+        which waits for '#', but after 'disable' the prompt changes to '>'.
+        """
+        output = ""
+        if self.check_enable_mode():
+            self.write_channel(self.normalize_cmd(exit_command))
+            output += self.read_until_pattern(pattern=r">")
+            # Drain any remaining data (serial ports may have buffered echoes)
+            time.sleep(0.5)
+            self.clear_buffer()
+            if self.check_enable_mode():
+                raise ValueError("Failed to exit enable mode.")
+        return output
+
+    def send_config_set(
+        self,
+        config_commands: Union[str, Sequence[str], Iterator[str], TextIO, None] = None,
+        exit_config_mode: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """FITELnet uses a candidate-config model; stay in config mode for commit."""
+        return super().send_config_set(
+            config_commands=config_commands,
+            exit_config_mode=exit_config_mode,
+            **kwargs,
+        )
+
+    def commit(
+        self,
+        read_timeout: float = 120.0,
+        comment: str = "",
+    ) -> str:
+        """
+        Commit the candidate configuration on the FITELnet device.
+
+        Applies the working.cfg (candidate) to current.cfg (running).
+
+        commit may prompt with '[y/n]' for confirmation.
+        """
+        if comment:
+            command_string = f"commit comment {comment}"
+        else:
+            command_string = "commit"
+
+        # Enter config mode (if necessary)
+        output = self.config_mode()
+
+        confirmation = r"onfirm|\[y/n\]|\[y/N\]"
+        pattern = rf"(?:#|{confirmation})"
+        new_data = self._send_command_str(
+            command_string,
+            expect_string=pattern,
+            strip_prompt=False,
+            strip_command=False,
+            read_timeout=read_timeout,
+        )
+
+        if "onfirm" in new_data or "[y/n]" in new_data or "[y/N]" in new_data:
+            output += new_data
+            new_data = self._send_command_str(
+                "y",
+                expect_string=r"#",
+                strip_prompt=False,
+                strip_command=False,
+                read_timeout=read_timeout,
+                cmd_verify=False,
+            )
+
+        output += new_data
+
+        if "Error" in output or "error" in output or "Failed" in output:
+            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+
+        return output
+
+    def save_config(
+        self,
+        cmd: str = "save",
+        confirm: bool = True,
+        confirm_response: str = "y",
+    ) -> str:
+        """Save working.cfg to boot.cfg (startup configuration).
+
+        FITELnet prompts 'save ok?[y/N]:' by default.
+        """
+        if self.check_config_mode():
+            self.exit_config_mode()
+        # Drain any buffered data (especially on serial)
+        time.sleep(0.5)
+        self.clear_buffer()
+        # Use \r only (not \r\n) to avoid the trailing \n being
+        # interpreted as the answer to the [y/N] confirmation prompt
+        # on serial connections where characters arrive sequentially.
+        self.write_channel(cmd + "\r")
+        output = self.read_until_pattern(pattern=r"\[y/N\]")
+        if confirm and confirm_response:
+            self.write_channel(confirm_response + self.RETURN)
+            output += self.read_until_pattern(pattern=r"#")
+        return output
+
+    def strip_command(self, command_string: str, output: str) -> str:
+        """Strip command echo from output.
+
+        FITELnet bare prompts cause the echoed command to appear as
+        ``#show ...`` instead of ``show ...``, so the base implementation's
+        ``output.startswith(cmd)`` check fails.  This override searches for
+        the command echo line (optionally prefixed by the prompt character)
+        and removes it along with any preceding prompt-only lines.
+        """
+        cmd = command_string.strip()
+        if output.startswith(cmd):
+            return super().strip_command(command_string, output)
+
+        output_lines = output.split(self.RESPONSE_RETURN)
+        for i, line in enumerate(output_lines):
+            line_s = line.strip()
+            if line_s == cmd or line_s == f"#{cmd}" or line_s == f">{cmd}":
+                start = i + 1
+                return self.RESPONSE_RETURN.join(output_lines[start:])
+        return output
+
+    def strip_prompt(self, a_string: str) -> str:
+        """Strip the trailing router prompt from the output.
+
+        The base implementation only removes a single trailing prompt line.
+        FITELnet devices may echo the prompt multiple times (especially on
+        serial/telnet), so this override uses a loop to strip all trailing
+        empty lines and prompt lines.
+
+        Uses a strict regex so that only actual prompt lines are removed --
+        content lines that happen to contain the hostname are preserved.
+        """
+        response_list = a_string.split(self.RESPONSE_RETURN)
+        base = self.base_prompt.strip()
+        if len(base) <= 1:
+            # Bare prompt: match "#", ">", "(config)#", etc.
+            prompt_re = re.compile(r"^(?:\([^)]*\))?[#>]\s*$")
+        else:
+            # Hostname prompt: match "F220#", "F220(config)#", etc.
+            prompt_re = re.compile(rf"^{re.escape(base)}(?:\([^)]*\))?[#>]\s*$")
+        while response_list:
+            last_line = response_list[-1].strip()
+            # Remove control characters (e.g. BEL \x07) before matching
+            clean_line = re.sub(r"[\x00-\x1f\x7f]", "", last_line)
+            if clean_line == "" or prompt_re.match(clean_line):
+                response_list.pop()
+            else:
+                break
+        return self.RESPONSE_RETURN.join(response_list)
+
+
+class FurukawaFitelnetSSH(FurukawaFitelnetBase):
+    """Furukawa FITELnet SSH driver."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        # "fitelnet" contains "telnet" as a substring, causing the default
+        # port to be set to 23 instead of 22. Force SSH port.
+        kwargs.setdefault("port", 22)
+        super().__init__(**kwargs)
+
+
+class FurukawaFitelnetTelnet(FurukawaFitelnetBase):
+    """Furukawa FITELnet Telnet driver."""
+
+    pass
+
+
+class FurukawaFitelnetSerial(FurukawaFitelnetBase):
+    """Furukawa FITELnet Serial driver."""
+
+    pass

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -313,6 +313,12 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "furukawa_fitelnet": {
+        "cmd": "show boot",
+        "search_patterns": [r"next-boot-side"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "paloalto_panos": {
         "cmd": "show system info",
         "search_patterns": [r"model:\s+PA"],

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -104,6 +104,11 @@ from netmiko.fiberstore import (
 )
 from netmiko.flexvnf import FlexvnfSSH
 from netmiko.fortinet import FortinetSSH
+from netmiko.furukawa import (
+    FurukawaFitelnetSSH,
+    FurukawaFitelnetTelnet,
+    FurukawaFitelnetSerial,
+)
 from netmiko.garderos import GarderosGrsSSH
 from netmiko.genexis import GenexisSOLT33Telnet
 from netmiko.hillstone import HillstoneStoneosSSH
@@ -280,6 +285,7 @@ CLASS_MAPPER_BASE = {
     "fiberstore_networkos": FiberstoreNetworkOSSSH,
     "flexvnf": FlexvnfSSH,
     "fortinet": FortinetSSH,
+    "furukawa_fitelnet": FurukawaFitelnetSSH,
     "garderos_grs": GarderosGrsSSH,
     "generic": GenericSSH,
     "generic_termserver": TerminalServerSSH,
@@ -413,6 +419,7 @@ CLASS_MAPPER["extreme_telnet"] = ExtremeExosTelnet
 CLASS_MAPPER["extreme_exos_telnet"] = ExtremeExosTelnet
 CLASS_MAPPER["extreme_netiron_telnet"] = ExtremeNetironTelnet
 CLASS_MAPPER["fiberstore_fsosv2_telnet"] = FiberstoreFsosV2Telnet
+CLASS_MAPPER["furukawa_fitelnet_telnet"] = FurukawaFitelnetTelnet
 CLASS_MAPPER["generic_telnet"] = GenericTelnet
 CLASS_MAPPER["generic_termserver_telnet"] = TerminalServerTelnet
 CLASS_MAPPER["genexis_solt33_telnet"] = GenexisSOLT33Telnet
@@ -444,6 +451,7 @@ CLASS_MAPPER["zte_zxros_telnet"] = ZteZxrosTelnet
 
 # Add serial drivers
 CLASS_MAPPER["cisco_ios_serial"] = CiscoIosSerial
+CLASS_MAPPER["furukawa_fitelnet_serial"] = FurukawaFitelnetSerial
 
 # Add general terminal_server driver and autodetect
 CLASS_MAPPER["terminal_server"] = TerminalServerSSH


### PR DESCRIPTION
### Summary

  Add support for Furukawa FITELnet series routers (F220, F221, F220 EX, etc.).
  https://www.furukawaelectric.com/fitelnet/

  Supports SSH, Telnet, and Serial connections.

  - `furukawa_fitelnet` (SSH)
  - `furukawa_fitelnet_telnet` (Telnet)
  - `furukawa_fitelnet_serial` (Serial)

 ### Device Info

  - Vendor: Furukawa Electric / FURUKAWA NETWORK SOLUTION CORP.
  - Platform: FITELnet F220 (firmware V01.13(00.01))
  - FITELnet uses a commit-based config model (`commit` / `save` / `refresh`)

### Changes

  - `netmiko/furukawa/furukawa_fitelnet.py` - Main driver (SSH/Telnet/Serial)
  - `netmiko/furukawa/__init__.py` - Package init
  - `netmiko/ssh_dispatcher.py` - Register device types
  - `netmiko/ssh_autodetect.py` - SSH autodetect support
  - `PLATFORMS.md` - Add FITELnet to supported platforms

### ruff / mypy / unit test (Ubuntu on WSL2)                                                                                                                                                                                                                                        
<details>

<summary>All log</summary>

$ poetry run ruff format --check .
327 files already formatted

$ poetry run ruff check .
All checks passed!

$ poetry run mypy netmiko/
Success: no issues found in 253 source files

$ poetry run py.test tests/unit/ -v
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-8.3.3, pluggy-1.6.0 -- /root/.cache/pypoetry/virtualenvs/netmiko-Yuowz7HE-py3.13/bin/python
cachedir: .pytest_cache
rootdir: /mnt/i/netmiko
configfile: pyproject.toml
plugins: cov-4.1.0
collecting ... collected 89 items

tests/unit/test_base_connection.py::test_timeout_exceeded PASSED         [  1%]
tests/unit/test_base_connection.py::test_timeout_not_exceeded PASSED     [  2%]
tests/unit/test_base_connection.py::test_timeout_invalid_start PASSED    [  3%]
tests/unit/test_base_connection.py::test_use_ssh_file PASSED             [  4%]
tests/unit/test_base_connection.py::test_use_ssh_file_proxyjump PASSED   [  5%]
tests/unit/test_base_connection.py::test_connect_params_dict PASSED      [  6%]
tests/unit/test_base_connection.py::test_sanitize_nothing PASSED         [  7%]
tests/unit/test_base_connection.py::test_sanitize_output PASSED          [  8%]
tests/unit/test_base_connection.py::test_select_global_delay_factor PASSED [ 10%]
tests/unit/test_base_connection.py::test_select_current_delay_factor PASSED [ 11%]
tests/unit/test_base_connection.py::test_strip_prompt PASSED             [ 12%]
tests/unit/test_base_connection.py::test_strip_no_prompt PASSED          [ 13%]
tests/unit/test_base_connection.py::test_strip_no_backspaces PASSED      [ 14%]
tests/unit/test_base_connection.py::test_strip_one_backspaces PASSED     [ 15%]
tests/unit/test_base_connection.py::test_strip_backspaces PASSED         [ 16%]
tests/unit/test_base_connection.py::test_strip_command PASSED            [ 17%]
tests/unit/test_base_connection.py::test_strip_command_w_backspaces PASSED [ 19%]
tests/unit/test_base_connection.py::test_normalize_linefeeds PASSED      [ 20%]
tests/unit/test_base_connection.py::test_normalize_cmd PASSED            [ 21%]
tests/unit/test_base_connection.py::test_unlocking_no_lock PASSED        [ 22%]
tests/unit/test_base_connection.py::test_locking_unlocking PASSED        [ 23%]
tests/unit/test_base_connection.py::test_lock_timeout PASSED             [ 24%]
tests/unit/test_base_connection.py::test_lock_timeout_loop PASSED        [ 25%]
tests/unit/test_base_connection.py::test_strip_ansi_codes PASSED         [ 26%]
tests/unit/test_base_connection.py::test_remove_SecretsFilter_after_disconnection PASSED [ 28%]
tests/unit/test_base_connection.py::test_fortinet_kex_values PASSED      [ 29%]
tests/unit/test_base_connection.py::test_disable_sha2_fix PASSED         [ 30%]
tests/unit/test_base_connection.py::test_nokiasrl_prompt_stripping[some important data\n--{ running }--[  ]--\nA:srl1#-some important data] PASSED [ 31%]
tests/unit/test_base_connection.py::test_nokiasrl_prompt_stripping[more data\nsome important data\n--{ running }--[  ]--\nA:srl1#-more data\nsome important data] PASSED [ 32%]
tests/unit/test_base_connection.py::test_nokiasrl_prompt_stripping[more data\nsome important data\n--{ candidate private private-admin }--[  ]--\nA:srl1#-more data\nsome important data0] PASSED [ 33%]
tests/unit/test_base_connection.py::test_nokiasrl_prompt_stripping[more data\nsome important data\n--{ candidate private private-admin }--[  ]--\nA:srl1#-more data\nsome important data1] PASSED [ 34%]
tests/unit/test_base_connection.py::test_nokiasrl_prompt_stripping[\n{\n  "basic system info": {\n    "Hostname": "srl1",\n    "Chassis Type": "7220 IXR-D2L",\n    "Part Number": "Sim Part No.",\n    "Serial Number": "Sim Serial No.",\n    "System HW MAC Address": "1A:03:00:FF:00:00",\n    "OS": "SR Linux",\n    "Software Version": "v24.7.2",\n    "Build Number": "319-g64b71941f7",\n    "Architecture": "<Unknown>",\n    "Last Booted": "2024-11-01T17:21:00.164Z",\n    "Total Memory": "<Unknown>",\n    "Free Memory": "<Unknown>"\n  }\n}\n\n--{ running }--[  ]--\nA:srl1#-\n{\n  "basic system info": {\n    "Hostname": "srl1",\n    "Chassis Type": "7220 IXR-D2L",\n    "Part Number": "Sim Part No.",\n    "Serial Number": "Sim Serial No.",\n    "System HW MAC Address": "1A:03:00:FF:00:00",\n    "OS": "SR Linux",\n    "Software Version": "v24.7.2",\n    "Build Number": "319-g64b71941f7",\n    "Architecture": "<Unknown>",\n    "Last Booted": "2024-11-01T17:21:00.164Z",\n    "Total Memory": "<Unknown>",\n    "Free Memory": "<Unknown>"\n  }\n}\n] PASSED [ 35%]
tests/unit/test_clitools_helpers.py::test_ssh_conn_success PASSED        [ 37%]
tests/unit/test_clitools_helpers.py::test_ssh_conn_failure PASSED        [ 38%]
tests/unit/test_clitools_helpers.py::test_obtain_devices_all[netmiko-cleartext.yml] PASSED [ 39%]
tests/unit/test_clitools_helpers.py::test_obtain_devices_all[netmiko-encr.yml] PASSED [ 40%]
tests/unit/test_clitools_helpers.py::test_obtain_devices_all[netmiko-encr-aes128.yml] PASSED [ 41%]
tests/unit/test_clitools_helpers.py::test_update_device_params[initial_params0-update_args0-expected_result0] PASSED [ 42%]
tests/unit/test_clitools_helpers.py::test_update_device_params[initial_params1-update_args1-expected_result1] PASSED [ 43%]
tests/unit/test_clitools_helpers.py::test_update_device_params[initial_params2-update_args2-expected_result2] PASSED [ 44%]
tests/unit/test_clitools_helpers.py::test_update_device_params[initial_params3-update_args3-expected_result3] PASSED [ 46%]
tests/unit/test_clitools_helpers.py::test_update_device_params[initial_params4-update_args4-expected_result4] PASSED [ 47%]
tests/unit/test_clitools_outputters.py::test_output_raw PASSED           [ 48%]
tests/unit/test_clitools_outputters.py::test_output_json PASSED          [ 49%]
tests/unit/test_clitools_outputters.py::test_output_raw_single_device PASSED [ 50%]
tests/unit/test_connection.py::test_connecthandler_auth_failure PASSED   [ 51%]
tests/unit/test_connection.py::test_connecthandler_timeout PASSED        [ 52%]
tests/unit/test_connection.py::test_connlogonly PASSED                   [ 53%]
tests/unit/test_connection.py::test_connunify PASSED                     [ 55%]
tests/unit/test_encryption_hanlding.py::test_encrypt_decrypt[fernet] PASSED [ 56%]
tests/unit/test_encryption_hanlding.py::test_encrypt_decrypt[aes128] PASSED [ 57%]
tests/unit/test_encryption_hanlding.py::test_get_encryption_key_success PASSED [ 58%]
tests/unit/test_encryption_hanlding.py::test_get_encryption_key_missing PASSED [ 59%]
tests/unit/test_entry_points.py::test_entry_points PASSED                [ 60%]
tests/unit/test_ssh_autodetect.py::test_ssh_base_mapper_order PASSED     [ 61%]
tests/unit/test_utilities.py::test_load_yaml_file PASSED                 [ 62%]
tests/unit/test_utilities.py::test_invalid_yaml_file PASSED              [ 64%]
tests/unit/test_utilities.py::test_find_cfg_file PASSED                  [ 65%]
tests/unit/test_utilities.py::test_load_cfg_file PASSED                  [ 66%]
tests/unit/test_utilities.py::test_obtain_all_devices PASSED             [ 67%]
tests/unit/test_utilities.py::test_find_netmiko_dir PASSED               [ 68%]
tests/unit/test_utilities.py::test_invalid_netmiko_dir PASSED            [ 69%]
tests/unit/test_utilities.py::test_string_to_bytes PASSED                [ 70%]
tests/unit/test_utilities.py::test_bytes_to_bytes PASSED                 [ 71%]
tests/unit/test_utilities.py::test_invalid_data_to_bytes PASSED          [ 73%]
tests/unit/test_utilities.py::test_ensure_resource_dir_exists PASSED     [ 74%]
tests/unit/test_utilities.py::test_ensure_file_exists PASSED             [ 75%]
tests/unit/test_utilities.py::test_clitable_to_dict PASSED               [ 76%]
tests/unit/test_utilities.py::test_textfsm_w_index PASSED                [ 77%]
tests/unit/test_utilities.py::test_ntc_templates_discovery PASSED        [ 78%]
tests/unit/test_utilities.py::test_textfsm_index_relative_path PASSED    [ 79%]
tests/unit/test_utilities.py::test_textfsm_direct_template PASSED        [ 80%]
tests/unit/test_utilities.py::test_textfsm_failed_parsing PASSED         [ 82%]
tests/unit/test_utilities.py::test_textfsm_missing_template PASSED       [ 83%]
tests/unit/test_utilities.py::test_parsing_errors_textfsm[Unparsable output-cisco_ios-show version-NetmikoParsingException] PASSED [ 84%]
tests/unit/test_utilities.py::test_parsing_errors_textfsm[Cisco IOS Software, Catalyst 4500 L3 Switch Software-cisco_ios-show invalid-command-NetmikoParsingException] PASSED [ 85%]
tests/unit/test_utilities.py::test_parsing_errors_textfsm[--show version-NetmikoParsingException] PASSED [ 86%]
tests/unit/test_utilities.py::test_get_structured_data_ttp[Building configuration...\n\nCurrent configuration : 98 bytes\n!\ninterface GigabitEthernet0/0/1\n description *** TTP Testing ***\n no ip address\n shutdown\n media-type rj45\n negotiation auto\nend-/mnt/i/netmiko/tests/etc/show_run_interfaces.ttp] PASSED [ 87%]
tests/unit/test_utilities.py::test_parsing_errors_ttp[Building configuration...\n\nCurrent configuration : 98 bytes\n!\ninterface GigabitEthernet0/0/1\n description *** TTP Testing ***\n no ip address\n shutdown\n media-type rj45\n negotiation auto\nend-invalid_path.ttp-NetmikoParsingException] PASSED [ 88%]
tests/unit/test_utilities.py::test_get_structured_data_genie PASSED      [ 89%]
tests/unit/test_utilities.py::test_parsing_errors_genie[Cisco IOS Software, C3560CX Software (C3560CX-UNIVERSALK9-M), Version 15.2(4)E7, RELEASE SOFTWARE (fc2)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2018 by Cisco Systems, Inc.\nCompiled Tue 18-Sep-18 13:20 by prod_rel_team\n\nROM: Bootstrap program is C3560CX boot loader\nBOOTLDR: C3560CX Boot Loader (C3560CX-HBOOT-M) Version 15.2(4r)E5, RELEASE SOFTWARE (fc4)\n\n3560CX uptime is 5 weeks, 1 day, 2 hours, 30 minutes\nSystem returned to ROM by power-on\nSystem restarted at 11:45:26 PDT Tue May 7 2019\nSystem image file is "flash:c3560cx-universalk9-mz.152-4.E7.bin"\nLast reload reason: power-on\n\n\n\nThis product contains cryptographic features and is subject to United\nStates and local country laws governing import, export, transfer and\nuse. Delivery of Cisco cryptographic products does not imply\nthird-party authority to import, export, distribute or use encryption.\nImporters, exporters, distributors and users are responsible for\ncompliance with U.S. and local country laws. By using this product you\nagree to comply with applicable laws and regulations. If you are unable\nto comply with U.S. and local laws, return this product immediately.\n\nA summary of U.S. laws governing Cisco cryptographic products may be found at:\nhttp://www.cisco.com/wwl/export/crypto/tool/stqrg.html\n\nIf you require further assistance please contact us by sending email to\nexport@cisco.com.\n\nLicense Level: ipservices\nLicense Type: Permanent Right-To-Use\nNext reload license Level: ipservices\n\ncisco WS-C3560CX-8PC-S (APM86XXX) processor (revision A0) with 524288K bytes of memory.\nProcessor board ID FOCXXXXXXXX\nLast reset from power-on\n5 Virtual Ethernet interfaces\n12 Gigabit Ethernet interfaces\nThe password-recovery mechanism is enabled.\n\n512K bytes of flash-simulated non-volatile configuration memory.\nBase ethernet MAC Address       : 12:34:56:78:9A:BC\nMotherboard assembly number     : 86-75309-01\nPower supply part number        : 867-5309-01\nMotherboard serial number       : FOCXXXXXXXX\nPower supply serial number      : FOCXXXXXXXX\nModel revision number           : A0\nMotherboard revision number     : A0\nModel number                    : WS-C3560CX-8PC-S\nSystem serial number            : FOCXXXXXXXX\nTop Assembly Part Number        : 86-7530-91\nTop Assembly Revision Number    : A0\nVersion ID                      : V01\nCLEI Code Number                : CMM1400DRA\nHardware Board Revision Number  : 0x02\n\n\nSwitch Ports Model                     SW Version            SW Image\n------ ----- -----                     ----------            ----------\n*    1 12    WS-C3560CX-8PC-S          15.2(4)E7             C3560CX-UNIVERSALK9-M\n\n\nConfiguration register is 0xF\n-cisco_xe-show invalid-command-NetmikoParsingException] PASSED [ 91%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-1.0-100-100.0] PASSED [ 92%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-1.0-90-90.0] PASSED [ 93%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-0.1-100-10.0] PASSED [ 94%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-5-100-500.0] PASSED [ 95%]
tests/unit/test_utilities.py::test_delay_factor_compat[1500-5-100-1500.0] PASSED [ 96%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-2-100-200.0] PASSED [ 97%]
tests/unit/test_utilities.py::test_delay_factor_compat[500-10-100-1000.0] PASSED [ 98%]
tests/unit/test_utilities.py::test_nokia_context_filter PASSED           [100%]

============================= 89 passed in 18.77s ==============================


</details>

### Real machine full test report
https://github.com/SeiyaFunaokaJP/netmiko-test-result/blob/main/TEST_REPORT.md