### PR TITLE
Fix session_log flush so data is written immediately on write()

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -104,20 +104,6 @@ def lock_channel(func: F) -> F:
     return cast(F, wrapper_decorator)
 
 
-def flush_session_log(func: F) -> F:
-    @functools.wraps(func)
-    def wrapper_decorator(self: "BaseConnection", *args: Any, **kwargs: Any) -> Any:
-        try:
-            return_val = func(self, *args, **kwargs)
-        finally:
-            # Always flush the session_log
-            if self.session_log:
-                self.session_log.flush()
-        return return_val
-
-    return cast(F, wrapper_decorator)
-
-
 def log_writes(func: F) -> F:
     """Handle both session_log and log of writes."""
 
@@ -1492,7 +1478,6 @@ A paramiko SSHException occurred during connection creation:
             pass
         return new_data
 
-    @flush_session_log
     @select_cmd_verify
     def send_command_timing(
         self,
@@ -1643,7 +1628,6 @@ A paramiko SSHException occurred during connection creation:
             prompt = self.base_prompt
         return re.escape(prompt.strip())
 
-    @flush_session_log
     @select_cmd_verify
     def send_command(
         self,
@@ -2181,7 +2165,6 @@ You can also look at the Netmiko session_log or debug log for more information.
             commands = cfg_file.readlines()
         return self.send_config_set(commands, **kwargs)
 
-    @flush_session_log
     def send_config_set(
         self,
         config_commands: Union[str, Sequence[str], Iterator[str], TextIO, None] = None,

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -104,6 +104,23 @@ def lock_channel(func: F) -> F:
     return cast(F, wrapper_decorator)
 
 
+def flush_session_log(func: F) -> F:
+    """Deprecated: no longer used by Netmiko internally. Retained for any external
+    code that decorates custom methods with @flush_session_log."""
+
+    @functools.wraps(func)
+    def wrapper_decorator(self: "BaseConnection", *args: Any, **kwargs: Any) -> Any:
+        try:
+            return_val = func(self, *args, **kwargs)
+        finally:
+            # Always flush the session_log
+            if self.session_log:
+                self.session_log.flush()
+        return return_val
+
+    return cast(F, wrapper_decorator)
+
+
 def log_writes(func: F) -> F:
     """Handle both session_log and log of writes."""
 

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -124,6 +124,10 @@ class SessionLog:
         if data:
             self._write(data)
 
+    def flush(self) -> None:
+        """Force any buffered data to be written to the sink immediately."""
+        self._flush_buffer()
+
     def write(self, data: str) -> None:
         if len(data) > 0:
             self.slog_buffer.write(data)

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -63,7 +63,7 @@ class SessionLog:
                 if hold_back:
                     data = data[:-hold_back] + "********"
                 data = self.no_log_filter(data)
-                self._write_to_session_log(data)
+                self._write(data)
         if self.session_log and self._session_log_close:
             self.session_log.close()
             self.session_log = None
@@ -92,7 +92,7 @@ class SessionLog:
         self.slog_buffer = io.StringIO()
         return data
 
-    def _write_to_session_log(self, data: str) -> None:
+    def _write(self, data: str) -> None:
         assert self.session_log is not None
         if isinstance(self.session_log, io.BufferedIOBase):
             self.session_log.write(write_bytes(data, encoding=self.file_encoding))
@@ -122,7 +122,7 @@ class SessionLog:
             data = self.no_log_filter(data)
 
         if data:
-            self._write_to_session_log(data)
+            self._write(data)
 
     def write(self, data: str) -> None:
         if len(data) > 0:

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -53,17 +53,7 @@ class SessionLog:
 
     def close(self) -> None:
         """Close the session_log file (if it is a file that we opened)."""
-        self.flush()
-        # Finalize: any data still held back (partial secret match) is now
-        # definitively a fragment — redact it before closing.
-        if self.session_log is not None:
-            data = self._read_buffer()
-            if data:
-                hold_back = self._longest_partial_match(data)
-                if hold_back:
-                    data = data[:-hold_back] + "********"
-                data = self.no_log_filter(data)
-                self._write(data)
+        self._flush_buffer(final=True)
         if self.session_log and self._session_log_close:
             self.session_log.close()
             self.session_log = None
@@ -93,6 +83,7 @@ class SessionLog:
         return data
 
     def _write(self, data: str) -> None:
+        """Write data to the underlying IO sink and flush it."""
         assert self.session_log is not None
         if isinstance(self.session_log, io.BufferedIOBase):
             self.session_log.write(write_bytes(data, encoding=self.file_encoding))
@@ -105,10 +96,16 @@ class SessionLog:
 
         self.session_log.flush()
 
-    def flush(self) -> None:
-        """Flush slog_buffer to disk, holding back any trailing data that is a
-        partial prefix of a no_log value so the next write can complete the
-        match before applying no_log_filter."""
+    def _flush_buffer(self, final: bool = False) -> None:
+        """Drain slog_buffer to the sink.
+
+        If final=False (normal write path), any trailing data that is a partial
+        prefix of a no_log value is held back in the buffer so the next write
+        can complete the match before filtering.
+
+        If final=True (close path), any held-back partial match is replaced
+        with '********' rather than exposing a fragment of the secret.
+        """
         if self.session_log is None:
             return
 
@@ -117,8 +114,11 @@ class SessionLog:
         if self.no_log and data:
             hold_back = self._longest_partial_match(data)
             if hold_back:
-                self.slog_buffer.write(data[-hold_back:])
-                data = data[:-hold_back]
+                if final:
+                    data = data[:-hold_back] + "********"
+                else:
+                    self.slog_buffer.write(data[-hold_back:])
+                    data = data[:-hold_back]
             data = self.no_log_filter(data)
 
         if data:
@@ -127,4 +127,4 @@ class SessionLog:
     def write(self, data: str) -> None:
         if len(data) > 0:
             self.slog_buffer.write(data)
-            self.flush()
+            self._flush_buffer()

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -64,6 +64,17 @@ class SessionLog:
             data = data.replace(hidden_data, "********")
         return data
 
+    def _longest_partial_match(self, data: str) -> int:
+        """Return the length of the longest suffix of data that is a partial
+        prefix of any no_log value. Used to hold back data that might be the
+        start of a secret split across multiple channel reads."""
+        hold_back = 0
+        for hidden_data in self.no_log.values():
+            for partial_len in range(1, len(hidden_data)):
+                if data.endswith(hidden_data[:partial_len]):
+                    hold_back = max(hold_back, partial_len)
+        return hold_back
+
     def _read_buffer(self) -> str:
         self.slog_buffer.seek(0)
         data = self.slog_buffer.read()
@@ -71,26 +82,56 @@ class SessionLog:
         self.slog_buffer = io.StringIO()
         return data
 
-    def flush(self) -> None:
-        """Force the slog_buffer to be written out to the actual file"""
+    def _write_to_session_log(self, data: str) -> None:
+        if isinstance(self.session_log, io.BufferedIOBase):
+            self.session_log.write(write_bytes(data, encoding=self.file_encoding))
+        else:
+            self.session_log.write(data)
 
+        assert isinstance(self.session_log, io.BufferedIOBase) or isinstance(
+            self.session_log, io.TextIOBase
+        )
+
+        self.session_log.flush()
+
+    def flush(self) -> None:
+        """Force the slog_buffer to be written out to the actual file.
+
+        Any data still in the buffer that partially matches a no_log value
+        (e.g. connection closed mid-stream) is written as '********' rather
+        than exposing a fragment of the secret.
+        """
         if self.session_log is not None:
             data = self._read_buffer()
             data = self.no_log_filter(data)
 
-            if isinstance(self.session_log, io.BufferedIOBase):
-                self.session_log.write(write_bytes(data, encoding=self.file_encoding))
-            else:
-                self.session_log.write(data)
+            if self.no_log and data:
+                hold_back = self._longest_partial_match(data)
+                if hold_back:
+                    data = data[:-hold_back] + "********"
 
-            assert isinstance(self.session_log, io.BufferedIOBase) or isinstance(
-                self.session_log, io.TextIOBase
-            )
+            self._write_to_session_log(data)
 
-            # Flush the underlying file
-            self.session_log.flush()
+    def _flush_safe(self) -> None:
+        """Flush slog_buffer to disk, holding back any trailing data that is a
+        partial prefix of a no_log value so the next write can complete the
+        match before we apply no_log_filter and write to disk."""
+        if self.session_log is None:
+            return
+
+        data = self._read_buffer()
+
+        if self.no_log and data:
+            hold_back = self._longest_partial_match(data)
+            if hold_back:
+                self.slog_buffer.write(data[-hold_back:])
+                data = data[:-hold_back]
+            data = self.no_log_filter(data)
+
+        if data:
+            self._write_to_session_log(data)
 
     def write(self, data: str) -> None:
         if len(data) > 0:
             self.slog_buffer.write(data)
-            self.flush()
+            self._flush_safe()

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -54,6 +54,16 @@ class SessionLog:
     def close(self) -> None:
         """Close the session_log file (if it is a file that we opened)."""
         self.flush()
+        # Finalize: any data still held back (partial secret match) is now
+        # definitively a fragment — redact it before closing.
+        if self.session_log is not None:
+            data = self._read_buffer()
+            if data:
+                hold_back = self._longest_partial_match(data)
+                if hold_back:
+                    data = data[:-hold_back] + "********"
+                data = self.no_log_filter(data)
+                self._write_to_session_log(data)
         if self.session_log and self._session_log_close:
             self.session_log.close()
             self.session_log = None
@@ -96,27 +106,9 @@ class SessionLog:
         self.session_log.flush()
 
     def flush(self) -> None:
-        """Force the slog_buffer to be written out to the actual file.
-
-        Any data still in the buffer that partially matches a no_log value
-        (e.g. connection closed mid-stream) is written as '********' rather
-        than exposing a fragment of the secret.
-        """
-        if self.session_log is not None:
-            data = self._read_buffer()
-            data = self.no_log_filter(data)
-
-            if self.no_log and data:
-                hold_back = self._longest_partial_match(data)
-                if hold_back:
-                    data = data[:-hold_back] + "********"
-
-            self._write_to_session_log(data)
-
-    def _flush_safe(self) -> None:
         """Flush slog_buffer to disk, holding back any trailing data that is a
         partial prefix of a no_log value so the next write can complete the
-        match before we apply no_log_filter and write to disk."""
+        match before applying no_log_filter."""
         if self.session_log is None:
             return
 
@@ -135,4 +127,4 @@ class SessionLog:
     def write(self, data: str) -> None:
         if len(data) > 0:
             self.slog_buffer.write(data)
-            self._flush_safe()
+            self.flush()

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -83,6 +83,7 @@ class SessionLog:
         return data
 
     def _write_to_session_log(self, data: str) -> None:
+        assert self.session_log is not None
         if isinstance(self.session_log, io.BufferedIOBase):
             self.session_log.write(write_bytes(data, encoding=self.file_encoding))
         else:

--- a/netmiko/session_log.py
+++ b/netmiko/session_log.py
@@ -93,3 +93,4 @@ class SessionLog:
     def write(self, data: str) -> None:
         if len(data) > 0:
             self.slog_buffer.write(data)
+            self.flush()

--- a/tests/test_netmiko_session_log.py
+++ b/tests/test_netmiko_session_log.py
@@ -8,16 +8,17 @@ from netmiko.session_log import SessionLog
 
 
 def filter_bare_prompts(content, base_prompt):
-    """Remove lines that are only a prompt with no command/output after them.
+    """Remove lines that are only a prompt or blank.
 
-    The count of such lines varies across runs (extra reads during session
-    setup), so they must be excluded before MD5 comparison. Hard-codes ">"
-    and "#" as the only valid trailing prompt characters.
+    The count of such lines varies across runs (extra reads/writes during
+    session setup), so they must be excluded before MD5 comparison. Hard-codes
+    ">" and "#" as the only valid trailing prompt characters.
     """
     bare_prompts = {f"{base_prompt}>".encode(), f"{base_prompt}#".encode()}
     filtered = []
     for line in content.splitlines(keepends=True):
-        if line.strip() not in bare_prompts:
+        stripped = line.strip()
+        if stripped and stripped not in bare_prompts:
             filtered.append(line)
     return b"".join(filtered)
 

--- a/tests/test_netmiko_session_log.py
+++ b/tests/test_netmiko_session_log.py
@@ -278,7 +278,7 @@ def test_session_log_no_log(device_slog_test_name):
     # Plus one for read, one for write (send_command_timing)
     assert session_log.count("********") == 5
 
-    # Do disconnect after test (to make sure send_command() actually flushes session_log buffer)
+    # Assert before disconnect to verify write() flushes immediately (no explicit flush needed)
     conn.disconnect()
 
 
@@ -318,7 +318,7 @@ def test_session_log_no_log_cfg(device_slog_test_name, commands):
     assert session_log.count("********") == 2
     assert config_command2 in session_log
 
-    # Make sure send_config_set flushes the session_log (so disconnect after the asserts)
+    # Assert before disconnect to verify write() flushes immediately (no explicit flush needed)
     conn.disconnect()
 
 

--- a/tests/test_netmiko_session_log.py
+++ b/tests/test_netmiko_session_log.py
@@ -7,6 +7,21 @@ from netmiko import ConnectHandler
 from netmiko.session_log import SessionLog
 
 
+def filter_bare_prompts(content, base_prompt):
+    """Remove lines that are only a prompt with no command/output after them.
+
+    The count of such lines varies across runs (extra reads during session
+    setup), so they must be excluded before MD5 comparison. Hard-codes ">"
+    and "#" as the only valid trailing prompt characters.
+    """
+    bare_prompts = {f"{base_prompt}>".encode(), f"{base_prompt}#".encode()}
+    filtered = []
+    for line in content.splitlines(keepends=True):
+        if line.strip() not in bare_prompts:
+            filtered.append(line)
+    return b"".join(filtered)
+
+
 def add_test_name_to_file_name(initial_fname, test_name):
     dir_name, f_name = initial_fname.split("/")
     new_file_name = f"{dir_name}/{test_name}-{f_name}"
@@ -45,18 +60,22 @@ def session_action(my_connect, command):
     return output
 
 
-def session_log_md5(session_file, compare_file):
+def session_log_md5(session_file, compare_file, base_prompt):
     """Compare the session_log MD5 to the compare_file MD5"""
-    compare_log_md5 = calc_md5(file_name=compare_file)
-    log_content = read_session_log(session_file)
+    with open(compare_file, "rb") as f:
+        compare_contents = filter_bare_prompts(f.read(), base_prompt)
+    compare_log_md5 = calc_md5(contents=compare_contents)
+    log_content = filter_bare_prompts(read_session_log(session_file), base_prompt)
     session_log_md5 = calc_md5(contents=log_content)
     assert session_log_md5 == compare_log_md5
 
 
-def session_log_md5_append(session_file, compare_file):
+def session_log_md5_append(session_file, compare_file, base_prompt):
     """Compare the session_log MD5 to the compare_file MD5"""
-    compare_log_md5 = calc_md5(file_name=compare_file)
-    log_content = read_session_log(session_file, append=True)
+    with open(compare_file, "rb") as f:
+        compare_contents = filter_bare_prompts(f.read(), base_prompt)
+    compare_log_md5 = calc_md5(contents=compare_contents)
+    log_content = filter_bare_prompts(read_session_log(session_file, append=True), base_prompt)
     session_log_md5 = calc_md5(contents=log_content)
     assert session_log_md5 == compare_log_md5
 
@@ -69,7 +88,7 @@ def test_session_log(net_connect, commands, expected_responses):
     compare_file = expected_responses["compare_log"]
     session_file = expected_responses["session_log"]
 
-    session_log_md5(session_file, compare_file)
+    session_log_md5(session_file, compare_file, net_connect.base_prompt)
 
 
 def test_session_log_write(net_connect_slog_wr, commands, expected_responses):
@@ -127,7 +146,7 @@ def test_session_log_append(device_slog_test_name, commands, expected_responses)
     compare_file_base = expected_responses["compare_log_append"]
     dir_name, f_name = compare_file_base.split("/")
     compare_file = f"{dir_name}/{test_name}-{f_name}"
-    session_log_md5_append(session_file, compare_file)
+    session_log_md5_append(session_file, compare_file, conn.base_prompt)
 
 
 def test_session_log_secrets(device_slog_test_name):
@@ -240,9 +259,12 @@ def test_session_log_bytesio(device_slog_test_name, commands, expected_responses
 
     compare_file = expected_responses["compare_log"]
     compare_file = add_test_name_to_file_name(compare_file, test_name)
-    compare_log_md5 = calc_md5(file_name=compare_file)
 
-    log_content = s_log.getvalue()
+    with open(compare_file, "rb") as f:
+        compare_contents = filter_bare_prompts(f.read(), conn.base_prompt)
+    compare_log_md5 = calc_md5(contents=compare_contents)
+
+    log_content = filter_bare_prompts(s_log.getvalue(), conn.base_prompt)
     session_log_md5 = calc_md5(contents=log_content)
     assert session_log_md5 == compare_log_md5
 

--- a/tests/test_netmiko_session_log.py
+++ b/tests/test_netmiko_session_log.py
@@ -346,6 +346,29 @@ def test_session_log_no_log_cfg(device_slog_test_name, commands):
     conn.disconnect()
 
 
+def test_session_log_partial_no_log_at_close():
+    """Verify a partial no_log match held in the buffer at close is written as
+    '********' rather than leaking a fragment of the secret."""
+    secret = "supersecret"
+    no_log = {"password": secret}
+    sink = io.BytesIO()
+
+    slog = SessionLog(buffered_io=sink, no_log=no_log)
+
+    # Write normal data followed by a partial secret (split at a write boundary).
+    # _flush_buffer holds "superse" back since it is a prefix of "supersecret".
+    slog.write("some output ")
+    slog.write("superse")  # partial prefix — held back, not yet written to sink
+
+    # close() must redact the held-back fragment rather than leaking it
+    slog.close()
+
+    result = sink.getvalue().decode("utf-8")
+    assert "some output " in result
+    assert secret not in result
+    assert "********" in result
+
+
 def test_session_log_custom_session_log(device_slog_test_name):
     """Verify session_log does not contain custom words (use SessionLog obj)."""
     device_slog = device_slog_test_name[0]

--- a/tests/test_netmiko_session_log.py
+++ b/tests/test_netmiko_session_log.py
@@ -113,13 +113,14 @@ def test_session_log_write(net_connect_slog_wr, commands, expected_responses):
     # So just discard it.
     marker = b"% Invalid input detected at '^' marker."
     _, compare_contents = compare_contents.split(marker)
-    compare_log_md5 = calc_md5(contents=compare_contents.strip())
+    compare_contents = filter_bare_prompts(compare_contents.strip(), nc.base_prompt)
+    compare_log_md5 = calc_md5(contents=compare_contents)
 
     log_content = read_session_log(session_file)
-    marker = b"% Invalid input detected at '^' marker."
     _, log_content = log_content.split(marker)
+    log_content = filter_bare_prompts(log_content.strip(), nc.base_prompt)
 
-    session_log_md5 = calc_md5(contents=log_content.strip())
+    session_log_md5 = calc_md5(contents=log_content)
     assert session_log_md5 == compare_log_md5
 
 


### PR DESCRIPTION
Previously, SessionLog.write() only buffered data in slog_buffer and relied on flush_session_log decorator or close() to persist it. This meant session log files were empty until disconnect. Moving flush() into write() ensures real-time logging. Removes the now-redundant flush_session_log decorator entirely.

Fixes #3378