### PR TITLE
Fix ZPE Nodegrid driver and tests

### DIFF
--- a/netmiko/zpe/zpe_nodegrid.py
+++ b/netmiko/zpe/zpe_nodegrid.py
@@ -38,6 +38,10 @@ class ZpeNodegridSSH(NoEnable, NoConfig, LinuxSSH):
 
     # Matches: [admin@nodegrid /]# and [+admin@nodegrid ETH0]#
     prompt_pattern = r"\[\+?.*\]#"
+    # Matches: root@nodegrid:/var/home# or admin@nodegrid:~$
+    shell_prompt_pattern = r".+@.+:.+[\$#]"
+    # WARNING: Not officially documented by ZPE. Could negatively impact performance.
+    disable_paging_command = ".sessionpageout undefined=no"
 
     def session_preparation(self) -> None:
         """Prepare the session after the connection has been established."""
@@ -92,20 +96,15 @@ class ZpeNodegridSSH(NoEnable, NoConfig, LinuxSSH):
 
     def disable_paging(
         self,
-        command: str = "set /settings/system_preferences/ paging=no",
+        command: str = "",
         delay_factor: Optional[float] = None,
         cmd_verify: bool = True,
         pattern: Optional[str] = None,
     ) -> str:
-        """Disable output paging globally.
-
-        On some Nodegrid versions this is a persistent setting requiring a
-        commit; on others it takes effect immediately. Both cases are handled.
-        """
-        output = self._send_command_str(command, expect_string=self.prompt_pattern)
-        if self.allow_auto_change:
-            output += self.commit()
-        return output
+        """Disable paging for the current CLI session."""
+        if not command:
+            command = self.disable_paging_command
+        return self._send_command_str(command, expect_string=self.prompt_pattern)
 
     def commit(self) -> str:
         """Commit staged configuration changes."""
@@ -113,7 +112,7 @@ class ZpeNodegridSSH(NoEnable, NoConfig, LinuxSSH):
 
     def _enter_shell(self) -> str:
         """Enter the Bash shell on ZPE Nodegrid."""
-        return self._send_command_str("shell", expect_string=r"[\$#]")
+        return self._send_command_str("shell", expect_string=self.shell_prompt_pattern)
 
     def _return_cli(self) -> str:
         """Return to the ZPE Nodegrid CLI."""
@@ -141,17 +140,24 @@ class ZpeNodegridFileTransfer(BaseFileTransfer):
             **kwargs,
         )
 
-    def remote_space_available(self, search_pattern: str = r"[\$#]") -> int:
+    def remote_space_available(self, search_pattern: str = "") -> int:
         """Return space available on remote device."""
+        search_pattern = ZpeNodegridSSH.shell_prompt_pattern
         return self._remote_space_available_unix(search_pattern=search_pattern)
 
     def check_file_exists(self, remote_cmd: str = "") -> bool:
         """Check if the dest_file already exists on the file system."""
-        return self._check_file_exists_unix(remote_cmd=remote_cmd)
+        return self._check_file_exists_unix(
+            remote_cmd=remote_cmd, search_pattern=ZpeNodegridSSH.shell_prompt_pattern
+        )
 
     def remote_file_size(self, remote_cmd: str = "", remote_file: Optional[str] = None) -> int:
         """Get the file size of the remote file."""
-        return self._remote_file_size_unix(remote_cmd=remote_cmd, remote_file=remote_file)
+        return self._remote_file_size_unix(
+            remote_cmd=remote_cmd,
+            remote_file=remote_file,
+            search_pattern=ZpeNodegridSSH.shell_prompt_pattern,
+        )
 
     def remote_md5(self, base_cmd: str = "md5sum", remote_file: Optional[str] = None) -> str:
         """Calculate remote MD5 and returns the hash."""
@@ -164,7 +170,9 @@ class ZpeNodegridFileTransfer(BaseFileTransfer):
         self.ssh_ctl_chan._enter_shell()
         try:
             output = self.ssh_ctl_chan._send_command_str(
-                remote_cmd, expect_string=r"[\$#]", read_timeout=300
+                remote_cmd,
+                expect_string=ZpeNodegridSSH.shell_prompt_pattern,
+                read_timeout=300,
             )
         finally:
             self.ssh_ctl_chan._return_cli()

--- a/tests/test_zpe_nodegrid/test9.txt
+++ b/tests/test_zpe_nodegrid/test9.txt
@@ -1,0 +1,1 @@
+no logging console

--- a/tests/test_zpe_nodegrid/testx.txt
+++ b/tests/test_zpe_nodegrid/testx.txt
@@ -1,0 +1,1 @@
+no logging console


### PR DESCRIPTION
The original ZPE Nodegrid implementation includes a non-existent command to disable paging. Change the command to a real one and tighten up the regex patterns to be detected. The parameter for `remote_space_available` also needs to always be overridden since the default Cisco-style search pattern does not work on this platform.

Additionally, `test_netmiko_scp` tests are failing due to missing files. Add the necessary files to allow the tests to pass.