### PR TITLE
Add Raisecom ROS Driver

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -124,6 +124,7 @@
 - QuantaMesh
 - Rad ETX
 - Raisecom ROAP
+- Raisecom ROS
 - Silver Peak VXOA
 - Sophos SFOS
 - Telco Systems BiNOS
@@ -271,6 +272,7 @@
 - quanta_mesh
 - rad_etx
 - raisecom_roap
+- raisecom_ros
 - ruckus_fastiron
 - ruijie_os
 - silverpeak_vxoa

--- a/netmiko/raisecom/__init__.py
+++ b/netmiko/raisecom/__init__.py
@@ -1,4 +1,6 @@
 from netmiko.raisecom.raisecom_roap import RaisecomRoapSSH
 from netmiko.raisecom.raisecom_roap import RaisecomRoapTelnet
+from netmiko.raisecom.raisecom_ros import RaisecomRosSSH
+from netmiko.raisecom.raisecom_ros import RaisecomRosTelnet
 
-__all__ = ["RaisecomRoapSSH", "RaisecomRoapTelnet"]
+__all__ = ["RaisecomRoapSSH", "RaisecomRoapTelnet", "RaisecomRosSSH", "RaisecomRosTelnet"]

--- a/netmiko/raisecom/raisecom_ros.py
+++ b/netmiko/raisecom/raisecom_ros.py
@@ -1,0 +1,179 @@
+from netmiko.cisco_base_connection import CiscoBaseConnection
+import re
+import time
+from socket import socket
+
+from netmiko._telnetlib.telnetlib import (
+    IAC,
+    DO,
+    DONT,
+    WILL,
+    WONT,
+    SB,
+    SE,
+    ECHO,
+    SGA,
+    NAWS,
+    Telnet,
+)
+from netmiko.exceptions import NetmikoAuthenticationException
+
+
+class RaisecomRosBase(CiscoBaseConnection):
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        self._test_channel_read(pattern=r"[>#]")
+        self.set_base_prompt()
+        self.enable()
+        self.disable_paging("terminal page-break disable")
+        # Clear the read buffer
+        time.sleep(0.3 * self.global_delay_factor)
+        self.clear_buffer()
+
+    def check_config_mode(
+        self, check_string: str = ")#", pattern: str = "#", force_regex: bool = False
+    ) -> bool:
+        """
+        Checks if the device is in configuration mode or not.
+        """
+        return super().check_config_mode(check_string=check_string, pattern=pattern)
+
+    def config_mode(
+        self,
+        config_command: str = "config",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        return super().config_mode(config_command=config_command, pattern=pattern, re_flags=re_flags)
+
+    def save_config(
+        self,
+        cmd: str = "write",
+        confirm: bool = False,
+        confirm_response: str = "",
+    ) -> str:
+        """Saves Config."""
+        self.exit_config_mode()
+        self.enable()
+        return super().save_config(
+            cmd=cmd, confirm=confirm, confirm_response=confirm_response
+        )
+
+
+class RaisecomRosSSH(RaisecomRosBase):
+    def special_login_handler(self, delay_factor: float = 1.0) -> None:
+        """
+        Raisecom presents with the following on login (in certain OS versions)
+        Login: user
+        Password:****
+        """
+        delay_factor = self.select_delay_factor(delay_factor)
+        i = 0
+        time.sleep(delay_factor * 0.5)
+        output = ""
+        while i <= 12:
+            output = self.read_channel()
+            if output:
+                if "Login:" in output:
+                    self.write_channel(self.username + self.RETURN)
+                elif "Password:" in output:
+                    assert self.password is not None
+                    self.write_channel(self.password + self.RETURN)
+                    break
+                time.sleep(delay_factor * 1)
+            else:
+                self.write_channel(self.RETURN)
+                time.sleep(delay_factor * 1.5)
+            i += 1
+
+
+class RaisecomRosTelnet(RaisecomRosBase):
+    @staticmethod
+    def _process_option(telnet_sock: socket, cmd: bytes, opt: bytes) -> None:
+        """
+        enable ECHO, SGA, set window size to [500, 50]
+        """
+        if cmd == WILL:
+            if opt in [ECHO, SGA]:
+                # reply DO ECHO / DO SGA
+                telnet_sock.sendall(IAC + DO + opt)
+            else:
+                telnet_sock.sendall(IAC + DONT + opt)
+        elif cmd == DO:
+            if opt == NAWS:
+                # negotiate about window size
+                telnet_sock.sendall(IAC + WILL + opt)
+                # Width:500, Weight:50
+                telnet_sock.sendall(IAC + SB + NAWS + b"\x01\xf4\x00\x32" + IAC + SE)
+            else:
+                telnet_sock.sendall(IAC + WONT + opt)
+
+    def telnet_login(
+        self,
+        pri_prompt_terminator: str = r"#\s*$",
+        alt_prompt_terminator: str = r">\s*$",
+        username_pattern: str = r"(Login|Username)",
+        pwd_pattern: str = r"Password",
+        delay_factor: float = 1.0,
+        max_loops: int = 20,
+    ) -> str:
+
+        # set callback function to handle telnet options.
+        assert isinstance(self.remote_conn, Telnet)
+        self.remote_conn.set_option_negotiation_callback(self._process_option)  # type: ignore
+        delay_factor = self.select_delay_factor(delay_factor)
+        time.sleep(1 * delay_factor)
+
+        output = ""
+        return_msg = ""
+        i = 1
+        while i <= max_loops:
+            try:
+                output = self.read_channel()
+                return_msg += output
+
+                # Search for username pattern / send username
+                if re.search(username_pattern, output, flags=re.I):
+                    self.write_channel(self.username + self.TELNET_RETURN)
+                    time.sleep(1 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+
+                # Search for password pattern / send password
+                if re.search(pwd_pattern, output, flags=re.I):
+                    assert self.password is not None
+                    self.write_channel(self.password + self.TELNET_RETURN)
+                    time.sleep(0.5 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+                    if re.search(
+                        pri_prompt_terminator, output, flags=re.M
+                    ) or re.search(alt_prompt_terminator, output, flags=re.M):
+                        return return_msg
+
+                # Check if proper data received
+                if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
+                    alt_prompt_terminator, output, flags=re.M
+                ):
+                    return return_msg
+
+                time.sleep(0.5 * delay_factor)
+                i += 1
+            except EOFError:
+                self.remote_conn.close()  # type: ignore
+                msg = f"Login failed: {self.host}"
+                raise NetmikoAuthenticationException(msg)
+
+        # Last try to see if we already logged in
+        self.write_channel(self.TELNET_RETURN)
+        time.sleep(0.5 * delay_factor)
+        output = self.read_channel()
+        return_msg += output
+        if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
+            alt_prompt_terminator, output, flags=re.M
+        ):
+            return return_msg
+
+        msg = f"Login failed: {self.host}"
+        self.remote_conn.close()  # type: ignore
+        raise NetmikoAuthenticationException(msg)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -150,6 +150,8 @@ from netmiko.rad import RadETXSSH
 from netmiko.rad import RadETXTelnet
 from netmiko.raisecom import RaisecomRoapSSH
 from netmiko.raisecom import RaisecomRoapTelnet
+from netmiko.raisecom import RaisecomRosSSH
+from netmiko.raisecom import RaisecomRosTelnet
 from netmiko.ruckus import RuckusFastironSSH
 from netmiko.ruckus import RuckusFastironTelnet
 from netmiko.ruijie import RuijieOSSSH, RuijieOSTelnet
@@ -325,6 +327,7 @@ CLASS_MAPPER_BASE = {
     "quanta_mesh": QuantaMeshSSH,
     "rad_etx": RadETXSSH,
     "raisecom_roap": RaisecomRoapSSH,
+    "raisecom_ros": RaisecomRosSSH,
     "ruckus_fastiron": RuckusFastironSSH,
     "ruijie_os": RuijieOSSSH,
     "silverpeak_vxoa": SilverPeakVXOASSH,
@@ -433,6 +436,7 @@ CLASS_MAPPER["optilink_golt924_telnet"] = OptilinkGOLT924Telnet
 CLASS_MAPPER["paloalto_panos_telnet"] = PaloAltoPanosTelnet
 CLASS_MAPPER["rad_etx_telnet"] = RadETXTelnet
 CLASS_MAPPER["raisecom_telnet"] = RaisecomRoapTelnet
+CLASS_MAPPER["raisecom_ros_telnet"] = RaisecomRosTelnet
 CLASS_MAPPER["ruckus_fastiron_telnet"] = RuckusFastironTelnet
 CLASS_MAPPER["ruijie_os_telnet"] = RuijieOSTelnet
 CLASS_MAPPER["supermicro_smis_telnet"] = SmciSwitchSmisTelnet


### PR DESCRIPTION
This diver is almost identical to the Raisecom ROAP driver but uses `config` or `config terminal` instead of `configure terminal` as can be seen on the [Scrapli Raisecom ROS Definition](https://github.com/carlmontanari/scrapli/blob/main/scrapli/definitions/raisecom_ros.yaml). It also uses `write` instead of `write startup-config` to save the config.

Tested on Raisecom ISCOM2948GF-4C-AC/D.

Didn't update the docs since that updated 250 other files as well.