### PR TITLE
Include matched error in ConfigInvalidException for cmd_verify=False …

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2313,8 +2313,12 @@ You can also look at the Netmiko session_log or debug log for more information.
                 # Gather the output incrementally due to error_pattern requirements
                 if error_pattern:
                     output += self.read_channel_timing(read_timeout=read_timeout)
-                    if re.search(error_pattern, output, flags=re.M):
-                        msg = f"Invalid input detected at command: {cmd}"
+                    error_match = re.search(error_pattern, output, flags=re.M)
+                    if error_match:
+                        error_msg = error_match.group(0)
+                        msg = (
+                            f"Invalid input detected at command: {cmd}, matched error: {error_msg}"
+                        )
                         raise ConfigInvalidException(msg)
 
             # Standard output gathering (no error_pattern)


### PR DESCRIPTION
…path

The cmd_verify=True path already included the matched error string in the exception message. Apply the same pattern to the cmd_verify=False path for consistency.

Fixes #3682