### PR TITLE
Add fsas_sir as alias for fujitsu_sir device_type

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -290,6 +290,7 @@ CLASS_MAPPER_BASE = {
     "fiberstore_networkos": FiberstoreNetworkOSSSH,
     "flexvnf": FlexvnfSSH,
     "fortinet": FortinetSSH,
+    "fsas_sir": FujitsuSirSSH,
     "fujitsu_sir": FujitsuSirSSH,
     "garderos_grs": GarderosGrsSSH,
     "generic": GenericSSH,


### PR DESCRIPTION
ntc-templates uses fsas_sir as the platform name; adding this alias ensures use_textfsm=True works properly