### PR TITLE
Add save_config to DellSonicSSH using 'write memory'

### DIFF
--- a/netmiko/dell/dell_sonic_ssh.py
+++ b/netmiko/dell/dell_sonic_ssh.py
@@ -35,6 +35,15 @@ class DellSonicSSH(NoEnable, CiscoSSHConnection):
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )
 
+    def save_config(
+        self,
+        cmd: str = "write memory",
+        confirm: bool = False,
+        confirm_response: str = "",
+    ) -> str:
+        """Save config."""
+        return super().save_config(cmd=cmd, confirm=confirm, confirm_response=confirm_response)
+
     def _enter_cli(self) -> str:
         """Enter the sonic-cli."""
         return self._send_command_str("sonic-cli", expect_string=r"\#")


### PR DESCRIPTION
Dell Enterprise SONiC uses 'write memory' to save configuration, not the inherited 'copy running-config startup-config' default.

Fixes #3191