### PR TITLE
Add dell_sonic to FILE_TRANSFER_MAP in ssh_dispatcher

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -69,7 +69,7 @@ from netmiko.dell import DellDNOS6SSH
 from netmiko.dell import DellDNOS6Telnet
 from netmiko.dell import DellForce10SSH
 from netmiko.dell import DellOS10SSH, DellOS10FileTransfer
-from netmiko.dell import DellSonicSSH
+from netmiko.dell import DellSonicSSH, DellSonicFileTransfer
 from netmiko.dell import DellPowerConnectSSH
 from netmiko.dell import DellPowerConnectTelnet
 from netmiko.dell import DellIsilonSSH
@@ -385,6 +385,7 @@ FILE_TRANSFER_MAP = {
     "cisco_xe": CiscoIosFileTransfer,
     "cisco_xr": CiscoXrFileTransfer,
     "dell_os10": DellOS10FileTransfer,
+    "dell_sonic": DellSonicFileTransfer,
     "extreme_exos": ExtremeExosFileTransfer,
     "juniper_junos": JuniperFileTransfer,
     "linux": LinuxFileTransfer,


### PR DESCRIPTION
DellSonicFileTransfer existed but was not wired into FILE_TRANSFER_MAP, causing "Unsupported SCP device_type" errors for dell_sonic users.

Fixes #3703