### PR TITLE
Add SSH and file transfer support for ZPE Nodegrid devices

### DIFF
--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -184,6 +184,7 @@ from netmiko.vyos import VyOSSSH
 from netmiko.watchguard import WatchguardFirewareSSH
 from netmiko.yamaha import YamahaSSH
 from netmiko.yamaha import YamahaTelnet
+from netmiko.zpe import ZpeNodegridSSH, ZpeNodegridFileTransfer
 from netmiko.zte import ZteZxrosSSH
 from netmiko.zte import ZteZxrosTelnet
 from netmiko.zyxel import ZyxelSSH
@@ -368,6 +369,7 @@ CLASS_MAPPER_BASE = {
     "vyatta_vyos": VyOSSSH,
     "vyos": VyOSSSH,
     "watchguard_fireware": WatchguardFirewareSSH,
+    "zpe_nodegrid": ZpeNodegridSSH,
     "zte_zxros": ZteZxrosSSH,
     "yamaha": YamahaSSH,
     "zyxel_os": ZyxelSSH,
@@ -391,6 +393,7 @@ FILE_TRANSFER_MAP = {
     "nokia_sros": NokiaSrosFileTransfer,
     "mikrotik_routeros": MikrotikRouterOsFileTransfer,
     "ubiquiti_edgerouter": UbiquitiEdgeRouterFileTransfer,
+    "zpe_nodegrid": ZpeNodegridFileTransfer,
 }
 
 # Also support keys that end in _ssh

--- a/netmiko/zpe/__init__.py
+++ b/netmiko/zpe/__init__.py
@@ -1,0 +1,3 @@
+from netmiko.zpe.zpe_nodegrid import ZpeNodegridSSH, ZpeNodegridFileTransfer
+
+__all__ = ["ZpeNodegridSSH", "ZpeNodegridFileTransfer"]

--- a/netmiko/zpe/zpe_nodegrid.py
+++ b/netmiko/zpe/zpe_nodegrid.py
@@ -1,0 +1,85 @@
+import re
+from typing import Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from netmiko.base_connection import BaseConnection
+
+from netmiko.linux.linux_ssh import LinuxSSH
+from netmiko.scp_handler import BaseFileTransfer
+
+
+class ZpeNodegridSSH(LinuxSSH):
+    def _enter_shell(self) -> str:
+        """Enter the Bash shell on ZPE Nodegrid."""
+        return self._send_command_str("shell", expect_string=r"[\$#]")
+
+    def _return_cli(self) -> str:
+        """Return to the ZPE Nodegrid CLI."""
+        return self._send_command_str("exit", expect_string=r"[\$#]")
+
+
+class ZpeNodegridFileTransfer(BaseFileTransfer):
+    """ZPE Nodegrid SCP File Transfer driver."""
+
+    def __init__(
+        self,
+        ssh_conn: "BaseConnection",
+        source_file: str,
+        dest_file: str,
+        file_system: Optional[str] = "/var/tmp",
+        direction: str = "put",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            ssh_conn=ssh_conn,
+            source_file=source_file,
+            dest_file=dest_file,
+            file_system=file_system,
+            direction=direction,
+            **kwargs,
+        )
+
+    def remote_space_available(self, search_pattern: str = "") -> int:
+        """Return space available on remote device."""
+        search_pattern = r"[\$#]"
+        return self._remote_space_available_unix(search_pattern=search_pattern)
+
+    def check_file_exists(self, remote_cmd: str = "") -> bool:
+        """Check if the dest_file already exists on the file system."""
+        return self._check_file_exists_unix(remote_cmd=remote_cmd)
+
+    def remote_file_size(self, remote_cmd: str = "", remote_file: Optional[str] = None) -> int:
+        """Get the file size of the remote file."""
+        return self._remote_file_size_unix(remote_cmd=remote_cmd, remote_file=remote_file)
+
+    def remote_md5(self, base_cmd: str = "md5sum", remote_file: Optional[str] = None) -> str:
+        """Calculate remote MD5 and returns the hash."""
+        if remote_file is None:
+            if self.direction == "put":
+                remote_file = self.dest_file
+            elif self.direction == "get":
+                remote_file = self.source_file
+        remote_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
+        self.ssh_ctl_chan._enter_shell()
+        try:
+            output = self.ssh_ctl_chan._send_command_str(
+                remote_cmd, expect_string=r"[\$#]", read_timeout=300
+            )
+        finally:
+            self.ssh_ctl_chan._return_cli()
+        return self.process_md5(output.strip())
+
+    @staticmethod
+    def process_md5(md5_output: str, pattern: str = r"(\S+)\s+") -> str:
+        """Process the string to retrieve the MD5 hash."""
+        match = re.search(pattern, md5_output)
+        if match:
+            return match.group(1)
+        else:
+            raise ValueError(f"Invalid output from MD5 command: {md5_output}")
+
+    def enable_scp(self, cmd: str = "") -> None:
+        raise NotImplementedError
+
+    def disable_scp(self, cmd: str = "") -> None:
+        raise NotImplementedError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -629,4 +629,9 @@ def get_platform_args():
             "enable_scp": True,
             "delete_file": delete_file_generic,
         },
+        "zpe_nodegrid": {
+            "file_system": "/var/tmp",
+            "enable_scp": False,
+            "delete_file": delete_file_generic,
+        },
     }

--- a/tests/test_zpe_nodegrid/test9.txt
+++ b/tests/test_zpe_nodegrid/test9.txt
@@ -1,0 +1,1 @@
+no logging console

--- a/tests/test_zpe_nodegrid/testx.txt
+++ b/tests/test_zpe_nodegrid/testx.txt
@@ -1,0 +1,1 @@
+no logging console


### PR DESCRIPTION
Add the classes and helper functions to allow users to perform SSH connections and file transfers to ZPE Nodegrid devices.

These devices are using the Linux kernel. The only difference is that an additional step is needed to enter the Bash shell prompt from the CLI.

Tested with a real device and all tests in `test_netmiko_scp` are passing.