### PR TITLE
Fix FortiOS version detection for 7.4.x

### DIFF
--- a/netmiko/fortinet/fortinet_ssh.py
+++ b/netmiko/fortinet/fortinet_ssh.py
@@ -129,14 +129,15 @@ Alternatively you can try configuring 'configure system console -> set output st
         return output
 
     def _determine_os_version(self) -> str:
-        check_command = "get system status | grep Version"
+        check_command = "get system status | grep Version:"
         output = self._send_command_str(check_command, expect_string=self.prompt_pattern)
-        if re.search(r"^Version: .* (v[78]\.).*$", output, flags=re.M):
-            return "v7_or_later"
-        elif re.search(r"^Version: .* (v[654]\.).*$", output, flags=re.M):
+        version_match = re.search(r"^Version: .* v(\d+)\.", output, flags=re.M)
+        if version_match:
+            major_version = int(version_match.group(1))
+            if major_version >= 7:
+                return "v7_or_later"
             return "v6_or_earlier"
-        else:
-            raise ValueError("Unexpected FortiOS Version encountered.")
+        raise ValueError("Unexpected FortiOS Version encountered.")
 
     def _get_output_mode_v6(self) -> str:
         """

--- a/tests/unit/test_fortinet.py
+++ b/tests/unit/test_fortinet.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import MagicMock
+
+from netmiko.fortinet.fortinet_ssh import FortinetSSH
+
+
+def make_connection(grep_output):
+    """Create a FortinetSSH object without opening an SSH session."""
+    conn = FortinetSSH.__new__(FortinetSSH)
+    conn._send_command_str = MagicMock(return_value=grep_output)
+    return conn
+
+
+@pytest.mark.parametrize(
+    "grep_output, expected",
+    [
+        # FortiOS 7.4.12 - issue #3861: 'grep Version' also returns a second line
+        # ("Release Version Information: GA") which contains the substring "Version".
+        (
+            "Version: FortiGate-900F v7.4.12,build2902,260505 (GA.M)\n"
+            "Release Version Information: GA",
+            "v7_or_later",
+        ),
+        # FortiOS 7.4.12 - clean single-line output from 'grep Version:'
+        (
+            "Version: FortiGate-900F v7.4.12,build2902,260505 (GA.M)",
+            "v7_or_later",
+        ),
+        ("Version: FortiGate-VM64 v7.0.14,build1631,230920 (interim)", "v7_or_later"),
+        ("Version: FortiGate-VM64 v8.2.5,build1234,240101 (GA)", "v7_or_later"),
+        ("Version: FortiGate-VM64 v6.4.15,build0000,230101 (GA)", "v6_or_earlier"),
+        ("Version: FortiGate-60E v5.6.10,build0000,200101 (GA)", "v6_or_earlier"),
+    ],
+)
+def test_determine_os_version(grep_output, expected):
+    conn = make_connection(grep_output)
+    assert conn._determine_os_version() == expected
+
+
+def test_determine_os_version_uses_grep_version_colon():
+    """Ensure the grep targets 'Version:' to avoid the extra 7.4.x line."""
+    conn = make_connection("Version: FortiGate-900F v7.4.12,build2902,260505 (GA.M)")
+    conn._determine_os_version()
+    conn._send_command_str.assert_called_once_with(
+        "get system status | grep Version:", expect_string=conn.prompt_pattern
+    )
+
+
+def test_determine_os_version_unexpected():
+    conn = make_connection("Release Version Information: GA")
+    with pytest.raises(ValueError):
+        conn._determine_os_version()


### PR DESCRIPTION
## Summary

Fixes #3861

## Root cause

On FortiOS 7.4.x, `get system status | grep Version` matches a second line (`Release Version Information: GA`) that contains the substring "Version", polluting the parsed output and causing `ValueError: Unexpected FortiOS Version encountered`.

## Fix

- Changed `grep Version` to `grep Version:` to match only the version field line
- Replaced hardcoded `v[78]`/`v[654]` regex with major-version capture so v7.4.x and future v8/v9 are classified correctly

## Test plan

- [x] New unit tests for FortiOS 7.4.12 (two-line output), clean output, v6/v5, grep-command assertion, and ValueError case
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — no issues
- [x] Full unit suite: 125 passed (5 pre-existing env failures unrelated)