### PR TITLE
Fix Huawei telnet password using "\r" instead of TELNET_RETURN

### DIFF
--- a/netmiko/huawei/huawei.py
+++ b/netmiko/huawei/huawei.py
@@ -193,7 +193,8 @@ class HuaweiTelnet(HuaweiBase):
             output = self.read_until_pattern(pattern=pwd_pattern, re_flags=re.I)
             return_msg += output
             assert self.password is not None
-            self.write_channel(self.password + self.TELNET_RETURN)
+            # Huawei might require only "\r" for password to be accepted
+            self.write_channel(self.password + "\r")
 
             # Waiting for the prompt or password change message
             output = self.read_until_pattern(pattern=self.prompt_or_password_change)


### PR DESCRIPTION
Certain Huawei devices require only "\r" for the password to be accepted during Telnet login. Using "\r\n" (TELNET_RETURN) causes authentication failure on these devices.

Fixes #3679