### PR TITLE
Fix check_serial_port to use exact match instead of regex grep

### DIFF
--- a/netmiko/utilities.py
+++ b/netmiko/utilities.py
@@ -259,18 +259,17 @@ def check_serial_port(name: str) -> str:
         )
         raise ValueError(msg)
 
-    try:
-        cdc = next(serial.tools.list_ports.grep(name))
-        serial_port = cdc[0]
-        assert isinstance(serial_port, str)
-        return serial_port
-    except StopIteration:
-        msg = f"device {name} not found. "
-        msg += "available devices are: "
-        ports = list(serial.tools.list_ports.comports())
-        for p in ports:
-            msg += f"{str(p)},"
-        raise ValueError(msg)
+    ports = serial.tools.list_ports.comports()
+    matches: List[str] = [p.device for p in ports if p.device == name]
+    if len(matches) > 1:
+        raise ValueError(f"Multiple ports found matching {name}")
+    if matches:
+        return matches[0]
+    msg = f"device {name} not found. "
+    msg += "available devices are: "
+    for p in ports:
+        msg += f"{str(p.device)},"
+    raise ValueError(msg)
 
 
 def get_template_dir(_skip_ntc_package: bool = False) -> str:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -5,6 +5,7 @@ import os
 import sys
 from os.path import dirname, join, relpath
 from pathlib import Path
+from unittest.mock import MagicMock
 import pytest
 
 from netmiko import utilities
@@ -547,3 +548,51 @@ def test_nokia_context_filter():
     test_case = 'foo[show router "Base" bgp]'
     out = utilities.nokia_context_filter(test_case)
     assert out != ""
+
+
+def test_check_serial_port_exact_match(monkeypatch):
+    """check_serial_port should return the port when an exact match is found."""
+    port1 = MagicMock()
+    port1.device = "/dev/ttyUSB0"
+    port2 = MagicMock()
+    port2.device = "/dev/ttyS0"
+    monkeypatch.setattr(
+        "netmiko.utilities.serial.tools.list_ports.comports", lambda: [port1, port2]
+    )
+    assert utilities.check_serial_port("/dev/ttyUSB0") == "/dev/ttyUSB0"
+    assert utilities.check_serial_port("/dev/ttyS0") == "/dev/ttyS0"
+
+
+def test_check_serial_port_no_partial_match(monkeypatch):
+    """check_serial_port should not match a port that is a substring of another."""
+    port1 = MagicMock()
+    port1.device = "COM9"
+    port2 = MagicMock()
+    port2.device = "COM99"
+    monkeypatch.setattr(
+        "netmiko.utilities.serial.tools.list_ports.comports", lambda: [port1, port2]
+    )
+    assert utilities.check_serial_port("COM9") == "COM9"
+    assert utilities.check_serial_port("COM99") == "COM99"
+
+
+def test_check_serial_port_not_found(monkeypatch):
+    """check_serial_port should raise ValueError when port is not found."""
+    port1 = MagicMock()
+    port1.device = "/dev/cu.Panther"
+    monkeypatch.setattr("netmiko.utilities.serial.tools.list_ports.comports", lambda: [port1])
+    with pytest.raises(ValueError, match="device /dev/cu.usbserial-1410 not found"):
+        utilities.check_serial_port("/dev/cu.usbserial-1410")
+
+
+def test_check_serial_port_multiple_matches(monkeypatch):
+    """check_serial_port should raise ValueError when multiple ports match."""
+    port1 = MagicMock()
+    port1.device = "COM9"
+    port2 = MagicMock()
+    port2.device = "COM9"
+    monkeypatch.setattr(
+        "netmiko.utilities.serial.tools.list_ports.comports", lambda: [port1, port2]
+    )
+    with pytest.raises(ValueError, match="Multiple ports found matching COM9"):
+        utilities.check_serial_port("COM9")


### PR DESCRIPTION
serial.tools.list_ports.grep() uses re.search() which causes partial matches (e.g. COM9 matching COM99). Replace with exact match on p.device attribute. Also raises ValueError if multiple ports match.

Fixes #3767