### PR TITLE
Refactor _build_ssh_client to use _get_ssh_client_instance (also fixes SSH-agent not working for certain drivers)

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1246,10 +1246,14 @@ A paramiko SSHException occurred during connection creation:
 
         raise NetmikoTimeoutException("Timed out waiting for data")
 
+    def _get_ssh_client_instance(self) -> paramiko.SSHClient:
+        """Return the appropriate SSHClient instance for this connection."""
+        return paramiko.SSHClient()
+
     def _build_ssh_client(self) -> paramiko.SSHClient:
         """Prepare for Paramiko SSH connection."""
         # Create instance of SSHClient object
-        remote_conn_pre = paramiko.SSHClient()
+        remote_conn_pre = self._get_ssh_client_instance()
 
         # Load host_keys for better SSH security
         if self.system_host_keys:

--- a/netmiko/calix/calix_b6.py
+++ b/netmiko/calix/calix_b6.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 import time
-from os import path
 
 from paramiko import SSHClient
 
@@ -85,24 +84,11 @@ class CalixB6SSH(CalixB6Base):
     the username/password.
     """
 
-    def _build_ssh_client(self) -> SSHClient:
-        """Prepare for Paramiko SSH connection."""
-        # Create instance of SSHClient object
-        # If not using SSH keys, we use noauth
-        if not self.use_keys:
-            remote_conn_pre: SSHClient = SSHClient_noauth()
-        else:
-            remote_conn_pre = SSHClient()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If not using SSH keys or agent, use noauth."""
+        if not self.use_keys and not self.allow_agent:
+            return SSHClient_noauth()
+        return SSHClient()
 
 
 class CalixB6Telnet(CalixB6Base):

--- a/netmiko/cisco/cisco_s200.py
+++ b/netmiko/cisco/cisco_s200.py
@@ -1,5 +1,4 @@
 import re
-from os import path
 
 from paramiko import SSHClient
 from netmiko.ssh_auth import SSHClient_noauth
@@ -20,21 +19,11 @@ class CiscoS200Base(CiscoSSHConnection):
 
     prompt_pattern = r"(?m:[>#]\s*$)"  # force re.Multiline
 
-    def _build_ssh_client(self) -> SSHClient:
-        """Allow passwordless authentication for Cisco SG200 devices being provisioned."""
-
-        # Create instance of SSHClient object. Use noauth
-        remote_conn_pre = SSHClient_noauth()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """SG200 devices always require noauth SSH authentication."""
+        if self.use_keys or self.allow_agent:
+            raise ValueError("Cisco SG200 does not support SSH key or agent authentication.")
+        return SSHClient_noauth()
 
     def special_login_handler(self, delay_factor: float = 1.0) -> None:
         """Cisco SG2xx presents with the following on login

--- a/netmiko/dell/dell_powerconnect.py
+++ b/netmiko/dell/dell_powerconnect.py
@@ -3,7 +3,6 @@
 from typing import Optional
 from paramiko import SSHClient
 import time
-from os import path
 from netmiko.ssh_auth import SSHClient_noauth
 from netmiko.cisco_base_connection import CiscoBaseConnection
 
@@ -65,28 +64,11 @@ class DellPowerConnectSSH(DellPowerConnectBase):
     If we use login/password, the ssh server use the (none) auth mechanism.
     """
 
-    def _build_ssh_client(self) -> SSHClient:
-        """Prepare for Paramiko SSH connection.
-
-        See base_connection.py file for any updates.
-        """
-        # Create instance of SSHClient object
-        # If user does not provide SSH key, we use noauth
-        remote_conn_pre: SSHClient
-        if not self.use_keys:
-            remote_conn_pre = SSHClient_noauth()
-        else:
-            remote_conn_pre = SSHClient()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If not using SSH keys or agent, use noauth."""
+        if not self.use_keys and not self.allow_agent:
+            return SSHClient_noauth()
+        return SSHClient()
 
     def special_login_handler(self, delay_factor: float = 1.0) -> None:
         """

--- a/netmiko/ericsson/ericsson_mltn.py
+++ b/netmiko/ericsson/ericsson_mltn.py
@@ -2,7 +2,6 @@
 
 import time
 import re
-from os import path
 from typing import Any
 from paramiko import SSHClient
 from netmiko.ssh_auth import SSHClient_noauth
@@ -40,20 +39,11 @@ class EricssonMinilinkBase(NoEnable, BaseConnection):
         if self._real_username:
             kwargs["username"] = self._real_username
 
-    def _build_ssh_client(self) -> SSHClient:
-        remote_conn_pre: SSHClient
-        if not self.use_keys:
-            remote_conn_pre = SSHClient_noauth()
-        else:
-            remote_conn_pre = SSHClient()
-
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If not using SSH keys or agent, use noauth."""
+        if not self.use_keys and not self.allow_agent:
+            return SSHClient_noauth()
+        return SSHClient()
 
     def session_preparation(self) -> None:
         self._test_channel_read(pattern=self.prompt_pattern)

--- a/netmiko/fiberstore/fiberstore_fsos.py
+++ b/netmiko/fiberstore/fiberstore_fsos.py
@@ -5,7 +5,6 @@ from paramiko import SSHClient
 from netmiko.ssh_auth import SSHClient_noauth
 from netmiko.no_enable import NoEnable
 import time
-from os import path
 from netmiko.cisco_base_connection import CiscoBaseConnection
 from netmiko.exceptions import NetmikoAuthenticationException
 
@@ -66,25 +65,11 @@ class FiberstoreFsosSSH(NoEnable, CiscoBaseConnection):
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )
 
-    def _build_ssh_client(self) -> SSHClient:
-        """Allows you to bypass standard SSH auth while still supporting SSH keys."""
-
-        # If user does not provide SSH key, we use noauth
-        remote_conn_pre: SSHClient
-        if not self.use_keys:
-            remote_conn_pre = SSHClient_noauth()
-        else:
-            remote_conn_pre = SSHClient()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If not using SSH keys or agent, use noauth."""
+        if not self.use_keys and not self.allow_agent:
+            return SSHClient_noauth()
+        return SSHClient()
 
     def special_login_handler(self, delay_factor: float = 1.0) -> None:
         """

--- a/netmiko/hp/hp_procurve.py
+++ b/netmiko/hp/hp_procurve.py
@@ -1,7 +1,6 @@
 import re
 import time
 import socket
-from os import path
 from typing import Optional, Any
 
 from paramiko import SSHClient
@@ -176,25 +175,11 @@ class HPProcurveBase(CiscoSSHConnection):
 
 
 class HPProcurveSSH(HPProcurveBase):
-    def _build_ssh_client(self) -> SSHClient:
-        """Allow passwordless authentication for HP devices being provisioned."""
-
-        # Create instance of SSHClient object. If no SSH keys and no password, then use noauth
-        remote_conn_pre: SSHClient
-        if not self.use_keys and not self.password:
-            remote_conn_pre = SSHClient_noauth()
-        else:
-            remote_conn_pre = SSHClient()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If no SSH keys, no agent, and no password, use noauth."""
+        if not self.use_keys and not self.allow_agent and not self.password:
+            return SSHClient_noauth()
+        return SSHClient()
 
 
 class HPProcurveTelnet(HPProcurveBase):

--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -1,7 +1,6 @@
 from typing import Optional, List, Any, Tuple
 import re
 import warnings
-from os import path
 from paramiko import SSHClient, Transport
 
 from netmiko.no_enable import NoEnable
@@ -231,25 +230,11 @@ class PaloAltoPanosBase(NoEnable, BaseConnection):
 
 
 class PaloAltoPanosSSH(PaloAltoPanosBase):
-    def _build_ssh_client(self) -> SSHClient:
-        """Prepare for Paramiko SSH connection."""
-        # Create instance of SSHClient object
-        # If not using SSH keys, we use noauth
-
-        if not self.use_keys:
-            remote_conn_pre: SSHClient = SSHClient_interactive()
-        else:
-            remote_conn_pre = SSHClient()
-
-        # Load host_keys for better SSH security
-        if self.system_host_keys:
-            remote_conn_pre.load_system_host_keys()
-        if self.alt_host_keys and path.isfile(self.alt_key_file):
-            remote_conn_pre.load_host_keys(self.alt_key_file)
-
-        # Default is to automatically add untrusted hosts (make sure appropriate for your env)
-        remote_conn_pre.set_missing_host_key_policy(self.key_policy)
-        return remote_conn_pre
+    def _get_ssh_client_instance(self) -> SSHClient:
+        """If not using SSH keys or agent, use interactive auth for PAN-OS banner handling."""
+        if not self.use_keys and not self.allow_agent:
+            return SSHClient_interactive()
+        return SSHClient()
 
 
 class PaloAltoPanosTelnet(PaloAltoPanosBase):


### PR DESCRIPTION
Add _get_ssh_client_instance() to BaseConnection so drivers only need to override the client selection logic rather than duplicating the full _build_ssh_client boilerplate. 

Also fixes allow_agent support across all affected drivers (calix, ericsson, dell, fiberstore, hp, paloalto). 

Cisco SG200 now raises ValueError if use_keys or allow_agent is set.