### PR TITLE
Remove deprecated License trove classifier from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ include = [
 ]
 repository = "https://github.com/ktbyers/netmiko"
 classifiers = [
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Replace with SPDX license expression via the existing license = "MIT" field, as recommended by the Python packaging guidelines.

Fixes #3728