### PR TITLE
Fix Juniper commit() expect_string false positive on '>'

### DIFF
--- a/netmiko/juniper/juniper.py
+++ b/netmiko/juniper/juniper.py
@@ -191,7 +191,7 @@ class JuniperBase(NoEnable, BaseConnection):
 
         # hostname might change on commit, and-quit might result in exiting config mode.
         re_prompt = re.escape(self.base_prompt)
-        expect_string = rf"(?:{re_prompt}|[>#])"
+        expect_string = rf"(?:{re_prompt}|[>#]\s*$)"
         output += self._send_command_str(
             command_string,
             expect_string=expect_string,


### PR DESCRIPTION
Change expect_string on commit operation such that bare '>' and bare '#' would be less likely to be accidentally matched. Anchoring [>#] to end-of-line ensures only actual prompts are matched, while preserving support for hostname changes and commit and-quit.

Fixes #3692