### PR TITLE
Fix remote space function in ZPE Nodegrid driver

### DIFF
--- a/netmiko/zpe/zpe_nodegrid.py
+++ b/netmiko/zpe/zpe_nodegrid.py
@@ -143,8 +143,7 @@ class ZpeNodegridFileTransfer(BaseFileTransfer):
 
     def remote_space_available(self, search_pattern: str = "") -> int:
         """Return space available on remote device."""
-        if not search_pattern:
-            search_pattern = self.ssh_ctl_chan.shell_prompt_pattern
+        search_pattern = self.ssh_ctl_chan.shell_prompt_pattern
         return self._remote_space_available_unix(search_pattern=search_pattern)
 
     def check_file_exists(self, remote_cmd: str = "") -> bool:


### PR DESCRIPTION
As mentioned in the previous ZPE Nodegrid driver fix commit, the override has to be done unconditionally for the remote space check to work properly. This is because the `BaseFileTransfer` class is checking for a non-existent output pattern of `(\\d+) \\w+ free`. The refactor added a conditional check for the sake of code style, which actually caused some of the `test_netmiko_scp` tests to throw a `ReadTimeout` exception and broke functionality of the driver.

Revert this function back to how it was originally written to fix this behavior.