### PR TITLE
Fix Furukawa FITELnet driver bug

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -329,7 +329,7 @@ class BaseConnection:
 
         self.TELNET_RETURN = "\r\n"
         if default_enter is None:
-            if "telnet" not in device_type:
+            if "_telnet" not in device_type:
                 self.RETURN = "\n"
             else:
                 self.RETURN = self.TELNET_RETURN

--- a/netmiko/furukawa/furukawa_fitelnet.py
+++ b/netmiko/furukawa/furukawa_fitelnet.py
@@ -1,9 +1,8 @@
 import re
 import time
-from typing import Any, Optional, Union, Sequence, Iterator, TextIO
+from typing import Optional
 
 from netmiko.cisco_base_connection import CiscoBaseConnection
-from netmiko.exceptions import NetmikoAuthenticationException
 
 
 class FurukawaFitelnetBase(CiscoBaseConnection):
@@ -13,15 +12,6 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
     - Bare prompts: ">" (user mode), "#" (enable mode)
     - Hostname prompts: "F220>", "F220#", "F220(config)#",
       "F220(config-GigaEthernet1/1)#", etc.
-
-    FITELnet password model:
-        - Login password: set via ``username <name> password <pass>`` or
-          ``line telnet/console password <pass>``.
-        - Enable password: separate from login, set via
-          ``enable password <pass>``.
-        - The device may show ``<WARNING> weak login password: set the
-          password`` messages that contain the word 'password' but are NOT
-          actual password prompts.
     """
 
     def session_preparation(self) -> None:
@@ -38,98 +28,36 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
         pri_prompt_terminator: str = r"\#\s*$",
         alt_prompt_terminator: str = r">\s*$",
         username_pattern: str = r"(?:user:|username|login|user name)",
-        pwd_pattern: str = r"assword",
+        pwd_pattern: str = r"assword:\s*$",
         delay_factor: float = 1.0,
         max_loops: int = 20,
     ) -> str:
         """Telnet/Serial login for FITELnet.
 
-        Overridden because FITELnet shows ``<WARNING>`` messages after login
-        that contain the word 'password' (e.g. ``<WARNING> weak login
-        password: set the password``).  The base class matches this as a
-        password prompt and incorrectly sends the password as a CLI command.
-
-        This override checks for the command prompt **before** checking for
-        the password pattern so that warning messages are not confused with
-        real password prompts.
+        FITELnet emits ``<WARNING> weak login password: set the password``
+        right after login.  The base class default ``pwd_pattern = r"assword"``
+        matches the word 'password' inside that warning and incorrectly sends
+        the password as a CLI command.  Anchoring to ``assword:\\s*$`` limits
+        matches to a real ``password:`` prompt at end-of-line.
         """
-        delay_factor = self.select_delay_factor(delay_factor)
-        time.sleep(1 * delay_factor)
-
-        output = ""
-        return_msg = ""
-        i = 1
-        while i <= max_loops:
-            try:
-                output = self.read_channel()
-                return_msg += output
-
-                # Search for username pattern / send username
-                if re.search(username_pattern, output, flags=re.I):
-                    self.write_channel(self.username + "\r")
-                    time.sleep(1 * delay_factor)
-                    output = self.read_channel()
-                    return_msg += output
-
-                # FITELnet fix: check for prompt BEFORE password pattern.
-                # This prevents matching 'password' in <WARNING> messages.
-                if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
-                    alt_prompt_terminator, output, flags=re.M
-                ):
-                    return return_msg
-
-                # Only check for password if no prompt was detected
-                if re.search(pwd_pattern, output, flags=re.I):
-                    assert isinstance(self.password, str)
-                    self.write_channel(self.password + "\r")
-                    time.sleep(0.5 * delay_factor)
-                    output = self.read_channel()
-                    return_msg += output
-                    if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
-                        alt_prompt_terminator, output, flags=re.M
-                    ):
-                        return return_msg
-
-                # Check for device with no password configured
-                if re.search(r"assword required, but none set", output):
-                    assert self.remote_conn is not None
-                    self.remote_conn.close()
-                    msg = f"Login failed - Password required, but none set: {self.host}"
-                    raise NetmikoAuthenticationException(msg)
-
-                self.write_channel(self.TELNET_RETURN)
-                time.sleep(0.5 * delay_factor)
-                i += 1
-
-            except EOFError:
-                assert self.remote_conn is not None
-                self.remote_conn.close()
-                msg = f"Login failed: {self.host}"
-                raise NetmikoAuthenticationException(msg)
-
-        # Last try to see if we already logged in
-        self.write_channel(self.TELNET_RETURN)
-        time.sleep(0.5 * delay_factor)
-        output = self.read_channel()
-        return_msg += output
-        if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(
-            alt_prompt_terminator, output, flags=re.M
-        ):
-            return return_msg
-
-        assert self.remote_conn is not None
-        self.remote_conn.close()
-        msg = f"Login failed: {self.host}"
-        raise NetmikoAuthenticationException(msg)
+        return super().telnet_login(
+            pri_prompt_terminator=pri_prompt_terminator,
+            alt_prompt_terminator=alt_prompt_terminator,
+            username_pattern=username_pattern,
+            pwd_pattern=pwd_pattern,
+            delay_factor=delay_factor,
+            max_loops=max_loops,
+        )
 
     def check_enable_mode(self, check_string: str = "#") -> bool:
         """Check if in enable mode.
 
-        FITELnet uses bare prompts (just ">" or "#"), so we read until
-        either prompt character appears rather than relying on base_prompt.
+        FITELnet uses bare prompts (just ">" or "#"), so we match the
+        prompt character at end-of-line to avoid false matches on
+        ``<WARNING>`` / ``<ERROR>`` messages that contain ``>``.
         """
         self.write_channel(self.RETURN)
-        output = self.read_until_pattern(pattern=r"[>#]")
+        output = self.read_until_pattern(pattern=r"[>#]\s*$")
         return check_string in output
 
     def enable(
@@ -149,6 +77,10 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
            ``<ERROR> Authentication failed`` followed by another ``password:``
            prompt.  The base implementation would hang waiting for "#".
            This override detects the failure immediately.
+
+        ``enable_pattern`` is accepted for API compatibility with the parent
+        signature but is not used; this override hardcodes the success /
+        failure detection patterns.
         """
         output = ""
         if check_state and self.check_enable_mode():
@@ -183,7 +115,7 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
         output = ""
         if self.check_enable_mode():
             self.write_channel(self.normalize_cmd(exit_command))
-            output += self.read_until_pattern(pattern=r">")
+            output += self.read_until_pattern(pattern=r">\s*$")
             # Drain any remaining data (serial ports may have buffered echoes)
             time.sleep(0.5)
             self.clear_buffer()
@@ -191,23 +123,9 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
                 raise ValueError("Failed to exit enable mode.")
         return output
 
-    def send_config_set(
-        self,
-        config_commands: Union[str, Sequence[str], Iterator[str], TextIO, None] = None,
-        exit_config_mode: bool = False,
-        **kwargs: Any,
-    ) -> str:
-        """FITELnet uses a candidate-config model; stay in config mode for commit."""
-        return super().send_config_set(
-            config_commands=config_commands,
-            exit_config_mode=exit_config_mode,
-            **kwargs,
-        )
-
     def commit(
         self,
         read_timeout: float = 120.0,
-        comment: str = "",
     ) -> str:
         """
         Commit the candidate configuration on the FITELnet device.
@@ -216,16 +134,11 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
 
         commit may prompt with '[y/n]' for confirmation.
         """
-        if comment:
-            command_string = f"commit comment {comment}"
-        else:
-            command_string = "commit"
-
         output = ""
         confirmation = r"onfirm|\[y/[nN]\]"
         pattern = rf"(?:#|{confirmation})"
         new_data = self._send_command_str(
-            command_string,
+            "commit",
             expect_string=pattern,
             strip_prompt=False,
             strip_command=False,
@@ -245,7 +158,18 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
 
         output += new_data
 
-        if "Error" in output or "error" in output or "Failed" in output:
+        # FITELnet refuses commit while another session/process is active with
+        # "Another processing is executing. This command can not be executed."
+        # The message contains neither "error" nor "failed", so it must be
+        # detected separately before the generic error check below.
+        if "Another processing is executing" in output:
+            raise ValueError(
+                "Commit failed: another process is executing on the device. "
+                "Retry once the other operation completes."
+            )
+
+        # FITELnet emits <ERROR> in all caps; match case-insensitively.
+        if re.search(r"error|failed", output, re.IGNORECASE):
             raise ValueError(f"Commit failed with the following errors:\n\n{output}")
 
         return output
@@ -259,28 +183,39 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
         """Save working.cfg to boot.cfg (startup configuration).
 
         FITELnet prompts 'save ok?[y/N]:' by default.
+
+        If another process is holding the config (e.g. a concurrent session
+        in the middle of commit/save/refresh), FITELnet replies with
+        "Another processing is executing. This command can not be executed."
+        and never prints the ``[y/N]`` prompt — so the confirm_response would
+        then be sent as a bare CLI command.  Detect this explicitly and raise.
         """
-        return super().save_config(cmd=cmd, confirm=confirm, confirm_response=confirm_response)
+        output = super().save_config(cmd=cmd, confirm=confirm, confirm_response=confirm_response)
+        if "Another processing is executing" in output:
+            raise ValueError(
+                "save_config failed: another process is executing on the device. "
+                "Retry once the other operation completes."
+            )
+        return output
 
     def strip_command(self, command_string: str, output: str) -> str:
         """Strip command echo from output.
 
-        FITELnet bare prompts cause the echoed command to appear as
-        ``#show ...`` instead of ``show ...``, so the base implementation's
-        ``output.startswith(cmd)`` check fails.  This override searches for
-        the command echo line (optionally prefixed by the prompt character)
-        and removes it along with any preceding prompt-only lines.
+        FITELnet echoes the command with the prompt still on the same line
+        (e.g. ``TEST-HOST#show version`` or ``#show version``), so the base
+        implementation's ``output.startswith(cmd)`` check fails.  This
+        override additionally matches an echo line that ends with the command
+        after an optional prompt terminator (``>`` or ``#``).
         """
         cmd = command_string.strip()
         if output.startswith(cmd):
             return super().strip_command(command_string=command_string, output=output)
 
+        echo_pattern = rf"^.*?[>#]?{re.escape(cmd)}\s*$"
         output_lines = output.split(self.RESPONSE_RETURN)
         for i, line in enumerate(output_lines):
-            line_s = line.strip()
-            if line_s == cmd or line_s == f"#{cmd}" or line_s == f">{cmd}":
-                start = i + 1
-                return self.RESPONSE_RETURN.join(output_lines[start:])
+            if re.match(echo_pattern, line.strip()):
+                return self.RESPONSE_RETURN.join(output_lines[i + 1 :])
         return output
 
     def strip_prompt(self, a_string: str) -> str:

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -505,7 +505,7 @@ def ConnectHandler(*args: Any, **kwargs: Any) -> "BaseConnection":
         if device_type is None:
             msg_str = platforms_str
         else:
-            msg_str = telnet_platforms_str if "telnet" in device_type else platforms_str
+            msg_str = telnet_platforms_str if "_telnet" in device_type else platforms_str
         raise ValueError(
             "Unsupported 'device_type' currently supported platforms are: {}".format(msg_str)
         )


### PR DESCRIPTION
Hi @ktbyers , thank you for reviewing on #3810 and sorry for PR again. 
Please check when you have a moment.

## Summary

While exercising the merged FITELnet driver (#3810) against real F220
hardware over SSH, Telnet, and Serial, some bugs surfaced and
some of the override code turned out to be unnecessary. This PR fixes
them and simplifies the implementation.

## Fixes

- **`base_connection.py`** — `"telnet" in device_type` also matched
  `"furukawa_fitelnet"`, so SSH connections got CRLF (`\r\n`) instead
  of `\n` and the password was treated as two Enter presses. Changed
  to `"_telnet"` so only Telnet drivers are matched.

- **`ssh_dispatcher.py`** — Same substring bug in the error-message
  routing for unknown `device_type`. Fixed the same way.

- **`commit()`** — Dropped the unused `comment` parameter (FITELnet's
  `commit` command does not support comments) and made the `<ERROR>`
  match case-insensitive, since the device always emits the tag in
  uppercase. Also detect the plain-text reply `Another processing is
  executing. This command can not be executed.` (which contains
  neither `error` nor `failed`) and raise `ValueError`, so a silently
  failed commit is not treated as success. Same idea as the
  `alt_error_marker` handling in `cisco_xr.commit()`.

- **`save_config()`** — Same `Another processing is executing`
  detection. Without it the base class blindly sends the `y`
  confirmation, which then runs as a bare CLI command and produces
  an unrelated `<ERROR> Invalid input detected` in the output.

- **`telnet_login()`** — The base class default
  `pwd_pattern = r"assword"` matched the `<WARNING> weak login
  password: set the password` banner FITELnet prints right after
  login, and the password was written as a CLI command. Replaced the
  80-line loop reimplementation with a `super()` call that simply
  tightens the pattern to `r"assword:\s*$"`.

- **`strip_command()`** — Previous fallback only matched bare `#cmd`
  / `>cmd`; hostname-prefixed echoes like `F220#show version` slipped
  through and were left in the output. Switched to a regex that
  covers both forms.

- **`check_enable_mode()` / `exit_enable_mode()`** — Anchored the
  prompt patterns to end-of-line so `>` / `#` characters inside
  `<WARNING>` or `<ERROR>` messages cannot match prematurely.

- **`send_config_set()` override** — Removed. FITELnet `commit` works
  from both enable mode and config mode, so the base class default
  is already correct.

- **Class docstring** — Removed the password-model section; parts of
  it were inaccurate for FITELnet and not important for the driver doc.

## Testing

WSL2 Ubuntu, poetry 2.3.3, Python 3.13.12:

| Check | Result |
|---|---|
| `poetry run ruff format netmiko/` | 268 files left unchanged |
| `poetry run ruff check netmiko/` | All checks passed |
| `poetry run mypy netmiko/` | Success: no issues found in 268 source files |
| `poetry run pytest tests/unit/` | **97 passed** |

<details>
<summary>Real machine test (command log ex.Telnet)</summary>

```
F220 (TEST-HOST) (pts/0)

login: 
<WARNING> weak login password: set the password
TEST-HOST>
TEST-HOST>
TEST-HOST>
TEST-HOST>enable

password:
<WARNING> weak enable password: contain at least 8 characters



TEST-HOST#
TEST-HOST#
TEST-HOST#no more
more : off

TEST-HOST#

====================[ post-connect state (session_preparation done) ]====================


====================[ find_prompt() ]====================

TEST-HOST#

====================[ check_enable_mode() (already enabled after session_preparation) ]====================

TEST-HOST#

====================[ exit_enable_mode() ]====================

TEST-HOST#disable

TEST-HOST>
TEST-HOST>
TEST-HOST>

====================[ enable() ]====================

TEST-HOST>enable

password:
<WARNING> weak enable password: contain at least 8 characters



TEST-HOST#
TEST-HOST#
TEST-HOST#

====================[ send_command('show version') ]====================

TEST-HOST#show version
  --------------------- present-side --------------------- 
F220   Version 01.12(00)[0]00.00.0 [2023/07/26 15:00]

  ---------------------- other-side ---------------------- 
F220   Version 01.12(00)[0]00.00.0 [2023/07/26 15:00]



TEST-HOST#

====================[ send_command_timing('show boot') ]====================
show boot
next-boot-side: present-side
config  : /drive/boot.cfg

TEST-HOST#

====================[ config_mode() ]====================

TEST-HOST#configure terminal

TEST-HOST(config)#
TEST-HOST(config)#
TEST-HOST(config)#

====================[ exit_config_mode() ]====================

TEST-HOST(config)#end

TEST-HOST#
TEST-HOST#
TEST-HOST#

====================[ send_config_set(['interface Loopback 1', 'description fulllog-demo']) ]====================

TEST-HOST#configure terminal

TEST-HOST(config)#
TEST-HOST(config)#interface Loopback 1

TEST-HOST(config-if-lo 1)#description fulllog-demo

TEST-HOST(config-if-lo 1)#
TEST-HOST(config-if-lo 1)#end

TEST-HOST#
TEST-HOST#

====================[ commit() ]====================
commit
................................Done

TEST-HOST#

====================[ save_config() ]====================

TEST-HOST#save
save ok?[y/N]:yes

% saving working-config

  1% |                                                 |     4 /   252 ( Lines)
  5% |**                                               |    13 /   252 ( Lines)
 10% |****                                             |    26 /   252 ( Lines)
 15% |*******                                          |    38 /   252 ( Lines)
 20% |*********                                        |    52 /   252 ( Lines)
 25% |************                                     |    63 /   252 ( Lines)
 30% |**************                                   |    76 /   252 ( Lines)
 35% |*****************                                |    89 /   252 ( Lines)
 40% |*******************                              |   101 /   252 ( Lines)
 45% |**********************                           |   114 /   252 ( Lines)
 50% |************************                         |   126 /   252 ( Lines)
 55% |**************************                       |   139 /   252 ( Lines)
 60% |*****************************                    |   152 /   252 ( Lines)
 65% |*******************************                  |   164 /   252 ( Lines)
 70% |**********************************               |   177 /   252 ( Lines)
 75% |************************************             |   189 /   252 ( Lines)
 80% |***************************************          |   202 /   252 ( Lines)
 85% |*****************************************        |   215 /   252 ( Lines)
 90% |********************************************     |   227 /   252 ( Lines)
 95% |**********************************************   |   240 /   252 ( Lines)
100% |*************************************************|   252 /   252 ( Lines)

TEST-HOST#
TEST-HOST#

====================[ cleanup: send_config_set([... 'no description']) + commit() + save_config() ]====================

TEST-HOST#configure terminal

TEST-HOST(config)#
TEST-HOST(config)#interface Loopback 1

TEST-HOST(config-if-lo 1)#no description

TEST-HOST(config-if-lo 1)#
TEST-HOST(config-if-lo 1)#end

TEST-HOST#
TEST-HOST#commit
................................Done

TEST-HOST#
TEST-HOST#save
save ok?[y/N]:yes

% saving working-config

  1% |                                                 |     4 /   251 ( Lines)
  5% |**                                               |    13 /   251 ( Lines)
 10% |****                                             |    26 /   251 ( Lines)
 15% |*******                                          |    38 /   251 ( Lines)
 20% |*********                                        |    52 /   251 ( Lines)
 25% |************                                     |    63 /   251 ( Lines)
 30% |**************                                   |    76 /   251 ( Lines)
 35% |*****************                                |    89 /   251 ( Lines)
 40% |*******************                              |   101 /   251 ( Lines)
 45% |**********************                           |   113 /   251 ( Lines)
 50% |************************                         |   126 /   251 ( Lines)
 55% |**************************                       |   139 /   251 ( Lines)
 60% |*****************************                    |   151 /   251 ( Lines)
 65% |*******************************                  |   164 /   251 ( Lines)
 70% |**********************************               |   176 /   251 ( Lines)
 75% |************************************             |   189 /   251 ( Lines)
 80% |***************************************          |   201 /   251 ( Lines)
 85% |*****************************************        |   214 /   251 ( Lines)
 90% |********************************************     |   226 /   251 ( Lines)
 95% |**********************************************   |   239 /   251 ( Lines)
100% |*************************************************|   251 /   251 ( Lines)

TEST-HOST#
TEST-HOST#

====================[ [show running.cfg] ]====================

TEST-HOST#show running.cfg
!  LAST EDIT    00:27:44 2023/07/27 by operator
!  LAST REFRESH 00:27:50 2023/07/27 by operator
!  LAST SAVE    00:27:37 2023/07/27 by operator
!
ip prefix-list ALLOW-OUT seq 10 permit 172.16.1.1/32
ip prefix-list ALLOW-OUT seq 20 permit 172.16.2.1/32

...

end

TEST-HOST#

====================[ disconnect() ]====================

TEST-HOST#exit
```

</details>