### PR TITLE
Fix hp_comware send_command empty output in Netmiko 4.x

### DIFF
--- a/netmiko/hp/hp_comware.py
+++ b/netmiko/hp/hp_comware.py
@@ -84,6 +84,14 @@ class HPComwareBase(CiscoSSHConnection):
             bypass_commands=bypass_commands,
         )
 
+    def _prompt_handler(self, auto_find_prompt: bool) -> str:
+        prompt = super()._prompt_handler(auto_find_prompt)
+        if auto_find_prompt:
+            # Comware can leave a <HOSTNAME> prompt fragment queued after find_prompt().
+            # Clear the residual prompt so send_command() reads the real command output.
+            self.clear_buffer()
+        return prompt
+
     def set_base_prompt(
         self,
         pri_prompt_terminator: str = ">",

--- a/tests/unit/test_hp_comware.py
+++ b/tests/unit/test_hp_comware.py
@@ -1,0 +1,55 @@
+import pytest
+
+from netmiko.hp.hp_comware import HPComwareBase
+
+
+class FakeHPComwareConnection(HPComwareBase):
+    def __init__(self):
+        pass
+
+
+@pytest.mark.parametrize("auto_find_prompt", [True, False])
+def test_hp_comware_prompt_handler_clear_buffer(monkeypatch, auto_find_prompt):
+    connection = FakeHPComwareConnection()
+    calls = []
+
+    def fake_find_prompt():
+        calls.append("find_prompt")
+        return "<HP1>"
+
+    def fake_clear_buffer():
+        calls.append("clear_buffer")
+
+    monkeypatch.setattr(connection, "find_prompt", fake_find_prompt)
+    monkeypatch.setattr(connection, "clear_buffer", fake_clear_buffer)
+    connection.base_prompt = "HP1"
+
+    prompt = connection._prompt_handler(auto_find_prompt=auto_find_prompt)
+
+    expected_prompt = "<HP1>" if auto_find_prompt else "HP1"
+    assert prompt == expected_prompt
+    if auto_find_prompt:
+        assert calls == ["find_prompt", "clear_buffer"]
+    else:
+        assert calls == []
+
+
+def test_hp_comware_prompt_handler_clear_buffer_after_find_prompt_fallback(monkeypatch):
+    connection = FakeHPComwareConnection()
+    calls = []
+
+    def fake_find_prompt():
+        calls.append("find_prompt")
+        raise ValueError
+
+    def fake_clear_buffer():
+        calls.append("clear_buffer")
+
+    monkeypatch.setattr(connection, "find_prompt", fake_find_prompt)
+    monkeypatch.setattr(connection, "clear_buffer", fake_clear_buffer)
+    connection.base_prompt = "HP1"
+
+    prompt = connection._prompt_handler(auto_find_prompt=True)
+
+    assert prompt == "HP1"
+    assert calls == ["find_prompt", "clear_buffer"]


### PR DESCRIPTION
Root cause: Netmiko 4.x send_command() relies on _prompt_handler() -> find_prompt() without the extra clear_buffer() safety net that existed in the 3.x flow. On H3C/HP Comware devices, find_prompt() can leave a residual <HOSTNAME> prompt fragment queued in the channel.

Reproduction: on hp_comware with auto_find_prompt enabled and cmd_verify disabled by default, send_command() may match the stale prompt before real command output arrives. strip_command()/strip_prompt() can then sanitize the buffer down to an empty string.

Fix: override hp_comware _prompt_handler() to clear_buffer() immediately after auto prompt detection. This keeps the change scoped to the Comware driver and avoids altering behavior for other platforms. Add unit tests covering auto_find_prompt on/off and find_prompt() fallback handling.,timeout:120}},{

Change-Id: I74d55cafef8890a8364109518484fdb52770615f