### PR TITLE
Add IIJ SEIL device support (SEIL/x86 Ayame)

### DIFF
--- a/netmiko/seil/__init__.py
+++ b/netmiko/seil/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.seil.seil import SeilSSH, SeilTelnet
+
+__all__ = ["SeilSSH", "SeilTelnet"]

--- a/netmiko/seil/seil.py
+++ b/netmiko/seil/seil.py
@@ -1,0 +1,58 @@
+"""IIJ SEIL device support (currently tested on SEIL/x86 Ayame)."""
+
+import re
+import time
+from typing import Any
+
+from netmiko.no_enable import NoEnable
+from netmiko.no_config import NoConfig
+from netmiko.base_connection import BaseConnection
+
+
+class SeilBase(NoEnable, NoConfig, BaseConnection):
+    """Common methods for IIJ SEIL devices."""
+
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self.ansi_escape_codes = True
+        self._test_channel_read(pattern=r"#")
+        self.set_base_prompt()
+        self.disable_paging(command="environment pager off")
+        self.set_terminal_width(command="environment terminal column 511")
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def strip_ansi_escape_codes(self, string_buffer: str) -> str:
+        """Strip ANSI escape codes including DEC private mode sequences."""
+        output = super().strip_ansi_escape_codes(string_buffer)
+        # DEC private mode set: ESC[?<n>h (e.g. ESC[?1h for cursor key mode)
+        output = re.sub(r"\x1b\[\?\d+h", "", output)
+        # DECKPAM/DECKPNM: ESC= and ESC>
+        output = re.sub(r"\x1b[=>]", "", output)
+        return output
+
+    def save_config(
+        self,
+        cmd: str = "save-to flashrom",
+        confirm: bool = False,
+        confirm_response: str = "",
+    ) -> str:
+        """Save the running configuration to flash memory."""
+        if confirm is True:
+            raise ValueError("SEIL does not support save_config confirmation.")
+        return self._send_command_str(command_string=cmd)
+
+
+class SeilSSH(SeilBase):
+    """IIJ SEIL SSH driver."""
+
+    pass
+
+
+class SeilTelnet(SeilBase):
+    """IIJ SEIL Telnet driver."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        default_enter = kwargs.get("default_enter")
+        kwargs["default_enter"] = "\n" if default_enter is None else default_enter
+        super().__init__(*args, **kwargs)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -153,6 +153,7 @@ from netmiko.raisecom import RaisecomRoapTelnet
 from netmiko.ruckus import RuckusFastironSSH
 from netmiko.ruckus import RuckusFastironTelnet
 from netmiko.ruijie import RuijieOSSSH, RuijieOSTelnet
+from netmiko.seil import SeilSSH, SeilTelnet
 from netmiko.silverpeak import SilverPeakVXOASSH
 from netmiko.sixwind import SixwindOSSSH
 from netmiko.smartoptics import SmartOpticsDWDMSSH
@@ -327,6 +328,8 @@ CLASS_MAPPER_BASE = {
     "raisecom_roap": RaisecomRoapSSH,
     "ruckus_fastiron": RuckusFastironSSH,
     "ruijie_os": RuijieOSSSH,
+    "seil": SeilSSH,
+    "seil_x86_ayame": SeilSSH,
     "silverpeak_vxoa": SilverPeakVXOASSH,
     "sixwind_os": SixwindOSSSH,
     "smartoptics_dwdm": SmartOpticsDWDMSSH,
@@ -435,6 +438,8 @@ CLASS_MAPPER["rad_etx_telnet"] = RadETXTelnet
 CLASS_MAPPER["raisecom_telnet"] = RaisecomRoapTelnet
 CLASS_MAPPER["ruckus_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["ruijie_os_telnet"] = RuijieOSTelnet
+CLASS_MAPPER["seil_telnet"] = SeilTelnet
+CLASS_MAPPER["seil_x86_ayame_telnet"] = SeilTelnet
 CLASS_MAPPER["supermicro_smis_telnet"] = SmciSwitchSmisTelnet
 CLASS_MAPPER["telcosystems_binos_telnet"] = TelcoSystemsBinosTelnet
 CLASS_MAPPER["teldat_cit_telnet"] = TeldatCITTelnet


### PR DESCRIPTION
## Summary

- Add a new driver for IIJ SEIL series routers, currently tested on SEIL/x86 Ayame
- SEIL devices have a flat CLI with no enable mode and no config mode — commands are executed directly at the
`#` prompt
- Inherits from `NoEnable` + `NoConfig` + `BaseConnection`

### New device types

| device_type | Protocol | Description |
|---|---|---|
| `seil` | SSH | Generic SEIL entry point |
| `seil_x86_ayame` | SSH | Explicit model alias |
| `seil_telnet` | Telnet | Generic SEIL Telnet |
| `seil_x86_ayame_telnet` | Telnet | Explicit model alias |

### Driver details

- `session_preparation`: enables ANSI escape code stripping, disables paging (`environment pager off`), sets
terminal width (`environment terminal column 511`)
- `save_config`: executes `save-to flashrom`
- `strip_ansi_escape_codes`: overridden to handle DEC private mode sequences (`ESC[?Nh`, `ESC=`, `ESC>`)
emitted by SEIL

### About SEIL

[SEIL](https://www.seil.jp/) is a network router series by IIJ (Internet Initiative Japan). Models still
under active support: SEIL/X4, SEIL/x86 Ayame, SEIL/x86 Fuji, CA10. This driver was developed and tested
against SEIL/x86 Ayame.

## Test plan

- [x] `ruff format --check` passes
- [x] `ruff check` passes
- [x] `mypy netmiko/seil/` passes (strict mode, 0 issues)
- [x] Existing unit tests unaffected
- [x] Tested on a real SEIL/x86 Ayame VM:
- SSH connection, `session_preparation` (paging disabled, terminal width set)
- `send_command("show system")`, `send_command("show config")`, `send_command("show users")`
- `send_config_set(["set hostname ..."])` — config applied and verified
- `save_config()` — command executed correctly