### PR TITLE
Fix Palo Alto command echo stripping

### DIFF
--- a/netmiko/paloalto/paloalto_panos.py
+++ b/netmiko/paloalto/paloalto_panos.py
@@ -181,11 +181,6 @@ class PaloAltoPanosBase(NoEnable, BaseConnection):
             raise ValueError(f"Commit failed with the following errors:\n\n{output}")
         return output
 
-    def strip_command(self, command_string: str, output: str) -> str:
-        """Strip command_string from output string."""
-        output_list = output.split(command_string)
-        return self.RESPONSE_RETURN.join(output_list)
-
     def strip_prompt(self, a_string: str) -> str:
         """Strip the trailing router prompt from the output."""
         response_list = a_string.split(self.RESPONSE_RETURN)

--- a/tests/unit/test_base_connection.py
+++ b/tests/unit/test_base_connection.py
@@ -7,6 +7,7 @@ from threading import Lock
 import paramiko
 from netmiko import NetmikoTimeoutException, log, ConnectHandler
 from netmiko.base_connection import BaseConnection
+from netmiko.paloalto.paloalto_panos import PaloAltoPanosSSH, PaloAltoPanosTelnet
 
 RESOURCE_FOLDER = join(dirname(dirname(__file__)), "etc")
 
@@ -343,6 +344,35 @@ myhostname>
     connection = FakeBaseConnection(RESPONSE_RETURN="\n")
     result = connection.strip_command(command, output)
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    ("connection_type", "device_type"),
+    [
+        (PaloAltoPanosSSH, "paloalto_panos"),
+        (PaloAltoPanosTelnet, "paloalto_panos_telnet"),
+    ],
+)
+def test_paloalto_strip_command_handles_normalized_enter(connection_type, device_type):
+    connection = connection_type(host="localhost", device_type=device_type, auto_connect=False)
+    command = connection.normalize_cmd("show system info")
+    output = connection.normalize_linefeeds(f"{command}hostname: pa\n")
+    result = connection.strip_command(command, output)
+    connection.disconnect()
+
+    assert result == "hostname: pa\n"
+
+
+def test_paloalto_strip_command_only_removes_leading_echo():
+    connection = PaloAltoPanosSSH(
+        host="localhost", device_type="paloalto_panos", auto_connect=False
+    )
+    command = connection.normalize_cmd("show system info")
+    output = "show system info\nshow system info\nhostname: pa\n"
+    result = connection.strip_command(command, output)
+    connection.disconnect()
+
+    assert result == "show system info\nhostname: pa\n"
 
 
 def test_normalize_linefeeds():


### PR DESCRIPTION
Fixes #3543

## Summary

- remove the Palo Alto-specific `strip_command` override
- use the shared base implementation for SSH and Telnet command echo handling
- cover LF/CRLF terminators and repeated command text

## Testing

- focused Palo Alto tests: 3 passed
- base connection unit tests: 35 passed
- feasible unit suite: 120 passed, 1 skipped, 5 dependency/environment deselections
- Ruff format and lint: passed
- mypy: passed for 270 source files

## Hardware

Not tested against a physical PAN-OS device.