### PR TITLE
Fix SSH agent support not working with PaloAlto PAN-OS driver

### DIFF
--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -236,7 +236,7 @@ class PaloAltoPanosSSH(PaloAltoPanosBase):
         # Create instance of SSHClient object
         # If not using SSH keys, we use noauth
 
-        if not self.use_keys:
+        if not self.use_keys and not self.allow_agent:
             remote_conn_pre: SSHClient = SSHClient_interactive()
         else:
             remote_conn_pre = SSHClient()


### PR DESCRIPTION
When allow_agent=True and use_keys=False, _build_ssh_client was incorrectly using SSHClient_interactive, causing an AssertionError when no password was provided. 

Fix by also checking allow_agent before falling back to interactive auth.