### PR TITLE
Fix exit_enable_mode issue with not verifying command echo

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -2081,6 +2081,12 @@ You can also look at the Netmiko session_log or debug log for more information.
         output = ""
         if self.check_enable_mode():
             self.write_channel(self.normalize_cmd(exit_command))
+            # Make sure you read until you detect the command echo (avoid getting out of sync)
+            if self.global_cmd_verify is not False:
+                output += self.read_until_pattern(pattern=re.escape(exit_command.strip()))
+            else:
+                time.sleep(0.3)
+                output += self.read_channel()
             output += self.read_until_prompt()
             if self.check_enable_mode():
                 raise ValueError("Failed to exit enable mode.")

--- a/netmiko/cisco/cisco_ftd_ssh.py
+++ b/netmiko/cisco/cisco_ftd_ssh.py
@@ -89,7 +89,7 @@ class CiscoFtdSSH(NoConfig, CiscoSSHConnection):
         """
         output = ""
         if getattr(self, "_in_diagnostic_cli", False):
-            output += self._send_command_str("\x01d", expect_string=r">")
+            output += self._send_command_str("\x01d", expect_string=r">", cmd_verify=False)
             self._in_diagnostic_cli = False
             self.set_base_prompt()
         return output


### PR DESCRIPTION
Also there might be a bug in Cisco FTD with exit_enable_mode() when you detach from the diagnostic CLI...so fixed that here also.