### PR TITLE
feat: support refresh command for latest FITELnet

### DIFF
--- a/netmiko/furukawa/furukawa_fitelnet.py
+++ b/netmiko/furukawa/furukawa_fitelnet.py
@@ -123,22 +123,16 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
                 raise ValueError("Failed to exit enable mode.")
         return output
 
-    def commit(
-        self,
-        read_timeout: float = 120.0,
-    ) -> str:
-        """
-        Commit the candidate configuration on the FITELnet device.
+    def _apply_config(self, cmd: str, read_timeout: float) -> str:
+        """Send a configuration-apply command and handle FITELnet's responses.
 
-        Applies the working.cfg (candidate) to current.cfg (running).
-
-        commit may prompt with '[y/n]' for confirmation.
+        Shared by commit() and refresh().
         """
         output = ""
         confirmation = r"onfirm|\[y/[nN]\]"
         pattern = rf"(?:#|{confirmation})"
         new_data = self._send_command_str(
-            "commit",
+            cmd,
             expect_string=pattern,
             strip_prompt=False,
             strip_command=False,
@@ -158,21 +152,47 @@ class FurukawaFitelnetBase(CiscoBaseConnection):
 
         output += new_data
 
-        # FITELnet refuses commit while another session/process is active with
-        # "Another processing is executing. This command can not be executed."
-        # The message contains neither "error" nor "failed", so it must be
-        # detected separately before the generic error check below.
+        # FITELnet refuses to apply the config while another session/process is
+        # active with "Another processing is executing. This command can not be
+        # executed."  The message contains neither "error" nor "failed", so it
+        # must be detected separately before the generic error check below.
         if "Another processing is executing" in output:
             raise ValueError(
-                "Commit failed: another process is executing on the device. "
+                f"'{cmd}' failed: another process is executing on the device. "
                 "Retry once the other operation completes."
             )
 
         # FITELnet emits <ERROR> in all caps; match case-insensitively.
         if re.search(r"error|failed", output, re.IGNORECASE):
-            raise ValueError(f"Commit failed with the following errors:\n\n{output}")
+            raise ValueError(f"'{cmd}' failed with the following errors:\n\n{output}")
 
         return output
+
+    def commit(
+        self,
+        read_timeout: float = 120.0,
+    ) -> str:
+        """
+        Commit the candidate configuration on the FITELnet device.
+
+        Applies the working.cfg (candidate) to current.cfg (running).
+
+        Newer FITELnet models apply the candidate configuration with 'refresh'
+        instead of 'commit' -- use refresh() on those platforms.
+        """
+        return self._apply_config("commit", read_timeout=read_timeout)
+
+    def refresh(
+        self,
+        read_timeout: float = 120.0,
+    ) -> str:
+        """
+        Apply the candidate configuration using 'refresh'.
+
+        This is the equivalent of commit() on newer FITELnet models, where
+        'commit' is not available.
+        """
+        return self._apply_config("refresh", read_timeout=read_timeout)
 
     def save_config(
         self,


### PR DESCRIPTION
## Summary

FITELnet routers keep an uncommitted candidate configuration (`working.cfg`) that has to be
applied before it becomes the running configuration (`running.cfg`). Depending on the model /
firmware, the CLI command that performs this is either `commit` or `refresh`.

The driver currently implements `commit()` only. On platforms where `commit` is not available,
users have to fall back to `send_command("refresh")` and re-implement the confirmation-prompt
handling and the FITELnet-specific error detection themselves.

This PR extracts the shared apply logic into a private helper and adds a `refresh()` method
next to the existing `commit()`.

## Testing 
- verification on a real device: FITELnet F220 / FITELnet vFX-R
- Github CI (linters) failed because of below PYSEC.  This is pre-existing on latest `develop`.  
```
pyasn1 0.6.0   PYSEC-2026-3457 0.6.4  
pyasn1 0.6.0   PYSEC-2026-3456 0.6.4  
pyasn1 0.6.0   PYSEC-2026-3455 0.6.4  
```

<details><summary>sample code for testing</summary>
Sample code

```
from netmiko import ConnectHandler

device = {
    'device_type': 'furukawa_fitelnet',
    'host': 'xxx',
    'username': 'xxx',
    'password': 'xxx',
    'secret': 'xxx',
}

conn = None
try:
    conn = ConnectHandler(**device)

    conn.send_config_set([
        "interface GigaEthernet 1/1",
        "no description"
    ])
    conn.refresh()
    
    conn.send_config_set([
        "interface GigaEthernet 1/1",
        "description TEST"
    ])

    print("--- Diff ---")
    output = conn.send_command('diff running.cfg working.cfg')
    print(output)

except Exception as e:
    print(f"error: {e}")

finally:
    conn.disconnect()
```

Result:

```
python .\sample2.py
--- Diff ---
1c1
< !  LAST EDIT    19:59:04 2026/05/17 by admin
---
> !  LAST EDIT    19:59:17 2026/05/17 by admin
94a95
>  description TEST
```

</details>

<details><summary>ruff and mypy pass log</summary>

```
ubuntu@ubuntu-Virtual-Machine:~/netmiko$ uv run --frozen ruff format --check .
345 files already formatted
ubuntu@ubuntu-Virtual-Machine:~/netmiko$ uv run --frozen ruff check .
All checks passed!
ubuntu@ubuntu-Virtual-Machine:~/netmiko$ uv run --frozen mypy netmiko/
Success: no issues found in 270 source files
ubuntu@ubuntu-Virtual-Machine:~/netmiko$ uv run --frozen pytest tests/unit
======================================= test session starts ========================================
platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/ubuntu/netmiko
configfile: pyproject.toml
plugins: cov-4.1.0
collected 123 items                                                                                

tests/unit/test_base_connection.py ................................                          [ 26%]
tests/unit/test_clitools_helpers.py ..........                                               [ 34%]
tests/unit/test_clitools_outputters.py .......                                               [ 39%]
tests/unit/test_connection.py ....                                                           [ 43%]
tests/unit/test_encryption_hanlding.py ....                                                  [ 46%]
tests/unit/test_entry_points.py .                                                            [ 47%]
tests/unit/test_session_log.py ..........................                                    [ 68%]
tests/unit/test_ssh_autodetect.py .                                                          [ 69%]
tests/unit/test_utilities.py ..............s.......................                          [100%]

========================================= warnings summary =========================================
tests/unit/test_utilities.py::test_ntc_templates_discovery
  /home/ubuntu/netmiko/netmiko/utilities.py:321: DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with pkg_resources.path(package="ntc_templates", resource="parse.py") as posix_path:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================== short test summary info ======================================
SKIPPED [1] tests/unit/test_utilities.py:331: ~/ntc-templates not found on this machine; please install ntc-templates into your home dir!
============================ 122 passed, 1 skipped, 1 warning in 10.07s ============================
```

</details>