### PR TITLE
Fix save_config for DellDNOS6 — use short command form with confirmation

### DIFF
--- a/netmiko/dell/dell_dnos6.py
+++ b/netmiko/dell/dell_dnos6.py
@@ -15,9 +15,9 @@ class DellDNOS6Base(DellPowerConnectBase):
 
     def save_config(
         self,
-        cmd: str = "copy running-configuration startup-configuration",
-        confirm: bool = False,
-        confirm_response: str = "",
+        cmd: str = "copy running-config startup-config",
+        confirm: bool = True,
+        confirm_response: str = "y",
     ) -> str:
         """Saves Config"""
         return super().save_config(cmd=cmd, confirm=confirm, confirm_response=confirm_response)


### PR DESCRIPTION
'copy running-configuration startup-configuration' is invalid on DNOS6 switches; 'copy running-config startup-config' is correct and prompts 'Are you sure you want to save? (y/n)' requiring confirmation.

Fixes #3191