### PR TITLE
fix: Raise specific exception for host-blocked ACL messages (Fixes #3779)

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -46,6 +46,7 @@ from netmiko.netmiko_globals import BACKSPACE_CHAR
 from netmiko.exceptions import (
     NetmikoTimeoutException,
     NetmikoAuthenticationException,
+    NetmikoHostBlockedException,
     ConfigInvalidException,
     ReadException,
     ReadTimeout,
@@ -939,6 +940,19 @@ You can look at the Netmiko session_log or debug log for more information.
             try:
                 output = self.read_channel()
                 return_msg += output
+
+                # Check for "host blocked" messages
+                HOST_BLOCKED_MESSAGES = [
+                    "You are not permitted to connect from this host",
+                    "Access denied",
+                    "Connection refused",
+                    "host is not allowed",
+                ]
+
+                if any(msg in output for msg in HOST_BLOCKED_MESSAGES):
+                    raise NetmikoHostBlockedException(
+                        f"Host is blocked by device ACL. Device said: {output.strip()}"
+                    )
 
                 # Search for username pattern / send username
                 if re.search(username_pattern, output, flags=re.I):

--- a/netmiko/exceptions.py
+++ b/netmiko/exceptions.py
@@ -60,3 +60,9 @@ class NetmikoParsingException(ReadException):
     """Exception raised when there is a parsing error."""
 
     pass
+
+
+class NetmikoHostBlockedException(NetmikoAuthenticationException):
+    """Exception raised when the connecting host is blocked by device ACLs."""
+
+    pass


### PR DESCRIPTION
This fixes issue #3779.

The problem:
When a router blocks your IP with an rACL, it sends a message like "You are not permitted to connect from this host" before you even see a login prompt. Netmiko doesn't recognize this, times out, and just says "Authentication failed". 

The real issue is the host got rejected before auth even happened - not that the credentials were wrong.

What I changed:
- Added NetmikoHostBlockedException to exceptions.py so users can catch this specifically
- Modified telnet_login() in base_connection.py to look for common "you're blocked" messages
- Now it throws a clear error saying the host was rejected

Testing:
Ran the unit tests - 133 passed. The 5 failures are unrelated to this change (missing TTP/Genie deps + a Windows path issue that was already there).

Let me know if you need any changes!