### PR TITLE
fix: remove SecretsFilter when a connection fails before disconnect()

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -487,7 +487,21 @@ class BaseConnection:
 
         # Establish the remote connection
         if auto_connect:
-            self._open()
+            try:
+                self._open()
+            except Exception:
+                # If the connection fails before disconnect() is ever reached
+                # (establish_connection errors: authentication, TCP timeout,
+                # SSH key-exchange/negotiation), the SecretsFilter registered
+                # above would be stranded on the module logger and leaked.
+                # Remove it (and close any session log) before propagating.
+                try:
+                    log.removeFilter(self._secrets_filter)
+                    if self.session_log:
+                        self.session_log.close()
+                except Exception:
+                    pass
+                raise
 
     def _open(self) -> None:
         """Decouple connection creation from __init__ for mocking."""


### PR DESCRIPTION
I'm running a daemon process which uses netmiko. I've noticed that a lot of failing connections lead to leaking memory.
With help from claude and some instrumentation using tracemalloc, it revelead leaking SecretsFilter objects.


BaseConnection.__init__ registers a per-connection SecretsFilter on the module-level "netmiko" logger (log.addFilter) and only removes it in disconnect(). When the connection fails before _open() completes -- establish_connection errors such as authentication failure, TCP timeout, or SSH key-exchange/negotiation failure -- __init__ raises without ever calling disconnect(), so the filter is stranded on the logger permanently. A process that repeatedly opens connections to failing devices accumulates these filters without bound (observed in production as tens of thousands of SecretsFilter objects and steady RSS growth), and every emitted log record then runs through all of them.

Guard the auto_connect _open() call so an early failure removes the filter (and closes any session log) before propagating, mirroring disconnect()'s own cleanup. The cleanup is wrapped so it can never mask the original error.